### PR TITLE
Typo fixes in error.py

### DIFF
--- a/maigret/errors.py
+++ b/maigret/errors.py
@@ -63,9 +63,9 @@ COMMON_ERRORS = {
 ERRORS_TYPES = {
     'Captcha': 'Try to switch to another IP address or to use service cookies',
     'Bot protection': 'Try to switch to another IP address',
-    'Censorship': 'switch to another internet service provider',
+    'Censorship': 'Switch to another internet service provider',
     'Request timeout': 'Try to increase timeout or to switch to another internet service provider',
-    'Connecting failure': 'Try to decrease number of parallel connections (e.g. --n 10)',
+    'Connecting failure': 'Try to decrease number of parallel connections (e.g. -n 10)',
 }
 
 # TODO: checking for reason


### PR DESCRIPTION
Fixing two small typos in the error definition file:
- "switch to another..." -> ""Switch to another...
   - Capitalizing this sentence 
- "...parallel connections (e.g. --n 10)" -> "...parallel connections (e.g. -n 10)"
   - Removing the extra `-` for this option