### PR TITLE
✨ Quality: Unexpanded tilde in file path

### DIFF
--- a/maigret/settings.py
+++ b/maigret/settings.py
@@ -5,7 +5,7 @@ from typing import List
 
 SETTINGS_FILES_PATHS = [
     path.join(path.dirname(path.realpath(__file__)), "resources/settings.json"),
-    '~/.maigret/settings.json',
+    path.expanduser('~/.maigret/settings.json'),
     path.join(os.getcwd(), 'settings.json'),
 ]
 


### PR DESCRIPTION
Closes #2282

## ✨ Code Quality

### Problem
The path `'~/.maigret/settings.json'` uses a tilde (`~`) which is not automatically expanded by Python's `open()` function. This will cause the settings file in the user's home directory to be silently ignored (caught by `FileNotFoundError`) because Python will look for a literal directory named `~` in the current working directory.

**Severity**: `medium`
**File**: `maigret/settings.py`

### Solution
Use `os.path.expanduser('~/.maigret/settings.json')` or `pathlib.Path('~/.maigret/settings.json').expanduser()` to properly resolve the home directory path.

### Changes
- `maigret/settings.py` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
