### PR TITLE
Fix missing Mastodon Regex on #906

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -18981,7 +18981,7 @@
         "chaos.social": {
             "checkType": "status_code",
             "alexaRank": 2073381,
-            "regexCheck": "^[^.]{1,}$",
+            "regexCheck": "^[a-zA-Z0-9_]+$",
             "urlMain": "https://chaos.social/",
             "url": "https://chaos.social/@{username}",
             "usernameClaimed": "rixx",
@@ -21672,7 +21672,7 @@
             ],
             "checkType": "status_code",
             "alexaRank": 489597,
-            "regexCheck": "^[^.]{1,}$",
+            "regexCheck": "^[a-zA-Z0-9_]+$",
             "urlMain": "https://social.tchncs.de/",
             "url": "https://social.tchncs.de/@{username}",
             "usernameClaimed": "Milan",


### PR DESCRIPTION
Hi, it's me again. 

Just noticed that `chaos.social` and `social.tchncs.de` is also powered by `Mastodon` and it was missing on #906 so I'm making sure the regex match what was put in this morning.

Thanks!