### PR TITLE
Refactor Dockerfile with best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM python:3.9-slim
-MAINTAINER Soxoj <soxoj@protonmail.com>
+LABEL maintainer="Soxoj <soxoj@protonmail.com>"
 WORKDIR /app
-RUN pip install --upgrade pip
-RUN apt update && \
-	apt install -y \
+RUN pip install --no-cache-dir --upgrade pip
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
       gcc \
       musl-dev \
       libxml2 \
       libxml2-dev \
-      libxslt-dev
-RUN apt clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
-ADD . .
-RUN YARL_NO_EXTENSIONS=1 python3 -m pip install .
+      libxslt-dev \
+    && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+COPY . .
+RUN YARL_NO_EXTENSIONS=1 python3 -m pip install --no-cache-dir .
 ENTRYPOINT ["maigret"]


### PR DESCRIPTION
Multiple best practices applied as below:

- Replace deprecated `MAINTAINER` with `LABEL maintainer`
- Remove additional `apt clean` as it'll be done automatically
- Use `apt-get` instead of `apt` in script, apt does not have a stable CLI interface, and it's for end-user.
- Put `apt-get install` & apt lists clean up in the same command
- Use `--no-install-recommends` with `apt-get install` to avoid install additional packages
- Use `--no-cache-dir` with `pip install` to prevent temporary cache
- Use `COPY` instead of `ADD` for files and folders
- Use spaces instead of mixing spaces with tabs to indent

Size change by the refactor, almost 100MB saved:

```
REPOSITORY   TAG      IMAGE ID       CREATED         SIZE
maigret      after    9e70c65dde32   1 minutes ago   543MB
maigret      before   a683f2b71751   7 minutes ago   635MB
```