### PR TITLE
Add compatibility with pytest >= 7.3.0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ empty_mark = Mark('', (), {})
 
 
 def by_slow_marker(item):
-    return item.get_closest_marker('slow', default=empty_mark)
+    return item.get_closest_marker('slow', default=empty_mark).name
 
 
 def pytest_collection_modifyitems(items):


### PR DESCRIPTION
Starting in this version, marks are no longer ordered. Sorting by their names still sorts slow marks to the end of the list of tests.