### PR TITLE
Fix usage of data.json files from web

### DIFF
--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -520,7 +520,9 @@ async def main():
     if args.tags:
         args.tags = list(set(str(args.tags).split(',')))
 
-    db_file = path.join(path.dirname(path.realpath(__file__)), args.db_file)
+    db_file = args.db_file \
+        if (args.db_file.startswith("http://") or args.db_file.startswith("https://")) \
+        else path.join(path.dirname(path.realpath(__file__)), args.db_file)
 
     if args.top_sites == 0 or args.all_sites:
         args.top_sites = sys.maxsize


### PR DESCRIPTION
While I was testing for https://github.com/soxoj/maigret/pull/2019 I noticed, that using `data.json` files from web seems to be broken:

```
$:~/projects/maigret$ maigret --db https://raw.githubusercontent.com/soxoj/maigret/refs/heads/main/maigret/resources/data.json
Traceback (most recent call last):
  File "/home/user/.cache/pypoetry/virtualenvs/maigret-ggego3Rt-py3.12/bin/maigret", line 6, in <module>
    sys.exit(run())
             ^^^^^
  File "/home/user/projects/maigret/maigret/maigret.py", line 776, in run
    asyncio.run(main())
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/user/projects/maigret/maigret/maigret.py", line 538, in main
    db = MaigretDatabase().load_from_path(db_file)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/projects/maigret/maigret/sites.py", line 451, in load_from_path
    return self.load_from_http(path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/projects/maigret/maigret/sites.py", line 461, in load_from_http
    raise FileNotFoundError(f"Invalid data file URL '{url}'.")
FileNotFoundError: Invalid data file URL '/home/user/projects/maigret/maigret/https://raw.githubusercontent.com/soxoj/maigret/refs/heads/main/maigret/resources/data.json'.
```

This pull request fixes this, by adding a simple check.