### PR TITLE
Update data.json

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -32979,7 +32979,7 @@
             "checkType": "status_code",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "url": "https://vidamora.com/profile/{username}"
+            "url": "https://www.vidamora.com/profile/{username}"
         },
         "vingle.net": {
             "checkType": "status_code",


### PR DESCRIPTION
changed the URL for vidamora.com to www.vidamora.com

any username on https://vidamora.com/profile/{username} returns a redirect, to www.vidamora.com

on https://www.vidamora.com, you get different behavior for existing and non-existing users.