### PR TITLE
[#2010] Add 6 more websites to manage

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -12424,6 +12424,17 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
+        "pixelfed.social": {
+            "tags": [
+                "art",
+                "pixelfed"
+            ],
+            "checkType": "status_code",
+            "usernameClaimed": "pylapp",
+            "usernameUnclaimed": "noonewouldeverusethis42",
+            "urlMain": "https://pixelfed.social/",
+            "url": "https://pixelfed.social/{username}/"
+        },        
         "PlanetMinecraft": {
             "tags": [
                 "us"
@@ -35871,6 +35882,7 @@
         "ai",
         "mastodon",
         "writefreely",
-        "lemmy"
+        "lemmy",
+        "pixelfed"
     ]
 }

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -35556,6 +35556,16 @@
             ]
         }
     },
+    "write.as": {
+        "tags": [
+            "writefreely"
+        ],
+        "checkType": "status_code",
+        "url": "https://write.as/{username}",
+        "urlMain": "https://write.as",
+        "usernameClaimed": "pylapp",
+        "usernameUnclaimed": "noonewouldeverusethis42"
+    },
     "engines": {
         "XenForo": {
             "name": "XenForo",
@@ -35836,6 +35846,7 @@
         "q&a",
         "crypto",
         "ai",
-        "mastodon"
+        "mastodon",
+        "writefreely"
     ]
 }

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -9790,6 +9790,16 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 4938389
         },
+        "Mamot": {
+            "tags": [
+                "mastodon"
+            ],
+            "checkType": "status_code",
+            "urlMain": "https://mamot.fr",
+            "url": "https://mamot.fr/@{username}",
+            "usernameClaimed": "pylapp",
+            "usernameUnclaimed": "noonewouldeverusethis42"
+        },          
         "Mamuli": {
             "tags": [
                 "ru",

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -11805,6 +11805,16 @@
             "usernameClaimed": "uehkon89",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
+        "Outgress": {
+            "checkType": "message",
+            "absenceStrs": [
+                "Outgress - Error"
+            ],
+            "url": "https://outgress.com/agents/{username}",
+            "urlMain": "https://outgress.com/",
+            "usernameClaimed": "pylapp",
+            "usernameUnclaimed": "noonewouldeverusethis42"
+        },          
         "Overclockers": {
             "tags": [
                 "ru"

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -6163,6 +6163,16 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
+        "Framapiaf": {
+            "tags": [
+                "mastodon"
+            ],
+            "checkType": "status_code",
+            "urlMain": "https://framapiaf.org",
+            "url": "https://framapiaf.org/@{username}",
+            "usernameClaimed": "pylapp",
+            "usernameUnclaimed": "noonewouldeverusethis42"
+        },        
         "Free-lance.ua": {
             "tags": [
                 "freelance",
@@ -35825,6 +35835,7 @@
         "i2p",
         "q&a",
         "crypto",
-        "ai"
+        "ai",
+        "mastodon"
     ]
 }

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -13086,6 +13086,19 @@
             "usernameClaimed": "Sinkler",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
+        "programming.dev": {
+            "tags": [
+                "lemmy"
+            ],
+            "checkType": "message",
+            "absenceStrs": [
+                "Error!"
+            ],
+            "url": "https://programming.dev/u/{username}",
+            "urlMain": "https://programming.dev",
+            "usernameClaimed": "pylapp",
+            "usernameUnclaimed": "noonewouldeverusethis42"
+        },  
         "Qbn": {
             "tags": [
                 "in",
@@ -35847,6 +35860,7 @@
         "crypto",
         "ai",
         "mastodon",
-        "writefreely"
+        "writefreely",
+        "lemmy"
     ]
 }

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -6172,7 +6172,7 @@
             "url": "https://framapiaf.org/@{username}",
             "usernameClaimed": "pylapp",
             "usernameUnclaimed": "noonewouldeverusethis42"
-        },        
+        },
         "Free-lance.ua": {
             "tags": [
                 "freelance",
@@ -9799,7 +9799,7 @@
             "url": "https://mamot.fr/@{username}",
             "usernameClaimed": "pylapp",
             "usernameUnclaimed": "noonewouldeverusethis42"
-        },          
+        },
         "Mamuli": {
             "tags": [
                 "ru",
@@ -11814,7 +11814,7 @@
             "urlMain": "https://outgress.com/",
             "usernameClaimed": "pylapp",
             "usernameUnclaimed": "noonewouldeverusethis42"
-        },          
+        },
         "Overclockers": {
             "tags": [
                 "ru"
@@ -12444,7 +12444,7 @@
             "usernameUnclaimed": "noonewouldeverusethis42",
             "urlMain": "https://pixelfed.social/",
             "url": "https://pixelfed.social/{username}/"
-        },        
+        },
         "PlanetMinecraft": {
             "tags": [
                 "us"
@@ -13129,7 +13129,7 @@
             "urlMain": "https://programming.dev",
             "usernameClaimed": "pylapp",
             "usernameUnclaimed": "noonewouldeverusethis42"
-        },  
+        },
         "Qbn": {
             "tags": [
                 "in",
@@ -35598,17 +35598,17 @@
             "tags": [
                 "tr"
             ]
+        },
+        "write.as": {
+            "tags": [
+                "writefreely"
+            ],
+            "checkType": "status_code",
+            "url": "https://write.as/{username}",
+            "urlMain": "https://write.as",
+            "usernameClaimed": "pylapp",
+            "usernameUnclaimed": "noonewouldeverusethis42"
         }
-    },
-    "write.as": {
-        "tags": [
-            "writefreely"
-        ],
-        "checkType": "status_code",
-        "url": "https://write.as/{username}",
-        "urlMain": "https://write.as",
-        "usernameClaimed": "pylapp",
-        "usernameUnclaimed": "noonewouldeverusethis42"
     },
     "engines": {
         "XenForo": {

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3137
+## List of supported sites (search methods): total 3143
 
 Rank data fetched from Alexa by domains.
 
@@ -340,7 +340,7 @@ Rank data fetched from Alexa by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://gitlab.com/) [GitLab (https://gitlab.com/)](https://gitlab.com/)*: top 5K, coding*
 1. ![](https://www.google.com/s2/favicons?domain=https://dev.to/) [DEV Community (https://dev.to/)](https://dev.to/)*: top 5K, coding*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.gumroad.com/) [Gumroad (https://www.gumroad.com/)](https://www.gumroad.com/)*: top 5K, us*
-1. ![](https://www.google.com/s2/favicons?domain=https://gramho.com/) [Gramho (https://gramho.com/)](https://gramho.com/)*: top 5K, photo*
+1. ![](https://www.google.com/s2/favicons?domain=https://gramho.com/) [Gramho (https://gramho.com/)](https://gramho.com/)*: top 5K, photo*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://taplink.cc/) [Taplink (https://taplink.cc/)](https://taplink.cc/)*: top 5K, links, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.buymeacoffee.com/) [BuyMeACoffee (https://www.buymeacoffee.com/)](https://www.buymeacoffee.com/)*: top 5K, in*
 1. ![](https://www.google.com/s2/favicons?domain=https://muckrack.com) [Muckrack (https://muckrack.com)](https://muckrack.com)*: top 5K, us*
@@ -2161,6 +2161,7 @@ Rank data fetched from Alexa by domains.
 1. ![](https://www.google.com/s2/favicons?domain=) [Finanzfrage ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=http://forum.quake2.com.ru/) [Forum.quake2.com.ru (http://forum.quake2.com.ru/)](http://forum.quake2.com.ru/)*: top 100M, forum, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://forums.tauck.com) [ForumTauck (https://forums.tauck.com)](https://forums.tauck.com)*: top 100M, forum, us*
+1. ![](https://www.google.com/s2/favicons?domain=https://framapiaf.org) [Framapiaf (https://framapiaf.org)](https://framapiaf.org)*: top 100M, mastodon*
 1. ![](https://www.google.com/s2/favicons?domain=) [G2g.com ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=https://gam1ng.com.br) [Gam1ng (https://gam1ng.com.br)](https://gam1ng.com.br)*: top 100M, br, webcam*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=) [GeniusArtists ()]()*: top 100M*
@@ -2202,6 +2203,7 @@ Rank data fetched from Alexa by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://macqa.ru) [Macqa (https://macqa.ru)](https://macqa.ru)*: top 100M, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=) [Maga-Chat ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Magabook ()]()*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://mamot.fr) [Mamot (https://mamot.fr)](https://mamot.fr)*: top 100M, mastodon*
 1. ![](https://www.google.com/s2/favicons?domain=) [Mapify.travel ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [MapMyTracks ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Marshmallow ()]()*: top 100M*
@@ -2224,10 +2226,12 @@ Rank data fetched from Alexa by domains.
 1. ![](https://www.google.com/s2/favicons?domain=) [Oglaszamy24h ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Olx.pl ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Ourfreedombook ()]()*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://outgress.com/) [Outgress (https://outgress.com/)](https://outgress.com/)*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Ow.ly ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Patronite ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Pewex.pl ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Piekielni ()]()*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://pixelfed.social/) [pixelfed.social (https://pixelfed.social/)](https://pixelfed.social/)*: top 100M, art, pixelfed*
 1. ![](https://www.google.com/s2/favicons?domain=) [Pol.social ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Polczat.pl ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Policja2009 ()]()*: top 100M*
@@ -2238,6 +2242,7 @@ Rank data fetched from Alexa by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://palexaRankru.net/) [PalexaRankru (https://palexaRankru.net/)](https://palexaRankru.net/)*: top 100M, forum, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.programmersforum) [ProgrammersForum (https://www.programmersforum)](https://www.programmersforum)*: top 100M, forum, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=) [Prv.pl ()]()*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://programming.dev) [programming.dev (https://programming.dev)](https://programming.dev)*: top 100M, lemmy*
 1. ![](https://www.google.com/s2/favicons?domain=) [Quitter.pl ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=) [Quizlet ()]()*: top 100M*
 1. ![](https://www.google.com/s2/favicons?domain=http://www.rammclan.ru) [Rammclan (http://www.rammclan.ru)](http://www.rammclan.ru)*: top 100M, ru*
@@ -3140,17 +3145,18 @@ Rank data fetched from Alexa by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://substack.com) [Substack (https://substack.com)](https://substack.com)*: top 100M, blog*
 1. ![](https://www.google.com/s2/favicons?domain=https://pubg.op.gg) [OP.GG [PUBG] (https://pubg.op.gg)](https://pubg.op.gg)*: top 100M, gaming*
 1. ![](https://www.google.com/s2/favicons?domain=https://valorant.op.gg) [OP.GG [Valorant] (https://valorant.op.gg)](https://valorant.op.gg)*: top 100M, gaming*
+1. ![](https://www.google.com/s2/favicons?domain=https://write.as) [write.as (https://write.as)](https://write.as)*: top 100M, writefreely*
 
-The list was updated at (2024-12-13)
+The list was updated at (2025-06-28)
 ## Statistics
 
-Enabled/total sites: 2684/3137 = 85.56%
+Enabled/total sites: 2689/3143 = 85.56%
 
-Incomplete message checks: 394/2684 = 14.68% (false positive risks)
+Incomplete message checks: 395/2689 = 14.69% (false positive risks)
 
-Status code checks: 615/2684 = 22.91% (false positive risks)
+Status code checks: 619/2689 = 23.02% (false positive risks)
 
-False positive risk (total): 37.59%
+False positive risk (total): 37.71%
 
 Sites with probing: 500px, Aparat, BinarySearch (disabled), BongaCams, BuyMeACoffee, Cent, Disqus, Docker Hub, Duolingo, Gab, GitHub, GitLab, Google Plus (archived), Gravatar, Imgur, Issuu, Keybase, Livejasmin, LocalCryptos (disabled), MixCloud, Niftygateway, Reddit Search (Pushshift) (disabled), SportsTracker, Spotify (disabled), TAP'D, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Weibo, Yapisal (disabled), YouNow, nightbot, notabug.org, polarsteps, qiwi.me (disabled)
 
@@ -3158,17 +3164,17 @@ Sites with activation: Spotify (disabled), Twitter, Vimeo, Weibo
 
 Top 20 profile URLs:
 - (796)	`{urlMain}/index/8-0-{username} (uCoz)`
-- (301)	`/{username}`
+- (303)	`/{username}`
 - (221)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
 - (161)	`/user/{username}`
 - (133)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
 - (127)	`{urlMain}{urlSubpath}/search.php?author={username} (phpBB/Search)`
 - (118)	`/profile/{username}`
-- (111)	`/u/{username}`
+- (112)	`/u/{username}`
 - (88)	`/users/{username}`
 - (87)	`{urlMain}/u/{username}/summary (Discourse)`
+- (54)	`/@{username}`
 - (54)	`/wiki/User:{username}`
-- (52)	`/@{username}`
 - (41)	`/members/?username={username}`
 - (41)	`SUBDOMAIN`
 - (32)	`/members/{username}`
@@ -3180,7 +3186,7 @@ Top 20 profile URLs:
 
 
 Top 20 tags:
-- (1105)	`NO_TAGS` (non-standard)
+- (1106)	`NO_TAGS` (non-standard)
 - (735)	`forum`
 - (92)	`gaming`
 - (48)	`photo`
@@ -3192,8 +3198,8 @@ Top 20 tags:
 - (19)	`finance`
 - (18)	`crypto`
 - (16)	`sharing`
+- (16)	`art`
 - (16)	`freelance`
-- (15)	`art`
 - (15)	`shopping`
 - (13)	`sport`
 - (13)	`business`


### PR DESCRIPTION
This pull request brings new websites to manage for *maigret*.
It is related to #2010 

Here is the curated list of new websites, tested with my pseudonym or accounts I managed and debuggued with *curl* to ensure definitions are usable:
- framapiaf.org (Mastodon instance) (b72ed33de487d9d2dd5d761c86db21f7136a061f)
- write.as (WriteFreely instance) (a4c6f34d72d8b5542ed1d4220b914b72bbb9d0de)
- programming.dev (Lemmy instance) (d289df7524952bb4ad69d01f587ff1936e56475d)
- mamot.fr (Mastodon instance) (bb588285a3f692b9c41943c3ddb056316df8429f)
- pixelfed.social (Pixelfed instance) (be89f7526f7b3b89bcde559dfe3fbe6cdecc9ea7)
- outgress.com (f10bb1ea325a24acf2374143eb68b0cd71401013)

Commits have been designed to allow cherry-picking :)

Let's keep in touch!