### PR TITLE
Changed docker run to interactive and remove on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip3 install -r requirements.txt
 docker pull soxoj/maigret
 
 # usage
-docker run soxoj/maigret:latest username
+docker run -it --rm soxoj/maigret:latest username
 
 # manual build
 docker build -t maigret .


### PR DESCRIPTION
The docker run example in the README.md does not clean up the container after it exits potentially collecting loads of garbage containers after a couple runs.

This PR adds the --rm switch to clean those up automatically.
`-it` switch helps make sure the progressbar shows up correctly in terminals.