### PR TITLE
Automatically start web interface upon container start.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . .
 RUN YARL_NO_EXTENSIONS=1 python3 -m pip install --no-cache-dir .
 # For production use, set FLASK_HOST to a specific IP address for security
 ENV FLASK_HOST=0.0.0.0
-ENTRYPOINT ["maigret"]
+ENTRYPOINT ["maigret", "--web", "5000"]


### PR DESCRIPTION
Very simple edit, but this makes the web interface now automatically start when starting container. Is currently using port 5000 but perhaps we could add an environment variable that provides the port to the container.