### PR TITLE
Fix Pinterest false positive

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -12073,6 +12073,9 @@
                 "<!-- --> \u043f\u043e\u0434\u043f\u0438\u0441\u0447\u0438\u043a\u043e\u0432",
                 "<!-- --> \u043f\u043e\u0434\u043f\u0438\u0441\u043e\u043a"
             ],
+            "absenceStrs": [
+                "@undefined"
+            ],
             "urlMain": "https://www.pinterest.com/",
             "url": "https://www.pinterest.com/{username}/",
             "usernameClaimed": "blue",


### PR DESCRIPTION
I'm creating this PR as part of #848.
![image](https://user-images.githubusercontent.com/44085158/222341507-b23106f8-e1cb-4ebf-a0b7-c2e8a114aa6c.png)

It seems like for `undefined` user, `Pinterest` would show `@undefined` before forwarding to home page.

Added a check for `@undefined`