### PR TITLE
Updated snapcraft yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,15 +25,15 @@ apps:
       - bin/homeishome-launch      
     environment:
       LC_ALL: C.UTF-8
+    plugs:
+      - home
+      - network
       
 parts:
   maigret2:
     plugin: python
     source: https://github.com/soxoj/maigret
     source-type: git
-    plugs:
-      - home
-      - network
     
     build-packages:
       - python3-pip

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,7 +17,6 @@ assumes:
     
 architectures:
   - build-on: amd64
-  - build-on: i386
 
 apps:
   maigret2:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,6 +31,9 @@ parts:
     plugin: python
     source: https://github.com/soxoj/maigret
     source-type: git
+    plugs:
+      - home
+      - network
     
     build-packages:
       - python3-pip

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,18 +11,12 @@ grade: stable
 confinement: strict
 compression: lzo
 
-assumes:
-  - command-chain
-
-    
 architectures:
   - build-on: amd64
 
 apps:
   maigret2:
     command: bin/maigret
-    command-chain: 
-      - bin/homeishome-launch      
     environment:
       LC_ALL: C.UTF-8
     plugs:
@@ -47,8 +41,3 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"
-
-  homeishome-launch:
-    plugin: nil
-    stage-snaps:
-      - homeishome-launch

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,30 +1,52 @@
 name: maigret2
-version: git
+adopt-info: maigret2
 summary: SOCMINT / Instagram
 description: |
   Test Test Test
-base: core18
+
+license: MIT
+
+base: core20
+grade: stable
 confinement: strict
+compression: lzo
 
+assumes:
+  - command-chain
 
-parts:
-  maigret2:
-    plugin: python
-    python-version: python3
-    source: .
-    stage-packages:
-      - python-six
-
-
-apps:
-  maigret2:
-    command: bin/maigret
-    
     
 architectures:
   - build-on: amd64
   - build-on: i386
 
+apps:
+  maigret2:
+    command: bin/maigret
+    command-chain: 
+      - bin/homeishome-launch      
+    environment:
+      LC_ALL: C.UTF-8
+      
+parts:
+  maigret2:
+    plugin: python
+    source: https://github.com/soxoj/maigret
+    source-type: git
+    
+    build-packages:
+      - python3-pip
+      - python3-six
+      - python3
+      
+    stage-packages:
+      - python3
+      - python3-six
 
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"
 
-
+  homeishome-launch:
+    plugin: nil
+    stage-snaps:
+      - homeishome-launch


### PR DESCRIPTION
Changes:

* Core20 (newer Ubuntu packages)
* Added needed plugs
  - home
  - network
* Adopt-info - easier snap versioning
* License info 


That said, I'm still getting the following error:
```
Traceback (most recent call last):
  File "/snap/maigret2/x1/bin/maigret", line 8, in <module>
    sys.exit(run())
  File "/snap/maigret2/x1/lib/python3.8/site-packages/maigret/maigret.py", line 726, in run
    loop.run_until_complete(main())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/snap/maigret2/x1/lib/python3.8/site-packages/maigret/maigret.py", line 717, in main
    db.save_to_file(db_file)
  File "/snap/maigret2/x1/lib/python3.8/site-packages/maigret/sites.py", line 304, in save_to_file
    with open(filename, "w") as f:
OSError: [Errno 30] Read-only file system: '/snap/maigret2/x1/lib/python3.8/site-packages/maigret/resources/data.json'

```

It's possible that the code isn't looking in `/home/$USER` to place the report - which poses a problem for the snap (read-only). 

Anyway, I hope this helps in some way - I ran the report and sheesh - that's kind of scary...