### PR TITLE
feat: add cybersecurity platforms + re-enable Root-Me

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -35811,6 +35811,31 @@
             "urlMain": "https://write.as",
             "usernameClaimed": "pylapp",
             "usernameUnclaimed": "noonewouldeverusethis42"
+        },
+        "CTFtime": {
+            "checkType": "status_code",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+            },
+            "tags": [
+                "hacking",
+                "us"
+            ],
+            "url": "https://ctftime.org/team/{username}",
+            "urlMain": "https://ctftime.org/",
+            "usernameClaimed": "1",
+            "usernameUnclaimed": "999999999"
+        },
+        "PentesterLab": {
+            "checkType": "status_code",
+            "tags": [
+                "hacking",
+                "us"
+            ],
+            "url": "https://pentesterlab.com/profile/{username}",
+            "urlMain": "https://pentesterlab.com/",
+            "usernameClaimed": "admin",
+            "usernameUnclaimed": "noonewouldeverusethis7"
         }
     },
     "engines": {


### PR DESCRIPTION
## Summary

Adds cybersecurity-focused platforms and re-enables a previously disabled site that's now working again.

### Changes

#### Re-enabled: Root-Me
- [Root-Me](https://www.root-me.org/) was marked as `disabled: true`
- Tested and confirmed it now works correctly:
  - Invalid usernames return HTTP 404
  - Valid profiles redirect (301) to the full profile URL with HTTP 200
- Updated `presenseStrs` to match current page content (`profil de`)

#### New: PentesterLab
- [PentesterLab](https://pentesterlab.com/) - Popular cybersecurity training platform
- Public user profiles at `/profile/{username}`
- Clean status_code detection (404 for non-existent, 200 for valid)

#### New: CTFtime
- [CTFtime](https://ctftime.org/) - The largest Capture The Flag competition tracker
- Public team profiles at `/team/{id}`
- Requires User-Agent header to avoid 403
- Clean status_code detection (404 for non-existent, 200 for valid)

## Testing

```bash
# Root-Me
curl -sL -o /dev/null -w '%{http_code}' 'https://www.root-me.org/adam'        # → 200
curl -s -o /dev/null -w '%{http_code}' 'https://www.root-me.org/noonewouldever'  # → 404

# PentesterLab
curl -s -o /dev/null -w '%{http_code}' 'https://pentesterlab.com/profile/admin'  # → 200
curl -s -o /dev/null -w '%{http_code}' 'https://pentesterlab.com/profile/noone'  # → 404

# CTFtime
curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent: Mozilla/5.0' 'https://ctftime.org/team/1'         # → 200
curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent: Mozilla/5.0' 'https://ctftime.org/team/999999999' # → 404
```

Closes: N/A (new sites)