### PR TITLE
Remove GunsandAmmo

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -7177,17 +7177,6 @@
             "usernameClaimed": "red",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "GunsAndAmmo": {
-            "tags": [
-                "us"
-            ],
-            "checkType": "status_code",
-            "alexaRank": 119883,
-            "urlMain": "https://gunsandammo.com/",
-            "url": "https://forums.gunsandammo.com/profile/{username}",
-            "usernameClaimed": "adam",
-            "usernameUnclaimed": "noonewouldeverusethis7"
-        },
         "Guru": {
             "tags": [
                 "in"


### PR DESCRIPTION
GunsAndAmmo forum is shutdown on June 29, 2023. We should remove it to avoid false positive.

Source: https://webcache.googleusercontent.com/search?q=cache:-TvnUb2h8eIJ:https://forums.gunsandammo.com/discussion/44187/update-notice-guns-ammo-forum-set-to-close-june-29&cd=29&hl=en&ct=clnk&gl=ca