### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM python:3.7-alpine
+FROM python:3.7
 LABEL maintainer="Soxoj <soxoj@protonmail.com>"
 
 WORKDIR /app
 
 ADD requirements.txt .
 
-RUN pip install --upgrade pip \
-&& apk add --update --virtual .build-dependencies \
-      build-base \
+RUN pip install --upgrade pip
+
+RUN apt update -y
+
+RUN apt install -y\
       gcc \
       musl-dev \
       libxml2 \
       libxml2-dev \
       libxslt-dev \
-      jpeg-dev \
 &&  YARL_NO_EXTENSIONS=1 python3 -m pip install maigret \
-&&  apk del .build-dependencies \
 &&  rm -rf /var/cache/apk/* \
            /tmp/* \
            /var/tmp/*


### PR DESCRIPTION
Fix the Dockerfile build error, because of scipy build dependencies error.

By changing from python:3.7-alpine to python:3.7 and restoring the dependencies