### PR TITLE
Disable ICQ site

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -7895,6 +7895,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "ICQ": {
+            "disabled": true,
             "tags": [
                 "ch",
                 "ru",


### PR DESCRIPTION
Fix the issue #1984, adds key _disabled_ and value _true_ in icq site to display only with flag `--use-disabled-sites`