### PR TITLE
feat: add *.log & *.bak files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ src/
 .ipynb_checkpoints
 *.ipynb
 
+# Logs and backups
+*.log
+*.bak
+
 # Output files, except requirements.txt
 *.txt
 !requirements.txt


### PR DESCRIPTION
## [SMALL FIX] Add *.log and *.bak files to .gitignore

When running maigret with `--debug` key, it creates huge log file, but it's not added to the **.gitignore**. Also log file may be backed up, so adding *.bak doesn't looks unnecessary.