### PR TITLE
Build docker images for arm64 and amd64

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/maigret:latest
+          platforms: linux/amd64,linux/arm64
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Currently the only arch docker images are building for is amd64. 
`docker/build-push-action` action can build for multiple platforms so by adding `platforms` key to the step we can build multiple archs at a time. 

Ref - https://github.com/soxoj/maigret/issues/676 