### PR TITLE
Alik.cz indirectly requests removal

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -616,17 +616,6 @@
             "usernameClaimed": "kdn",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "Alik.cz": {
-            "checkType": "status_code",
-            "alexaRank": 606240,
-            "urlMain": "https://www.alik.cz/",
-            "url": "https://www.alik.cz/u/{username}",
-            "usernameClaimed": "julian",
-            "usernameUnclaimed": "noonewouldeverusethis",
-            "tags": [
-                "cz"
-            ]
-        },
         "All-mods": {
             "tags": [
                 "ru"


### PR DESCRIPTION
Alik.cz is seeing unusually high traffic on usernames `julian` and `noonewouldeverusethis` due to its presence in both Sherlock and Maigret. The administrators of this website have gone out of their way to change the landing page for these usernames, requesting to be removed. This target should be blacklisted.

References:
https://www.alik.cz/u/julian (positive test case)
https://www.alik.cz/u/noonewouldeverusethis (negative test case)
https://www.alik.cz/u/normal (positive real)
https://www.alik.cz/u/normalnotreal (negative real)

Working around this is expected on large sites, but we should be courteous towards these smaller targets. Especially considering, being a young children's learning site, there is a _very_ low likelihood that this target would be of use to users of either tool.

I've removed and blacklisted the target from Sherlock, as well: sherlock-project/sherlock@09b324f7d4ee393bd2055b0748155d5d6f98208f

Considering adding some sort of check to our ci to alert when this target is included in any future PRs.