### PR TITLE
Adding permutator feature for usernames

### DIFF
--- a/maigret/permutator.py
+++ b/maigret/permutator.py
@@ -1,0 +1,26 @@
+# License MIT. by balestek https://github.com/balestek
+from itertools import permutations
+
+
+class Permute:
+    def __init__(self, elements: dict):
+        self.separators = ["", "_", "-", "."]
+        self.elements = elements
+
+    def gather(self, method: str = "strict" or "all") -> dict:
+        permutations_dict = {}
+        for i in range(1, len(self.elements) + 1):
+            for subset in permutations(self.elements, i):
+                if i == 1:
+                    if method == "all":
+                        permutations_dict[subset[0]] = self.elements[subset[0]]
+                        permutations_dict["_" + subset[0]] = self.elements[subset[0]]
+                        permutations_dict[subset[0] + "_"] = self.elements[subset[0]]
+                else:
+                    for separator in self.separators:
+                        perm = separator.join(subset)
+                        permutations_dict[perm] = self.elements[subset[0]]
+                        if separator == "":
+                            permutations_dict["_" + perm] = self.elements[subset[0]]
+                            permutations_dict[perm + "_"] = self.elements[subset[0]]
+        return permutations_dict


### PR DESCRIPTION
("", "_", "-", ".") when id_type == username

File : maigret/permutator.py

Arg : --permute

For now, only permute from 2 elements and doesn't return single elements (element1, _element1, element1_,  element2, _element2, ...). 12 permuts for 2 elements.

To return single elements as well, Permute(usernames).gather(method="all"), but not implemented in maigrat.py. 18 permuts for 2 elements. Should we ? With another argument ?