### PR TITLE
Tags and site names improvements

### DIFF
--- a/LLM/site-checks-playbook.md
+++ b/LLM/site-checks-playbook.md
@@ -97,6 +97,46 @@ Practical observations from fixing top-ranked sites. Full details: section **7**
 | **Non-standard anti-bot HTTP codes** | HTTP 468 (Tengine), 520–530 (Cloudflare) — not standard 403/429. Check with `curl -sIL`; if code is from intermediary → `disabled: true`. |
 | **`--diagnose` doesn't test POST** | `site_check.py --diagnose` uses GET only. For POST APIs (Discord, Holopin), verify with `curl -X POST` or `maigret --self-check`. |
 
-## 8. Documentation maintenance
+## 8. Site naming rules
+
+Site names in `data.json` are the **keys** of the `"sites"` object and appear in user-facing reports. Follow these rules:
+
+| Rule | Example | Counter-example |
+|------|---------|-----------------|
+| **Title Case** by default | `Hacker News`, `Product Hunt` | ~~`hackernews`~~, ~~`product hunt`~~ |
+| **Lowercase** if the brand is written that way | `kofi`, `note`, `hi5` | ~~`Kofi`~~, ~~`Note`~~ |
+| **No domain suffix** unless it is part of the recognized brand | `Flickr`, `Calendly`, `Upwork` | ~~`www.flickr.com`~~, ~~`calendly.com`~~ |
+| **Domain OK** when the brand is commonly written with it | `last.fm`, `VC.ru`, `Archive.org` | |
+| **No full UPPERCASE** unless the brand is an acronym/initialism | `VK`, `CNET`, `ICQ`, `IFTTT` | ~~`BOOTH`~~, ~~`VSCO`~~ → `Booth`, `VSCO` (brand) |
+| **`{username}` templates** in names are OK | `{username}.tilda.ws` | |
+| **Spaces** are allowed when the brand uses them | `Star Citizen`, `Google Maps` | |
+| **No `www.` or `https://`** prefix | `Flickr`, `Change.org` | ~~`www.flickr.com`~~, ~~`https:`~~ |
+
+When in doubt, check how the service refers to itself on its homepage or in its page title.
+
+## 9. Tagging rules
+
+### Country tags (ISO 3166-1 alpha-2)
+
+The goal of a country tag is to **attribute a person to their country of origin or residence**, not to be a perfect truth source.
+
+| Scenario | Action | Example |
+|----------|--------|---------|
+| Site is global, account says nothing about country | **No country tag** | GitHub, YouTube, Reddit, Medium, Udemy |
+| Account implies connection to a specific country | **Add country tag** | VK → `ru`, Naver → `kr`, Zhihu → `cn` |
+| Service used mostly in a few specific countries | **Multiple country tags OK** | Xing → `de`, `eu` |
+| Very local/regional site | **Must have country tag** | Nairaland → `ng`, 4pda → `ru` |
+
+**Do NOT** assign country tags based on traffic statistics (e.g. Alexa/SimilarWeb audience data). A site popular in India by traffic is not "Indian" if it is used globally. The `in` tag was previously over-applied this way.
+
+### Category tags
+
+- Every tag used in `data.json` must be registered in the `"tags"` array at the bottom of the file. The `test_tags_validity` test enforces this.
+- Do not use platform/software names as tags (`writefreely`, `pixelfed`). Use category names instead (`blog`, `photo`).
+- Avoid 2-letter category tags that collide with ISO country codes (e.g. `ai` = Anguilla). The `is_country_tag()` function treats any 2-letter tag as a country code.
+- Keep existing category tags when modifying country tags.
+- Top-50 sites by alexaRank must have at least one category tag (enforced by `test_top_sites_have_category_tag`).
+
+## 10. Documentation maintenance
 
 When you change Maigret, add search tools, or change check logic, keep **this playbook**, [`site-checks-guide.md`](site-checks-guide.md), and (when applicable) the template in [`socid_extractor_improvements.log`](socid_extractor_improvements.log) aligned. New log **entries** are append-only at the bottom of that file.

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -69,6 +69,21 @@ Use the following commands to check Maigret:
   make speed
 
 
+Site naming conventions
+-----------------------------------------------
+
+Site names are the keys in ``data.json`` and appear in user-facing reports. Follow these rules:
+
+- **Title Case** by default: ``Product Hunt``, ``Hacker News``.
+- **Lowercase** only if the brand itself is written that way: ``kofi``, ``note``, ``hi5``.
+- **No domain suffix** (``calendly.com`` → ``Calendly``), unless the domain is part of the recognized brand name: ``last.fm``, ``VC.ru``, ``Archive.org``.
+- **No full UPPERCASE** unless the brand is an acronym: ``VK``, ``CNET``, ``ICQ``, ``IFTTT``.
+- **No** ``www.`` **or** ``https://`` **prefix** in the name.
+- **Spaces** are allowed when the brand uses them: ``Star Citizen``, ``Google Maps``.
+- **{username} templates** in names are acceptable: ``{username}.tilda.ws``.
+
+When in doubt, check how the service refers to itself on its homepage.
+
 How to fix false-positives
 -----------------------------------------------
 

--- a/docs/source/tags.rst
+++ b/docs/source/tags.rst
@@ -10,7 +10,12 @@ The use of tags allows you to select a subset of the sites from big Maigret DB f
 
 There are several types of tags:
 
-1. **Country codes**: ``us``, ``jp``, ``br``... (`ISO 3166-1 alpha-2 <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_). These tags reflect the site language and regional origin of its users and are then used to locate the owner of a username. If the regional origin is difficult to establish or a site is positioned as worldwide, `no country code is given`. There could be multiple country code tags for one site.
+1. **Country codes**: ``us``, ``jp``, ``br``... (`ISO 3166-1 alpha-2 <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_). A country tag means that having an account on the site implies a connection to that country — either origin or residence. The goal is attribution, not perfect accuracy.
+
+   - **Global sites** (GitHub, YouTube, Reddit, Medium, etc.) get **no country tag** — an account there says nothing about where a person is from.
+   - **Regional/local sites** where an account implies a specific country **must** have a country tag: ``VK`` → ``ru``, ``Naver`` → ``kr``, ``Zhihu`` → ``cn``.
+   - Multiple country tags are allowed when a service is used predominantly in a few countries (e.g. ``Xing`` → ``de``, ``eu``).
+   - Do **not** assign country tags based on traffic statistics alone — a site popular in India by traffic is not "Indian" if it is used globally.
 
 2. **Site engines**. Most of them are forum engines now: ``uCoz``, ``vBulletin``, ``XenForo`` et al. Full list of engines stored in the Maigret database.
 

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -18,7 +18,7 @@
             "usernameClaimed": "zuck",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "networking"
+                "social"
             ]
         },
         "YouTube": {
@@ -70,10 +70,11 @@
         "Instagram": {
             "disabled": true,
             "tags": [
-                "photo"
+                "photo",
+                "social"
             ],
             "errors": {
-                "Login \u2022 Instagram": "Login required"
+                "Login • Instagram": "Login required"
             },
             "checkType": "message",
             "presenseStrs": [
@@ -87,13 +88,13 @@
         },
         "Twitter": {
             "tags": [
-                "messaging"
+                "social"
             ],
             "headers": {
                 "sec-ch-ua": "Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\"",
                 "authorization": "Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA",
                 "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
-                "x-guest-token": "2035841115320996156"
+                "x-guest-token": "2037668354144538994"
             },
             "errors": {
                 "Bad guest token": "x-guest-token update required"
@@ -125,9 +126,7 @@
         },
         "MicrosoftTechNet": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://social.technet.microsoft.com",
             "url": "https://social.technet.microsoft.com/profile/{username}/",
@@ -136,8 +135,7 @@
         },
         "MicrosoftLearn": {
             "tags": [
-                "tech",
-                "us"
+                "tech"
             ],
             "checkType": "response_url",
             "urlMain": "https://learn.microsoft.com",
@@ -148,9 +146,7 @@
         },
         "social.msdn.microsoft.com": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "engine": "engine404",
             "urlMain": "https://social.msdn.microsoft.com",
             "url": "https://social.msdn.microsoft.com/profile/{username}",
@@ -159,8 +155,7 @@
         },
         "AppleDeveloper": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "urlMain": "https://developer.apple.com/forums",
@@ -169,9 +164,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "AppleDiscussions": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://discussions.apple.com/",
             "url": "https://discussions.apple.com/profile/{username}",
@@ -205,7 +198,8 @@
         },
         "WordPressOrg": {
             "tags": [
-                "in"
+                "blog",
+                "coding"
             ],
             "checkType": "response_url",
             "alexaRank": 12,
@@ -217,8 +211,7 @@
         },
         "GooglePlayStore": {
             "tags": [
-                "apps",
-                "us"
+                "apps"
             ],
             "checkType": "status_code",
             "alexaRank": 14,
@@ -245,8 +238,7 @@
         },
         "Google Maps": {
             "tags": [
-                "maps",
-                "us"
+                "maps"
             ],
             "type": "gaia_id",
             "checkType": "message",
@@ -266,15 +258,16 @@
             "tags": [
                 "art",
                 "photo",
-                "sharing"
+                "sharing",
+                "social"
             ],
             "checkType": "message",
             "alexaRank": 18,
             "presenseStrs": [
                 "<!-- --> followers",
                 "<!-- --> following",
-                "<!-- --> \u043f\u043e\u0434\u043f\u0438\u0441\u0447\u0438\u043a\u043e\u0432",
-                "<!-- --> \u043f\u043e\u0434\u043f\u0438\u0441\u043e\u043a"
+                "<!-- --> подписчиков",
+                "<!-- --> подписок"
             ],
             "absenceStrs": [
                 "@undefined"
@@ -296,7 +289,7 @@
                 "method": "vimeo"
             },
             "headers": {
-                "Authorization": "jwt eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3NzQyMTk5MjAsInVzZXJfaWQiOm51bGwsImFwcF9pZCI6NTg0NzksInNjb3BlcyI6InB1YmxpYyIsInRlYW1fdXNlcl9pZCI6bnVsbCwianRpIjoiMzk4ZTVlYmMtMTEyOS00OTE5LWJmYzYtYmE2OWYwZDdhNGIxIn0.XEYGPsAnwgBdFaAgrDToeQHs3B5wqgjMs-_zeVEXV58"
+                "Authorization": "jwt eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3NzQ2NTM5MDAsInVzZXJfaWQiOm51bGwsImFwcF9pZCI6NTg0NzksInNjb3BlcyI6InB1YmxpYyIsInRlYW1fdXNlcl9pZCI6bnVsbCwianRpIjoiZDM3N2QyY2EtYTEyMC00NWRlLThkYjAtMGUzYWZlNWQ0NGRlIn0.5ZfqU66p6wQtFNg5-7Syrmu3mXTOzQ4Tju97eaw3Nbo"
             },
             "urlProbe": "https://api.vimeo.com/users/{username}?fields=name%2Cgender%2Cbio%2Curi%2Clink%2Cbackground_video%2Clocation_details%2Cpictures%2Cverified%2Cmetadata.public_videos.total%2Cavailable_for_hire%2Ccan_work_remotely%2Cmetadata.connections.videos.total%2Cmetadata.connections.albums.total%2Cmetadata.connections.followers.total%2Cmetadata.connections.following.total%2Cmetadata.public_videos.total%2Cmetadata.connections.vimeo_experts.is_enrolled%2Ctotal_collection_count%2Ccreated_time%2Cprofile_preferences%2Cmembership%2Cclients%2Cskills%2Cproject_types%2Crates%2Ccategories%2Cis_expert%2Cprofile_discovery%2Cwebsites%2Ccontact_emails&fetch_user_profile=1",
             "checkType": "status_code",
@@ -308,7 +301,8 @@
         },
         "TikTok": {
             "tags": [
-                "video"
+                "video",
+                "social"
             ],
             "headers": {
                 "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
@@ -331,7 +325,7 @@
         },
         "Amazon": {
             "tags": [
-                "us"
+                "shopping"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -348,9 +342,7 @@
         },
         "community.adobe.com": {
             "similarSearch": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "presenseStrs": [
                 "lia-user-item-profile",
@@ -390,9 +382,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Mozilla Support": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 ">Page Not Found</h1>",
@@ -436,7 +426,10 @@
             "urlProbe": "https://web.archive.org/web/timemap/?url=http%3A%2F%2Fplus.google.com%2F{username}&matchType=prefix&collapse=urlkey&output=json&fl=original%2Cmimetype%2Ctimestamp%2Cendtimestamp%2Cgroupcount%2Cuniqcount&filter=!statuscode%3A%5B45%5D..&limit=100000&_=1624789582128",
             "url": "https://web.archive.org/web/*/plus.google.com/{username}*",
             "usernameClaimed": "117522081019092547227",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "tags": [
+                "social"
+            ]
         },
         "Telegram": {
             "tags": [
@@ -494,7 +487,8 @@
         "Reddit": {
             "tags": [
                 "discussion",
-                "news"
+                "news",
+                "social"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -515,7 +509,8 @@
         },
         "Tumblr": {
             "tags": [
-                "blog"
+                "blog",
+                "social"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -538,8 +533,7 @@
         "Spotify": {
             "disabled": true,
             "tags": [
-                "music",
-                "us"
+                "music"
             ],
             "headers": {
                 "authorization": "Bearer BQDDk6n__YLKqIDKxBb2fvOZm6yxuOj0XeU0mCpRmBi_0UsUz2fUP-tFsl7IjT-YOCXxmvfzUMAnQ0Y4KBo"
@@ -578,7 +572,10 @@
             "url": "https://archive.org/details/@{username}",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewould",
-            "disabled": true
+            "disabled": true,
+            "tags": [
+                "archive"
+            ]
         },
         "Flickr": {
             "tags": [
@@ -591,7 +588,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.flickr.com": {
+        "Flickr Groups": {
             "checkType": "message",
             "absenceStrs": [
                 ":404,",
@@ -611,12 +608,14 @@
             "urlMain": "https://www.flickr.com",
             "usernameClaimed": "sunny2000",
             "usernameUnclaimed": "vozkxyhksz",
-            "alexaRank": 68
+            "alexaRank": 68,
+            "tags": [
+                "photo"
+            ]
         },
         "Medium": {
             "tags": [
-                "blog",
-                "us"
+                "blog"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -658,7 +657,7 @@
                 "\"hydratable\":\"user\""
             ],
             "absenceStrs": [
-                "SoundCloud - Hear the world\u2019s sounds"
+                "SoundCloud - Hear the world’s sounds"
             ],
             "urlMain": "https://soundcloud.com/",
             "url": "https://soundcloud.com/{username}",
@@ -668,8 +667,7 @@
         },
         "SourceForge": {
             "tags": [
-                "coding",
-                "us"
+                "coding"
             ],
             "checkType": "message",
             "alexaRank": 80,
@@ -684,8 +682,8 @@
         "TheGuardian": {
             "disabled": true,
             "tags": [
-                "news",
-                "us"
+                "gb",
+                "news"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -699,9 +697,7 @@
         },
         "Oracle Community": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://community.oracle.com",
             "url": "https://community.oracle.com/people/{username}",
@@ -710,8 +706,7 @@
         },
         "forums.opera.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.opera.com/",
@@ -721,7 +716,8 @@
         },
         "VK": {
             "tags": [
-                "ru"
+                "ru",
+                "social"
             ],
             "checkType": "status_code",
             "regexCheck": "^(?!id\\d)\\w*$",
@@ -733,7 +729,8 @@
         },
         "VK (by id)": {
             "tags": [
-                "ru"
+                "ru",
+                "social"
             ],
             "type": "vk_id",
             "checkType": "response_url",
@@ -747,8 +744,7 @@
         },
         "Launchpad": {
             "tags": [
-                "tech",
-                "us"
+                "tech"
             ],
             "checkType": "status_code",
             "alexaRank": 96,
@@ -769,8 +765,8 @@
         },
         "ResearchGate": {
             "tags": [
-                "in",
-                "us"
+                "research",
+                "social"
             ],
             "regexCheck": "\\w+_\\w+",
             "checkType": "response_url",
@@ -783,8 +779,7 @@
         },
         "Scratch": {
             "tags": [
-                "coding",
-                "us"
+                "coding"
             ],
             "checkType": "status_code",
             "urlMain": "https://scratch.mit.edu/",
@@ -793,9 +788,7 @@
             "usernameUnclaimed": "noonewould"
         },
         "cyber.harvard.edu": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://cyber.harvard.edu",
             "url": "https://cyber.harvard.edu/people/{username}",
@@ -852,7 +845,7 @@
             "activation": {
                 "method": "weibo",
                 "marks": [
-                    "<title>\u5fae\u535a</title",
+                    "<title>微博</title",
                     "<title>Sina Visitor System</title>"
                 ],
                 "url": "https://passport.weibo.com/visitor/genvisitor2"
@@ -865,7 +858,7 @@
             "checkType": "message",
             "tags": [
                 "cn",
-                "networking"
+                "social"
             ],
             "alexaRank": 115
         },
@@ -893,7 +886,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "The page you\u2019re looking for doesn\u2019t exist.",
+                "The page you’re looking for doesn’t exist.",
                 "Want this to be your username?"
             ],
             "presenseStrs": [
@@ -927,7 +920,11 @@
                 "The resource is being rate limited": "Rate limited",
                 "You are being rate limited": "Rate limited",
                 "rate_limited": "Rate limited"
-            }
+            },
+            "tags": [
+                "messaging",
+                "gaming"
+            ]
         },
         "Unsplash": {
             "tags": [
@@ -941,9 +938,9 @@
             "usernameClaimed": "jenny",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "calendly.com": {
+        "Calendly": {
             "tags": [
-                "us"
+                "business"
             ],
             "checkType": "status_code",
             "presenseStrs": [
@@ -962,12 +959,11 @@
         "Etsy": {
             "disabled": true,
             "tags": [
-                "shopping",
-                "us"
+                "shopping"
             ],
             "errors": {
                 "Sanctions Policy": "Site censorship",
-                "\u041f\u043e\u043b\u0438\u0442\u0438\u043a\u0430 \u0441\u0430\u043d\u043a\u0446\u0438\u0439": "Site censorship"
+                "Политика санкций": "Site censorship"
             },
             "checkType": "status_code",
             "alexaRank": 151,
@@ -993,8 +989,7 @@
         },
         "Twitch": {
             "tags": [
-                "streaming",
-                "us"
+                "streaming"
             ],
             "urlProbe": "https://twitchtracker.com/{username}",
             "checkType": "status_code",
@@ -1006,8 +1001,7 @@
         },
         "Ebay": {
             "tags": [
-                "shopping",
-                "us"
+                "shopping"
             ],
             "errors": {
                 "<title>Security Measure</title>": "Captcha detected"
@@ -1062,7 +1056,11 @@
             ],
             "errors": {
                 "Client Challenge": "Anti-bot challenge"
-            }
+            },
+            "tags": [
+                "documents",
+                "sharing"
+            ]
         },
         "Behance": {
             "tags": [
@@ -1099,7 +1097,7 @@
         },
         "Bluesky": {
             "tags": [
-                "messaging"
+                "social"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -1160,8 +1158,7 @@
         "CNET": {
             "tags": [
                 "news",
-                "tech",
-                "us"
+                "tech"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -1193,7 +1190,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "This page is on vacation\u2026"
+                "This page is on vacation…"
             ],
             "headers": {
                 "Accept-Language": "en-US,en;q=0.5"
@@ -1206,7 +1203,7 @@
         },
         "Wix": {
             "tags": [
-                "us"
+                "tech"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -1246,8 +1243,7 @@
         },
         "Bandcamp": {
             "tags": [
-                "music",
-                "us"
+                "music"
             ],
             "checkType": "status_code",
             "alexaRank": 230,
@@ -1318,7 +1314,8 @@
         },
         "TheVerge": {
             "tags": [
-                "us"
+                "news",
+                "tech"
             ],
             "checkType": "response_url",
             "alexaRank": 241,
@@ -1329,7 +1326,8 @@
         },
         "ThemeForest": {
             "tags": [
-                "in"
+                "coding",
+                "shopping"
             ],
             "checkType": "status_code",
             "alexaRank": 242,
@@ -1340,7 +1338,8 @@
         },
         "Myspace": {
             "tags": [
-                "blog"
+                "social",
+                "music"
             ],
             "checkType": "status_code",
             "alexaRank": 244,
@@ -1359,12 +1358,15 @@
             "absenceStrs": [
                 "did not match any articles",
                 "not match"
+            ],
+            "tags": [
+                "education",
+                "research"
             ]
         },
         "GoodReads": {
             "tags": [
-                "books",
-                "us"
+                "books"
             ],
             "checkType": "status_code",
             "alexaRank": 256,
@@ -1383,10 +1385,10 @@
             },
             "checkType": "message",
             "presenseStrs": [
-                "content=\"\u041e\u0442\u0437\u044b\u0432\u044b \u0438 \u043e\u0446\u0435\u043d\u043a\u0438"
+                "content=\"Отзывы и оценки"
             ],
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441\u043a\u0440\u044b\u043b \u0441\u0432\u043e\u044e \u043f\u0443\u0431\u043b\u0438\u0447\u043d\u0443\u044e \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443"
+                "Пользователь скрыл свою публичную страницу"
             ],
             "alexaRank": 262,
             "urlMain": "https://yandex.ru/",
@@ -1531,8 +1533,7 @@
         },
         "forums.docker.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forums.docker.com",
@@ -1541,8 +1542,7 @@
         },
         "Weforum": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "alexaRank": 270,
@@ -1583,7 +1583,8 @@
         },
         "Academia.edu": {
             "tags": [
-                "id"
+                "education",
+                "research"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -1596,8 +1597,7 @@
         "DiscussPython": {
             "tags": [
                 "coding",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://discuss.python.org/",
@@ -1619,8 +1619,7 @@
         },
         "Dribbble": {
             "tags": [
-                "business",
-                "in"
+                "business"
             ],
             "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
             "checkType": "message",
@@ -1659,8 +1658,7 @@
         },
         "Kickstarter": {
             "tags": [
-                "finance",
-                "us"
+                "finance"
             ],
             "checkType": "status_code",
             "alexaRank": 300,
@@ -1669,9 +1667,9 @@
             "usernameClaimed": "zhovner",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.change.org": {
+        "Change.org": {
             "tags": [
-                "us"
+                "social"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -1689,7 +1687,6 @@
         },
         "Armchairgm": {
             "tags": [
-                "us",
                 "wiki"
             ],
             "checkType": "message",
@@ -1708,7 +1705,6 @@
         "Battleraprus": {
             "tags": [
                 "ru",
-                "us",
                 "wiki"
             ],
             "checkType": "status_code",
@@ -1738,7 +1734,7 @@
         },
         "Fandom": {
             "tags": [
-                "us"
+                "wiki"
             ],
             "checkType": "status_code",
             "alexaRank": 315,
@@ -1818,8 +1814,7 @@
         },
         "Waypoint": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.waypoint.vice.com",
@@ -1829,8 +1824,7 @@
         },
         "Gofundme": {
             "tags": [
-                "finance",
-                "us"
+                "finance"
             ],
             "checkType": "status_code",
             "alexaRank": 397,
@@ -1848,13 +1842,13 @@
             "urlMain": "https://www.zhihu.com/",
             "url": "https://www.zhihu.com/people/{username}",
             "absenceStrs": [
-                "\u7528\u6237\u4e0d\u5b58\u5728"
+                "用户不存在"
             ],
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "disabled": true
         },
-        "giphy.com": {
+        "Giphy": {
             "absenceStrs": [
                 "404 Not Found"
             ],
@@ -1877,14 +1871,17 @@
             "urlMain": "https://www.threads.net/",
             "checkType": "message",
             "absenceStrs": [
-                "<title>Threads \u2022 Log in</title>"
+                "<title>Threads • Log in</title>"
             ],
             "headers": {
                 "Sec-Fetch-Mode": "navigate"
             },
             "usernameClaimed": "zuck",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 407
+            "alexaRank": 407,
+            "tags": [
+                "social"
+            ]
         },
         "Slack": {
             "tags": [
@@ -1905,7 +1902,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "https://weld.in.ua",
             "url": "https://weld.in.ua/forum/member.php/?username={username}",
@@ -1914,8 +1911,7 @@
         },
         "BuzzFeed": {
             "tags": [
-                "news",
-                "us"
+                "news"
             ],
             "checkType": "status_code",
             "alexaRank": 451,
@@ -1926,8 +1922,7 @@
         },
         "W3Schools": {
             "tags": [
-                "education",
-                "us"
+                "education"
             ],
             "checkType": "status_code",
             "urlMain": "https://www.w3schools.com/",
@@ -1949,7 +1944,8 @@
         },
         "Disqus": {
             "tags": [
-                "discussion"
+                "discussion",
+                "social"
             ],
             "errors": {
                 "Invalid API key": "New API key needed"
@@ -1971,9 +1967,7 @@
         },
         "Ask Fedora": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "absenceStrs": [
                 "Sorry, we couldn't find that page."
@@ -1985,7 +1979,8 @@
         },
         "OK": {
             "tags": [
-                "ru"
+                "ru",
+                "social"
             ],
             "regexCheck": "^[a-zA-Z][a-zA-Z0-9_.-]*$",
             "checkType": "status_code",
@@ -2003,7 +1998,10 @@
             "usernameClaimed": "teamsnapchat",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 525,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "social"
+            ]
         },
         "Trello": {
             "tags": [
@@ -2023,8 +2021,7 @@
         "Photobucket": {
             "disabled": true,
             "tags": [
-                "photo",
-                "us"
+                "photo"
             ],
             "regexCheck": "\\w{4,32}",
             "checkType": "message",
@@ -2041,7 +2038,7 @@
         "Udemy": {
             "disabled": true,
             "tags": [
-                "in"
+                "education"
             ],
             "checkType": "response_url",
             "alexaRank": 546,
@@ -2054,8 +2051,7 @@
             "tags": [
                 "music",
                 "photo",
-                "stock",
-                "us"
+                "stock"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -2189,7 +2185,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430"
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра"
             ],
             "urlMain": "https://cfire.mail.ru",
             "url": "https://cfire.mail.ru/forums/member.php?username={username}",
@@ -2215,7 +2211,7 @@
             "regexCheck": "^\\d+$",
             "checkType": "message",
             "absenceStrs": [
-                "<title>\u0417\u043d\u0430\u043a\u043e\u043c\u0441\u0442\u0432\u0430@Mail.Ru</title>"
+                "<title>Знакомства@Mail.Ru</title>"
             ],
             "urlMain": "https://love.mail.ru",
             "url": "https://love.mail.ru/profile/{username}",
@@ -2233,7 +2229,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/ok/{username}",
@@ -2251,7 +2247,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/vk/{username}",
@@ -2268,7 +2264,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/bk/{username}/",
@@ -2285,7 +2281,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/gmail.com/{username}/",
@@ -2302,7 +2298,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/list/{username}/",
@@ -2319,7 +2315,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/mail/{username}/",
@@ -2336,7 +2332,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/ya.ru/{username}/",
@@ -2353,7 +2349,7 @@
             ],
             "absenceStrs": [
                 "mm-profile_not-found_content",
-                "<title>\u041c\u043e\u0439 \u041c\u0438\u0440@Mail.Ru</title>"
+                "<title>Мой Мир@Mail.Ru</title>"
             ],
             "urlMain": "https://my.mail.ru/",
             "url": "https://my.mail.ru/yandex.ru/{username}/",
@@ -2472,7 +2468,6 @@
         "DigitalOcean": {
             "tags": [
                 "forum",
-                "in",
                 "tech"
             ],
             "regexCheck": "^[^\\.]+$",
@@ -2485,8 +2480,7 @@
         },
         "About.me": {
             "tags": [
-                "blog",
-                "in"
+                "blog"
             ],
             "checkType": "status_code",
             "alexaRank": 669,
@@ -2511,8 +2505,7 @@
         },
         "PeopleIgn": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -2526,8 +2519,7 @@
         "Envato": {
             "tags": [
                 "au",
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forums.envato.com",
@@ -2558,7 +2550,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Пользователь не найден"
             ],
             "urlMain": "https://2berega.spb.ru",
             "url": "https://2berega.spb.ru/user/{username}",
@@ -2572,7 +2564,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435"
+                "Извините"
             ],
             "urlMain": "https://diveforum.spb.ru/",
             "url": "https://diveforum.spb.ru/profile.php?mode=viewprofile&u={username}",
@@ -2587,8 +2579,7 @@
         },
         "Fiverr": {
             "tags": [
-                "shopping",
-                "us"
+                "shopping"
             ],
             "checkType": "response_url",
             "alexaRank": 733,
@@ -2604,7 +2595,12 @@
             "urlMain": "https://huggingface.co/",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 749
+            "alexaRank": 749,
+            "tags": [
+                "coding",
+                "tech",
+                "llm"
+            ]
         },
         "Laracast": {
             "url": "https://laracasts.com/@{username}",
@@ -2613,7 +2609,11 @@
             "regexCheck": "^[a-zA-Z0-9_-]{3,}$",
             "usernameClaimed": "user1",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 752
+            "alexaRank": 752,
+            "tags": [
+                "coding",
+                "education"
+            ]
         },
         "Paypal": {
             "tags": [
@@ -2636,7 +2636,7 @@
         },
         "Itch.io": {
             "tags": [
-                "blog"
+                "gaming"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -2662,8 +2662,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.ea.com",
@@ -2684,7 +2683,7 @@
         },
         "Gumroad": {
             "tags": [
-                "us"
+                "shopping"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -2720,7 +2719,7 @@
         },
         "Douban": {
             "absenceStrs": [
-                "\u8fd4\u56de\u9996\u9875"
+                "返回首页"
             ],
             "presenseStrs": [
                 "db-usr-profile"
@@ -2735,9 +2734,9 @@
             ],
             "alexaRank": 874
         },
-        "upwork.com": {
+        "Upwork": {
             "tags": [
-                "us"
+                "freelance"
             ],
             "engine": "engine404",
             "urlMain": "https://upwork.com",
@@ -2749,7 +2748,7 @@
         "LonelyPlanet": {
             "disabled": true,
             "tags": [
-                "us"
+                "travel"
             ],
             "checkType": "status_code",
             "alexaRank": 893,
@@ -2800,8 +2799,7 @@
         },
         "PyPi": {
             "tags": [
-                "in",
-                "us"
+                "coding"
             ],
             "errors": {
                 "Please enable JavaScript to proceed": "Scraping protection"
@@ -2827,8 +2825,7 @@
         },
         "ComicvineGamespot": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "urlMain": "https://comicvine.gamespot.com/",
@@ -2838,8 +2835,7 @@
         },
         "Gamefaqs": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "regexCheck": "^\\S+$",
             "errors": {
@@ -2861,8 +2857,7 @@
         },
         "Gamespot": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 913,
@@ -2877,8 +2872,7 @@
             "usernameClaimed": "abbyec",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Figma": {
@@ -2914,7 +2908,7 @@
         "Houzz": {
             "disabled": true,
             "tags": [
-                "us"
+                "design"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -2929,7 +2923,7 @@
         "Foursquare": {
             "tags": [
                 "geosocial",
-                "in"
+                "social"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -2946,8 +2940,7 @@
         },
         "HackerNews": {
             "tags": [
-                "news",
-                "us"
+                "news"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -2961,8 +2954,7 @@
         },
         "TradingView": {
             "tags": [
-                "trading",
-                "us"
+                "trading"
             ],
             "checkType": "status_code",
             "alexaRank": 995,
@@ -2973,8 +2965,7 @@
         },
         "Discogs": {
             "tags": [
-                "music",
-                "us"
+                "music"
             ],
             "checkType": "status_code",
             "alexaRank": 1016,
@@ -2985,7 +2976,7 @@
         },
         "Jimdo": {
             "tags": [
-                "jp"
+                "de"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -3018,8 +3009,7 @@
         },
         "Codepen": {
             "tags": [
-                "coding",
-                "in"
+                "coding"
             ],
             "errors": {
                 "Checking your browser before accessing": "Autoredirect detected"
@@ -3036,8 +3026,7 @@
         },
         "Rottentomatoes": {
             "tags": [
-                "movies",
-                "us"
+                "movies"
             ],
             "checkType": "status_code",
             "alexaRank": 1083,
@@ -3048,8 +3037,7 @@
         },
         "TomsHardware": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -3063,7 +3051,7 @@
         },
         "Smugmug": {
             "tags": [
-                "us"
+                "photo"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "response_url",
@@ -3079,13 +3067,12 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Duolingo": {
             "tags": [
-                "us"
+                "education"
             ],
             "urlProbe": "https://www.duolingo.com/2017-06-30/users?username={username}",
             "checkType": "message",
@@ -3100,10 +3087,7 @@
         },
         "kofi": {
             "tags": [
-                "freelance",
-                "in",
-                "ru",
-                "us"
+                "freelance"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -3119,8 +3103,8 @@
         },
         "Ustream": {
             "tags": [
-                "eg",
-                "us"
+                "streaming",
+                "video"
             ],
             "checkType": "response_url",
             "alexaRank": 1143,
@@ -3130,9 +3114,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "djskt.lnk.to": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "presenseStrs": [
                 "artistName",
@@ -3158,7 +3140,7 @@
         },
         "Strava": {
             "tags": [
-                "us"
+                "sport"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -3186,7 +3168,7 @@
         },
         "Wikidot": {
             "tags": [
-                "us"
+                "wiki"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -3215,7 +3197,7 @@
         },
         "ReverbNation": {
             "tags": [
-                "us"
+                "music"
             ],
             "errors": {
                 "But your computer or network appears to be generating a lot of automated requests": "Too many requests"
@@ -3268,7 +3250,7 @@
         "VirusTotal": {
             "disabled": true,
             "tags": [
-                "in"
+                "tech"
             ],
             "headers": {
                 "accept-language": "en-US,en;q=0.9,es;q=0.8",
@@ -3294,7 +3276,7 @@
                 "ru"
             ],
             "errors": {
-                "\u041f\u0440\u0438 \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u0438\u0438 \u0437\u0430\u043f\u0440\u043e\u0441\u0430 \u044d\u0442\u043e\u0439 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u044b \u043f\u0440\u043e\u0438\u0437\u043e\u0448\u043b\u0430 \u043e\u0448\u0438\u0431\u043a\u0430.": "Site error"
+                "При выполнении запроса этой страницы произошла ошибка.": "Site error"
             },
             "checkType": "message",
             "absenseStrs": [
@@ -3311,8 +3293,7 @@
         },
         "ProductHunt": {
             "tags": [
-                "tech",
-                "us"
+                "tech"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -3329,8 +3310,7 @@
         },
         "HubPages": {
             "tags": [
-                "blog",
-                "us"
+                "blog"
             ],
             "checkType": "status_code",
             "urlMain": "https://hubpages.com/",
@@ -3341,8 +3321,7 @@
         },
         "Genius": {
             "tags": [
-                "music",
-                "us"
+                "music"
             ],
             "checkType": "status_code",
             "alexaRank": 1324,
@@ -3364,7 +3343,6 @@
         },
         "Flipboard": {
             "tags": [
-                "in",
                 "tech"
             ],
             "regexCheck": "^([a-zA-Z0-9_]){1,15}$",
@@ -3402,7 +3380,7 @@
         },
         "BuyMeACoffee": {
             "tags": [
-                "in"
+                "freelance"
             ],
             "urlProbe": "https://www.buymeacoffee.com/{username}",
             "checkType": "status_code",
@@ -3414,7 +3392,8 @@
         },
         "Techrepublic": {
             "tags": [
-                "us"
+                "news",
+                "tech"
             ],
             "checkType": "status_code",
             "alexaRank": 1360,
@@ -3425,7 +3404,7 @@
         },
         "Pbase": {
             "tags": [
-                "in"
+                "photo"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -3440,8 +3419,7 @@
         },
         "Packagist": {
             "tags": [
-                "in",
-                "jp"
+                "coding"
             ],
             "checkType": "response_url",
             "alexaRank": 1400,
@@ -3472,11 +3450,16 @@
             "absenceStrs": [
                 "not found",
                 "404"
+            ],
+            "tags": [
+                "coding",
+                "education"
             ]
         },
         "AllTrails": {
             "tags": [
-                "us"
+                "sport",
+                "travel"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -3494,7 +3477,7 @@
         },
         "Diigo": {
             "tags": [
-                "in"
+                "bookmarks"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -3508,7 +3491,7 @@
         },
         "AllRecipes": {
             "tags": [
-                "us"
+                "hobby"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -3532,7 +3515,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<h1>\u041e\u0448\u0438\u0431\u043a\u0430 404</h1>"
+                "<h1>Ошибка 404</h1>"
             ],
             "urlMain": "https://career.habr.com/",
             "url": "https://career.habr.com/{username}",
@@ -3580,8 +3563,7 @@
             "usernameClaimed": "admin",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Gorod.dp.ua": {
@@ -3605,8 +3587,7 @@
         },
         "Redbubble": {
             "tags": [
-                "shopping",
-                "us"
+                "shopping"
             ],
             "checkType": "status_code",
             "alexaRank": 1503,
@@ -3617,7 +3598,7 @@
         },
         "codeberg.org": {
             "tags": [
-                "in"
+                "coding"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -3636,7 +3617,8 @@
         },
         "Codecanyon": {
             "tags": [
-                "in"
+                "coding",
+                "shopping"
             ],
             "checkType": "status_code",
             "alexaRank": 1571,
@@ -3648,11 +3630,7 @@
         "Windy": {
             "disabled": true,
             "tags": [
-                "in",
-                "jp",
-                "kr",
-                "pl",
-                "us"
+                "maps"
             ],
             "checkType": "status_code",
             "alexaRank": 1580,
@@ -3663,8 +3641,7 @@
         },
         "community.brave.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://community.brave.com",
@@ -3717,7 +3694,10 @@
             "regexCheck": "^.{1,25}$",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 1629
+            "alexaRank": 1629,
+            "tags": [
+                "gaming"
+            ]
         },
         "{username}.tilda.ws": {
             "tags": [
@@ -3733,8 +3713,7 @@
         "Discuss.Elastic.co": {
             "tags": [
                 "forum",
-                "tech",
-                "us"
+                "tech"
             ],
             "engine": "Discourse",
             "urlMain": "https://discuss.elastic.co/",
@@ -3761,8 +3740,7 @@
         },
         "discuss.codecademy.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://discuss.codecademy.com",
@@ -3771,7 +3749,8 @@
         },
         "Polygon": {
             "tags": [
-                "us"
+                "gaming",
+                "news"
             ],
             "checkType": "status_code",
             "alexaRank": 1658,
@@ -3796,10 +3775,9 @@
                 "forum"
             ]
         },
-        "hackernoon.com": {
+        "HackerNoon": {
             "tags": [
-                "news",
-                "us"
+                "news"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -3857,8 +3835,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -3889,7 +3866,10 @@
             "usernameClaimed": "john",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 1757,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "reading"
+            ]
         },
         "RamblerDating": {
             "disabled": true,
@@ -3950,10 +3930,11 @@
             "usernameClaimed": "Dogstho7951",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "opensea.io": {
+        "OpenSea": {
             "disabled": true,
             "tags": [
-                "us"
+                "nft",
+                "crypto"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -3973,8 +3954,7 @@
         },
         "Speakerdeck": {
             "tags": [
-                "in",
-                "us"
+                "sharing"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -4026,7 +4006,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041c\u044b \u0432\u0441\u0435 \u0432\u043d\u0438\u043c\u0430\u0442\u0435\u043b\u044c\u043d\u043e \u043f\u043e\u0441\u043c\u043e\u0442\u0440\u0435\u043b\u0438, \u043d\u043e \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0448\u043b\u0438 :("
+                "Мы все внимательно посмотрели, но ничего не нашли :("
             ],
             "alexaRank": 1879,
             "urlMain": "https://vc.ru",
@@ -4107,9 +4087,7 @@
             ]
         },
         "fablero.ucoz.ru": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "engine": "uCoz",
             "urlMain": "http://fablero.ucoz.ru",
             "usernameClaimed": "alex",
@@ -5356,9 +5334,7 @@
             ]
         },
         "SoftwareInformer": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "response_url",
             "urlMain": "https://users.software.informer.com",
             "url": "https://users.software.informer.com/{username}/",
@@ -5379,11 +5355,11 @@
         },
         "Letterboxd": {
             "tags": [
-                "us"
+                "movies"
             ],
             "checkType": "message",
             "absenceStrs": [
-                "Sorry, we can\u2019t find the page you\u2019ve requested."
+                "Sorry, we can’t find the page you’ve requested."
             ],
             "alexaRank": 2000,
             "urlMain": "https://letterboxd.com/",
@@ -5393,7 +5369,7 @@
         },
         "MyAnimeList": {
             "tags": [
-                "movies"
+                "anime"
             ],
             "checkType": "status_code",
             "alexaRank": 2033,
@@ -5416,8 +5392,7 @@
         },
         "Roblox": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 2097,
@@ -5428,9 +5403,7 @@
         },
         "Flightradar24": {
             "tags": [
-                "de",
-                "es",
-                "us"
+                "maps"
             ],
             "regexCheck": "^[a-zA-Z0-9_]{3,20}$",
             "checkType": "status_code",
@@ -5446,8 +5419,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "discuss.hashicorp.com": {
@@ -5459,15 +5431,15 @@
                 "tech"
             ]
         },
-        "metacritic": {
+        "Metacritic": {
             "disabled": true,
             "tags": [
-                "us"
+                "review"
             ],
             "regexCheck": "^(?![-_])[A-Za-z0-9-_]{3,15}$",
             "checkType": "message",
             "absenceStrs": [
-                "This user hasn\u2019t rated anything yet"
+                "This user hasn’t rated anything yet"
             ],
             "presenseStrs": [
                 "Avg. User score"
@@ -5480,7 +5452,7 @@
         },
         "TVTropes": {
             "tags": [
-                "us"
+                "wiki"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -5497,9 +5469,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "T-MobileSupport": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://support.t-mobile.com",
             "url": "https://support.t-mobile.com/people/{username}",
@@ -5521,9 +5491,7 @@
         "ICQ": {
             "disabled": true,
             "tags": [
-                "ch",
-                "ru",
-                "tr"
+                "ru"
             ],
             "checkType": "status_code",
             "alexaRank": 2391,
@@ -5535,7 +5503,7 @@
         "Eurogamer": {
             "disabled": true,
             "tags": [
-                "us"
+                "gb"
             ],
             "checkType": "status_code",
             "alexaRank": 2394,
@@ -5547,8 +5515,7 @@
         "BoardGameGeek": {
             "checkType": "message",
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "absenceStrs": [
                 "\t\tUser not found",
@@ -5576,9 +5543,13 @@
             "checkType": "status_code",
             "usernameClaimed": "notice",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 2424
+            "alexaRank": 2424,
+            "tags": [
+                "blog",
+                "kr"
+            ]
         },
-        "jsfiddle.net": {
+        "JSFiddle": {
             "tags": [
                 "coding",
                 "sharing"
@@ -5612,8 +5583,7 @@
         "123rf": {
             "tags": [
                 "photo",
-                "ru",
-                "us"
+                "ru"
             ],
             "checkType": "response_url",
             "urlMain": "https://ru.123rf.com",
@@ -5623,9 +5593,7 @@
         },
         "linuxfoundation": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "urlMain": "https://forum.linuxfoundation.org",
@@ -5633,10 +5601,9 @@
             "usernameClaimed": "chap92",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "techspot.com": {
+        "TechSpot": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "errors": {
                 "You must be logged-in to do that.": "Login required"
@@ -5647,9 +5614,10 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.gamesradar.com": {
+        "GamesRadar": {
             "tags": [
-                "us"
+                "gaming",
+                "news"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -5671,8 +5639,7 @@
         },
         "Gog": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 2516,
@@ -5681,11 +5648,9 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "geocaching": {
+        "Geocaching": {
             "tags": [
-                "de",
-                "hobby",
-                "us"
+                "hobby"
             ],
             "checkType": "status_code",
             "alexaRank": 2520,
@@ -5696,7 +5661,7 @@
         },
         "Coub": {
             "tags": [
-                "us"
+                "video"
             ],
             "checkType": "status_code",
             "alexaRank": 2543,
@@ -5708,8 +5673,7 @@
         "Metacafe": {
             "disabled": true,
             "tags": [
-                "in",
-                "us"
+                "video"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -5741,8 +5705,7 @@
         "Rust-lang": {
             "tags": [
                 "coding",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://users.rust-lang.org",
@@ -5751,8 +5714,7 @@
         },
         "Keybase": {
             "tags": [
-                "business",
-                "us"
+                "business"
             ],
             "urlProbe": "https://keybase.io/_/api/1.0/user/lookup.json?usernames={username}",
             "checkType": "message",
@@ -5769,7 +5731,8 @@
         "LiveLeak": {
             "disabled": true,
             "tags": [
-                "us"
+                "video",
+                "news"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -5783,7 +5746,7 @@
         },
         "Artsy": {
             "tags": [
-                "us"
+                "art"
             ],
             "checkType": "status_code",
             "alexaRank": 2691,
@@ -5813,7 +5776,7 @@
         },
         "beacons.ai": {
             "tags": [
-                "us"
+                "links"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -5839,7 +5802,7 @@
             "checkType": "message",
             "absenceStrs": [
                 "Page not found",
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430"
+                "Страница не найдена"
             ],
             "presenseStrs": [
                 "taplink.cc"
@@ -5852,8 +5815,7 @@
         },
         "MetaDiscourse": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://meta.discourse.org/",
@@ -5874,7 +5836,7 @@
             "checkType": "message",
             "alexaRank": 2778,
             "tags": [
-                "us"
+                "news"
             ]
         },
         "Odysee": {
@@ -5886,7 +5848,10 @@
             ],
             "usernameClaimed": "Odysee",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 2787
+            "alexaRank": 2787,
+            "tags": [
+                "video"
+            ]
         },
         "community.icons8.com": {
             "urlMain": "https://community.icons8.com",
@@ -5894,8 +5859,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "Hack MD": {
@@ -5913,8 +5877,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "movies",
-                "us"
+                "movies"
             ],
             "headers": {
                 "'User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0"
@@ -5947,7 +5910,7 @@
                 "coding"
             ]
         },
-        "donorbox": {
+        "Donorbox": {
             "absenceStrs": [
                 "/orgs/new"
             ],
@@ -5966,8 +5929,7 @@
         },
         "Freelancer.com": {
             "tags": [
-                "freelance",
-                "us"
+                "freelance"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -5981,7 +5943,7 @@
         },
         "Giantbomb": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 2936,
@@ -5996,9 +5958,12 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 2948
+            "alexaRank": 2948,
+            "tags": [
+                "coding"
+            ]
         },
-        "steemit": {
+        "Steemit": {
             "absenceStrs": [
                 "NotFound__menu"
             ],
@@ -6019,8 +5984,7 @@
         "gentoo": {
             "tags": [
                 "fi",
-                "forum",
-                "in"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -6049,11 +6013,10 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
-        "www.inaturalist.org": {
+        "iNaturalist": {
             "checkType": "message",
             "absenceStrs": [
                 "display:none",
@@ -6073,13 +6036,14 @@
             "urlMain": "https://www.inaturalist.org",
             "usernameClaimed": "sparky123",
             "usernameUnclaimed": "cawlpwmifx",
-            "alexaRank": 3027
+            "alexaRank": 3027,
+            "tags": [
+                "science",
+                "hobby"
+            ]
         },
         "Pluralsight": {
-            "tags": [
-                "in",
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "errors": {
                 "Unfortunately, Pluralsight's products are not available in your area at this time": "Site censorship"
@@ -6093,7 +6057,7 @@
             "usernameClaimed": "adam-crahen",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "gfycat": {
+        "Gfycat": {
             "tags": [
                 "photo",
                 "sharing"
@@ -6120,7 +6084,7 @@
         },
         "Teletype": {
             "tags": [
-                "in",
+                "ru",
                 "writing"
             ],
             "checkType": "status_code",
@@ -6132,16 +6096,14 @@
         },
         "F-droid": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.f-droid.org",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "dailykos": {
+        "DailyKos": {
             "tags": [
                 "us"
             ],
@@ -6158,11 +6120,15 @@
             "checkType": "status_code",
             "usernameClaimed": "briggs",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 3099
+            "alexaRank": 3099,
+            "tags": [
+                "coding"
+            ]
         },
         "Mix": {
             "tags": [
-                "in"
+                "links",
+                "sharing"
             ],
             "checkType": "response_url",
             "alexaRank": 3128,
@@ -6201,7 +6167,8 @@
         },
         "OpenCollective": {
             "tags": [
-                "in"
+                "finance",
+                "coding"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -6235,7 +6202,7 @@
         },
         "ChaturBate": {
             "tags": [
-                "us"
+                "webcam"
             ],
             "checkType": "status_code",
             "alexaRank": 3165,
@@ -6247,8 +6214,8 @@
         "Techdirt": {
             "disabled": true,
             "tags": [
-                "in",
-                "us"
+                "news",
+                "tech"
             ],
             "checkType": "status_code",
             "alexaRank": 3176,
@@ -6299,7 +6266,7 @@
         },
         "Ultimate-Guitar": {
             "tags": [
-                "us"
+                "music"
             ],
             "checkType": "status_code",
             "alexaRank": 3347,
@@ -6311,8 +6278,7 @@
         "SublimeForum": {
             "tags": [
                 "coding",
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.sublimetext.com/",
@@ -6540,7 +6506,8 @@
         },
         "Plurk": {
             "tags": [
-                "tw"
+                "tw",
+                "social"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7089,7 +7056,7 @@
         "TechPowerUp": {
             "disabled": true,
             "tags": [
-                "us"
+                "tech"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7114,8 +7081,7 @@
         },
         "HackerOne": {
             "tags": [
-                "hacking",
-                "in"
+                "hacking"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7149,13 +7115,15 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 3699
+            "alexaRank": 3699,
+            "tags": [
+                "movies"
+            ]
         },
         "Winamp": {
             "disabled": true,
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "vBulletin",
             "urlMain": "http://forums.winamp.com",
@@ -7165,8 +7133,7 @@
         "Skyrock": {
             "disabled": true,
             "tags": [
-                "fr",
-                "in"
+                "fr"
             ],
             "regexCheck": "^[^_\\.]+$",
             "checkType": "status_code",
@@ -7192,7 +7159,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "angel.co": {
+        "AngelList": {
             "absenceStrs": [
                 "render_not_found"
             ],
@@ -7217,11 +7184,9 @@
             "disabled": true,
             "tags": [
                 "de",
-                "in",
                 "it",
                 "nl",
-                "no",
-                "us"
+                "no"
             ],
             "checkType": "status_code",
             "urlMain": "https://discussions.tomtom.com/",
@@ -7231,7 +7196,7 @@
         },
         "Cracked": {
             "tags": [
-                "us"
+                "news"
             ],
             "checkType": "response_url",
             "alexaRank": 3845,
@@ -7245,8 +7210,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "gb",
-                "us"
+                "gb"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.digitalspy.com/",
@@ -7293,8 +7257,8 @@
         },
         "Gab": {
             "tags": [
-                "in",
-                "us"
+                "us",
+                "social"
             ],
             "urlProbe": "https://gab.com/api/v1/account_by_username/{username}",
             "checkType": "status_code",
@@ -7312,7 +7276,7 @@
         },
         "MyFitnessPal": {
             "tags": [
-                "us"
+                "sport"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7328,9 +7292,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "BodyBuilding": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "response_url",
             "urlMain": "https://bodyspace.bodybuilding.com/",
             "url": "https://bodyspace.bodybuilding.com/{username}",
@@ -7340,8 +7302,7 @@
         },
         "Contently": {
             "tags": [
-                "freelance",
-                "in"
+                "freelance"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7358,8 +7319,8 @@
         },
         "MyMiniFactory": {
             "tags": [
-                "gb",
-                "us"
+                "3d",
+                "shopping"
             ],
             "checkType": "status_code",
             "alexaRank": 4013,
@@ -7374,15 +7335,13 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "Folkd": {
             "disabled": true,
             "tags": [
-                "eu",
-                "in"
+                "bookmarks"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7397,7 +7356,8 @@
         },
         "9GAG": {
             "tags": [
-                "sharing"
+                "sharing",
+                "social"
             ],
             "checkType": "status_code",
             "alexaRank": 4141,
@@ -7408,8 +7368,7 @@
         },
         "Cbr": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "vBulletin",
             "urlMain": "https://community.cbr.com",
@@ -7427,7 +7386,7 @@
             "usernameClaimed": "red",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "imgflip.com": {
+        "Imgflip": {
             "checkType": "message",
             "absenceStrs": [
                 "\t\t<h1>404 Page Not Found</h1>\r",
@@ -7447,7 +7406,11 @@
             "urlMain": "https://imgflip.com",
             "usernameClaimed": "sparkles99",
             "usernameUnclaimed": "hrypxleske",
-            "alexaRank": 4268
+            "alexaRank": 4268,
+            "tags": [
+                "photo",
+                "sharing"
+            ]
         },
         "azovmore.dn.ua": {
             "engine": "uCoz",
@@ -7467,7 +7430,7 @@
             "checkType": "message",
             "absenceStrs": [
                 "Whoomp, there it isn't...",
-                "It looks like the page you\u2019re looking for is no longer available. "
+                "It looks like the page you’re looking for is no longer available. "
             ],
             "presenseStrs": [
                 "Likes"
@@ -7478,9 +7441,9 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "couchsurfing": {
+        "Couchsurfing": {
             "tags": [
-                "in"
+                "travel"
             ],
             "checkType": "status_code",
             "alexaRank": 4340,
@@ -7491,8 +7454,8 @@
         },
         "Hackaday": {
             "tags": [
-                "de",
-                "us"
+                "tech",
+                "hobby"
             ],
             "checkType": "status_code",
             "alexaRank": 4348,
@@ -7503,10 +7466,7 @@
         },
         "Metal-archives": {
             "tags": [
-                "de",
-                "music",
-                "pl",
-                "us"
+                "music"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -7521,10 +7481,9 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "opensource": {
+        "OpenSource": {
             "tags": [
-                "in",
-                "us"
+                "coding"
             ],
             "checkType": "status_code",
             "alexaRank": 4379,
@@ -7535,7 +7494,7 @@
         },
         "Fodors": {
             "tags": [
-                "us"
+                "travel"
             ],
             "checkType": "response_url",
             "alexaRank": 4384,
@@ -7547,8 +7506,8 @@
         "AnimeNewsNetwork": {
             "urlSubpath": "/bbs",
             "tags": [
-                "gb",
-                "us"
+                "anime",
+                "news"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7560,7 +7519,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.itemfix.com": {
+        "ItemFix": {
             "absenceStrs": [
                 "<title>ItemFix - Channel: </title>"
             ],
@@ -7573,11 +7532,11 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "checkType": "message",
             "tags": [
-                "us"
+                "video"
             ],
             "alexaRank": 4413
         },
-        "99designs.com": {
+        "Designs99": {
             "absenceStrs": [
                 "mobile-only"
             ],
@@ -7618,7 +7577,7 @@
         },
         "LibraryThing": {
             "tags": [
-                "us"
+                "books"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7638,7 +7597,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u0440\u043e\u0441\u0442\u0438\u0442\u0435, \u043d\u043e \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a"
+                "Простите, но участник"
             ],
             "urlMain": "https://forum.ixbt.com",
             "url": "https://forum.ixbt.com/users.cgi?id=info:{username}",
@@ -7649,7 +7608,6 @@
             "tags": [
                 "coding",
                 "forum",
-                "in",
                 "za"
             ],
             "engine": "Discourse",
@@ -7659,8 +7617,7 @@
         },
         "Kongregate": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
             "checkType": "message",
@@ -7675,8 +7632,7 @@
         },
         "Freesound": {
             "tags": [
-                "music",
-                "us"
+                "music"
             ],
             "checkType": "status_code",
             "alexaRank": 4582,
@@ -7691,14 +7647,12 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "AlternativeTo": {
             "tags": [
-                "in",
-                "us"
+                "tech"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -7728,7 +7682,11 @@
             "urlMain": "https://www.pscp.tv",
             "usernameClaimed": "moonlitraven",
             "usernameUnclaimed": "higfjqmiez",
-            "alexaRank": 4652
+            "alexaRank": 4652,
+            "tags": [
+                "streaming",
+                "video"
+            ]
         },
         "discourse.jupyter.org": {
             "urlMain": "https://discourse.jupyter.org",
@@ -7743,7 +7701,8 @@
         "Pikabu": {
             "tags": [
                 "ru",
-                "sharing"
+                "sharing",
+                "social"
             ],
             "checkType": "status_code",
             "alexaRank": 4727,
@@ -7756,8 +7715,7 @@
             "urlSubpath": "/v3",
             "disabled": true,
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "presenseStrs": [
                 "reputation_alexaRank"
@@ -7795,7 +7753,7 @@
         },
         "Speedrun.com": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -7812,7 +7770,7 @@
         },
         "F6S": {
             "tags": [
-                "in"
+                "business"
             ],
             "errors": {
                 "custom-page-main-frontpage-captcha": "Captcha detected"
@@ -7842,8 +7800,8 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430"
+                "Пользователь не найден",
+                "Страница не найдена"
             ],
             "alexaRank": 19671,
             "urlMain": "https://club.cnews.ru/",
@@ -7853,7 +7811,6 @@
         },
         "Boosty": {
             "tags": [
-                "eu",
                 "ru"
             ],
             "checkType": "message",
@@ -7871,7 +7828,7 @@
         },
         "Soup": {
             "tags": [
-                "in"
+                "blog"
             ],
             "checkType": "response_url",
             "alexaRank": 5179,
@@ -7882,7 +7839,7 @@
         },
         "adblockplus.org": {
             "tags": [
-                "us"
+                "tech"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -7901,7 +7858,6 @@
         "LiverpoolFC": {
             "tags": [
                 "forum",
-                "us",
                 "za"
             ],
             "checkType": "message",
@@ -7925,7 +7881,6 @@
         },
         "Hackster": {
             "tags": [
-                "in",
                 "tech"
             ],
             "checkType": "status_code",
@@ -7938,8 +7893,7 @@
         "Dreamwidth": {
             "disabled": true,
             "tags": [
-                "in",
-                "us"
+                "blog"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -7954,8 +7908,7 @@
         },
         "Xvideos": {
             "tags": [
-                "porn",
-                "us"
+                "porn"
             ],
             "checkType": "status_code",
             "alexaRank": 5295,
@@ -7975,7 +7928,7 @@
             ],
             "alexaRank": 5338
         },
-        "www.furaffinity.net": {
+        "Fur Affinity": {
             "checkType": "message",
             "absenceStrs": [
                 ">The username ",
@@ -7995,14 +7948,14 @@
             "urlMain": "https://www.furaffinity.net",
             "usernameClaimed": "astrid7",
             "usernameUnclaimed": "djmgizlhqb",
-            "alexaRank": 5404
+            "alexaRank": 5404,
+            "tags": [
+                "art"
+            ]
         },
         "ModDB": {
             "tags": [
-                "au",
-                "cn",
-                "gb",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 5439,
@@ -8011,9 +7964,10 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "hashnode": {
+        "Hashnode": {
             "tags": [
-                "in"
+                "blog",
+                "coding"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -8029,7 +7983,7 @@
             "alexaRank": 5495,
             "urlProbe": "https://gql.hashnode.com?query=%7Buser(username%3A%20%22{username}%22)%20%7B%20name%20username%20%7D%7D"
         },
-        "allmylinks": {
+        "AllMyLinks": {
             "tags": [
                 "links"
             ],
@@ -8046,8 +8000,7 @@
         "Funnyordie": {
             "disabled": true,
             "tags": [
-                "in",
-                "us"
+                "video"
             ],
             "checkType": "status_code",
             "alexaRank": 5543,
@@ -8058,8 +8011,7 @@
         },
         "Carbonmade": {
             "tags": [
-                "in",
-                "us"
+                "design"
             ],
             "checkType": "response_url",
             "alexaRank": 5658,
@@ -8071,8 +8023,8 @@
         },
         "Audiojungle": {
             "tags": [
-                "in",
-                "us"
+                "music",
+                "shopping"
             ],
             "regexCheck": "^[a-zA-Z0-9_]+$",
             "checkType": "status_code",
@@ -8082,7 +8034,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "segmentfault": {
+        "SegmentFault": {
             "disabled": true,
             "tags": [
                 "cn"
@@ -8092,7 +8044,7 @@
                 "message\":\"Not Found\""
             ],
             "presenseStrs": [
-                "- SegmentFault \u601d\u5426</title>"
+                "- SegmentFault 思否</title>"
             ],
             "alexaRank": 5833,
             "urlMain": "https://segmentfault.com/",
@@ -8103,8 +8055,7 @@
         "Untappd": {
             "tags": [
                 "geosocial",
-                "networking",
-                "us"
+                "networking"
             ],
             "checkType": "status_code",
             "alexaRank": 5848,
@@ -8124,17 +8075,6 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "designspiration.com": {
-            "tags": [
-                "art"
-            ],
-            "engine": "engine404",
-            "urlMain": "https://designspiration.com",
-            "url": "https://designspiration.com/{username}/",
-            "usernameUnclaimed": "noonewouldeverusethis7",
-            "usernameClaimed": "alex",
-            "alexaRank": 5889
-        },
         "Alabay": {
             "tags": [
                 "forum",
@@ -8142,7 +8082,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://alabay.forum24.ru",
             "url": "https://alabay.forum24.ru/?32-{username}",
@@ -8156,7 +8096,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "http://jer.forum24.ru",
             "url": "http://jer.forum24.ru/?32-{username}",
@@ -8170,7 +8110,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://kuban.forum24.ru/",
             "url": "https://kuban.forum24.ru/?32-{username}",
@@ -8185,7 +8125,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d"
+                "Профиль забанен"
             ],
             "urlMain": "https://uaksu.forum24.ru/",
             "url": "https://uaksu.forum24.ru/?32-{username}",
@@ -8201,7 +8141,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://volkodavcaoko.forum24.ru",
             "url": "https://volkodavcaoko.forum24.ru/?32-{username}",
@@ -8215,7 +8155,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://microcap.forum24.ru",
             "url": "https://microcap.forum24.ru/?32-{username}",
@@ -8228,7 +8168,12 @@
             "checkType": "status_code",
             "usernameClaimed": "qlgks1",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 5921
+            "alexaRank": 5921,
+            "tags": [
+                "kr",
+                "blog",
+                "coding"
+            ]
         },
         "Tinkoff Invest": {
             "tags": [
@@ -8274,10 +8219,10 @@
                 "forum"
             ]
         },
-        "rapidapi.com": {
+        "RapidAPI": {
             "urlSubpath": "/blog",
             "tags": [
-                "in"
+                "coding"
             ],
             "engine": "Wordpress/Author",
             "urlMain": "https://rapidapi.com",
@@ -8287,8 +8232,7 @@
         },
         "Fanpop": {
             "tags": [
-                "in",
-                "us"
+                "discussion"
             ],
             "checkType": "response_url",
             "alexaRank": 6149,
@@ -8315,9 +8259,9 @@
             "usernameClaimed": "red",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.minds.com": {
+        "Minds": {
             "tags": [
-                "in"
+                "social"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -8333,18 +8277,18 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 6243
         },
-        "mercadolivre": {
+        "MercadoLivre": {
             "tags": [
                 "br"
             ],
             "checkType": "message",
             "presenseStrs": [
-                "An\u00fancios do vendedor",
+                "Anúncios do vendedor",
                 "Publicaciones del Vendedor"
             ],
             "absenceStrs": [
-                "Parece que esta p\u00e1gina n\u00e3o existe",
-                "Este usu\u00e1rio foi temporariamente desativado ou exclu\u00eddo"
+                "Parece que esta página não existe",
+                "Este usuário foi temporariamente desativado ou excluído"
             ],
             "alexaRank": 6294,
             "urlMain": "https://www.mercadolivre.com.br",
@@ -8352,7 +8296,7 @@
             "usernameClaimed": "MLB",
             "usernameUnclaimed": "noonewouldeverusethis77777"
         },
-        "morguefile.com": {
+        "Morguefile": {
             "absenceStrs": [
                 "free photographs for commercial use"
             ],
@@ -8372,8 +8316,7 @@
         },
         "Tinder": {
             "tags": [
-                "dating",
-                "us"
+                "dating"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -8390,8 +8333,7 @@
         "Kali community": {
             "disabled": true,
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "errors": {
                 "You are not logged in or you do not have permission to access this page.": "Auth required"
@@ -8408,7 +8350,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430  "
+                "Страница не найдена  "
             ],
             "alexaRank": 6397,
             "urlMain": "https://dtf.ru",
@@ -8474,7 +8416,7 @@
         },
         "Setlist": {
             "tags": [
-                "us"
+                "music"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -8495,8 +8437,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Tweakers": {
@@ -8505,12 +8446,17 @@
             "checkType": "status_code",
             "usernameClaimed": "femme",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 6611
+            "alexaRank": 6611,
+            "tags": [
+                "tech",
+                "nl"
+            ]
         },
         "Destructoid": {
             "disabled": true,
             "tags": [
-                "us"
+                "gaming",
+                "news"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -8528,15 +8474,13 @@
             "usernameClaimed": "olibriss",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Star Citizen": {
             "disabled": true,
             "tags": [
-                "de",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 6635,
@@ -8547,8 +8491,7 @@
         },
         "Star Citizens Community": {
             "tags": [
-                "de",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "urlMain": "https://robertsspaceindustries.com/",
@@ -8564,7 +8507,10 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 6653
+            "alexaRank": 6653,
+            "tags": [
+                "streaming"
+            ]
         },
         "antihack.ucoz.net": {
             "engine": "uCoz",
@@ -8731,12 +8677,14 @@
             "checkType": "status_code",
             "usernameClaimed": "namu",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 6693
+            "alexaRank": 6693,
+            "tags": [
+                "wiki",
+                "kr"
+            ]
         },
         "Cheezburger": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "response_url",
             "urlMain": "https://profile.cheezburger.com",
             "url": "https://profile.cheezburger.com/{username}",
@@ -8749,14 +8697,13 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "GaiaOnline": {
             "tags": [
-                "ro",
-                "us"
+                "gaming",
+                "social"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -8948,8 +8895,7 @@
         },
         "Jigsawplanet": {
             "tags": [
-                "fr",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 6935,
@@ -8965,12 +8911,14 @@
             "usernameClaimed": "arrangeme",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 6988,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "music"
+            ]
         },
         "community.getpostman.com": {
             "tags": [
                 "forum",
-                "in",
                 "tech"
             ],
             "engine": "Discourse",
@@ -8981,9 +8929,7 @@
         "AskFM": {
             "disabled": true,
             "tags": [
-                "eg",
-                "in",
-                "ru"
+                "social"
             ],
             "regexCheck": "^[a-zA-Z0-9_]{3,40}$",
             "checkType": "message",
@@ -8998,7 +8944,7 @@
         },
         "PlanetMinecraft": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -9039,10 +8985,10 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Пользователь не найден"
             ],
             "presenseStrs": [
-                "\u041f\u0440\u043e\u0444\u0438\u043b\u044c \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Профиль пользователя"
             ],
             "alexaRank": 7251,
             "urlMain": "https://rutracker.org/",
@@ -9085,7 +9031,7 @@
             "usernameClaimed": "siamparagon",
             "usernameUnclaimed": "asadasdsd"
         },
-        "kwork": {
+        "Kwork": {
             "tags": [
                 "ru"
             ],
@@ -9115,8 +9061,7 @@
         },
         "Memrise": {
             "tags": [
-                "jp",
-                "us"
+                "education"
             ],
             "checkType": "response_url",
             "alexaRank": 7364,
@@ -9130,7 +9075,6 @@
             "disabled": true,
             "tags": [
                 "blog",
-                "in",
                 "photo"
             ],
             "checkType": "message",
@@ -9155,7 +9099,11 @@
             "url": "https://www.americanthinker.com/author/{username}/",
             "usernameClaimed": "monicashowalter",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 7389
+            "alexaRank": 7389,
+            "tags": [
+                "news",
+                "us"
+            ]
         },
         "Yummly": {
             "tags": [
@@ -9185,7 +9133,7 @@
         },
         "ArchiveOfOurOwn": {
             "tags": [
-                "us"
+                "writing"
             ],
             "regexCheck": "^[a-zA-Z0-9_]{3,40}$",
             "checkType": "response_url",
@@ -9197,7 +9145,7 @@
         },
         "Ello": {
             "tags": [
-                "in"
+                "social"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -9216,8 +9164,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "RubyGems": {
@@ -9563,8 +9510,7 @@
         },
         "WebNode": {
             "tags": [
-                "cz",
-                "us"
+                "cz"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -9574,9 +9520,9 @@
             "usernameClaimed": "radkabalcarova",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "colourlovers.com": {
+        "ColourLovers": {
             "tags": [
-                "in"
+                "design"
             ],
             "engine": "engine404",
             "urlMain": "http://colourlovers.com",
@@ -9587,8 +9533,7 @@
         },
         "Wowhead": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "urlMain": "https://www.wowhead.com",
@@ -9599,8 +9544,7 @@
         },
         "Aptoide": {
             "tags": [
-                "apps",
-                "in"
+                "apps"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -9616,7 +9560,6 @@
             "disabled": true,
             "tags": [
                 "streaming",
-                "us",
                 "video"
             ],
             "checkType": "status_code",
@@ -9645,7 +9588,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://rodgersforum.borda.ru",
             "url": "https://rodgersforum.borda.ru/?32-{username}",
@@ -9658,7 +9601,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://starsonice.borda.ru",
             "url": "https://starsonice.borda.ru/?32-{username}",
@@ -9671,7 +9614,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://terminatorium.borda.ru/",
             "url": "https://terminatorium.borda.ru/?32-{username}",
@@ -9692,10 +9635,7 @@
         },
         "SkyscraperCity": {
             "tags": [
-                "de",
-                "forum",
-                "pl",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 7917,
@@ -9703,7 +9643,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "drive2": {
+        "Drive2": {
             "tags": [
                 "ru"
             ],
@@ -9716,8 +9656,7 @@
         },
         "Empowher": {
             "tags": [
-                "in",
-                "us"
+                "medicine"
             ],
             "checkType": "status_code",
             "alexaRank": 7948,
@@ -9885,8 +9824,7 @@
         },
         "Armorgames": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "response_url",
             "alexaRank": 8017,
@@ -9913,8 +9851,7 @@
         },
         "Kinja": {
             "tags": [
-                "in",
-                "us"
+                "blog"
             ],
             "checkType": "status_code",
             "alexaRank": 8140,
@@ -9960,8 +9897,7 @@
         },
         "Paltalk": {
             "tags": [
-                "sa",
-                "us"
+                "messaging"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -9978,9 +9914,7 @@
         },
         "Ccm": {
             "tags": [
-                "ao",
-                "in",
-                "ve"
+                "fr"
             ],
             "checkType": "status_code",
             "alexaRank": 8363,
@@ -10001,8 +9935,7 @@
         },
         "Rate Your Music": {
             "tags": [
-                "gb",
-                "us"
+                "music"
             ],
             "checkType": "status_code",
             "alexaRank": 8392,
@@ -10027,7 +9960,8 @@
         },
         "Airliners": {
             "tags": [
-                "us"
+                "photo",
+                "hobby"
             ],
             "checkType": "status_code",
             "alexaRank": 8484,
@@ -10036,7 +9970,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "videohive.net": {
+        "VideoHive": {
             "absenceStrs": [
                 "Page Not Found | VideoHive"
             ],
@@ -10056,8 +9990,7 @@
         },
         "forum.snapcraft.io": {
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.snapcraft.io",
@@ -10066,8 +9999,7 @@
         },
         "xHamster": {
             "tags": [
-                "porn",
-                "us"
+                "porn"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10084,11 +10016,7 @@
         },
         "xenforo.com": {
             "tags": [
-                "forum",
-                "in",
-                "jp",
-                "tr",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://xenforo.com/community/",
@@ -10186,7 +10114,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0410\u0432\u0442\u043e\u0440 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Автор не найден"
             ],
             "alexaRank": 8932,
             "urlMain": "https://www.proza.ru/",
@@ -10200,7 +10128,10 @@
             "checkType": "status_code",
             "usernameClaimed": "waniathar",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 8998
+            "alexaRank": 8998,
+            "tags": [
+                "social"
+            ]
         },
         "blogs.klerk.ru": {
             "presenseStrs": [
@@ -10212,10 +10143,9 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "checkType": "message"
         },
-        "aminoapp": {
+        "AminoApp": {
             "tags": [
-                "br",
-                "us"
+                "social"
             ],
             "checkType": "status_code",
             "alexaRank": 9040,
@@ -10354,9 +10284,7 @@
         },
         "Namepros": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 9310,
@@ -10380,9 +10308,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Niftygateway": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "urlProbe": "https://api.niftygateway.com/user/profile-and-offchain-nifties-by-url/?profile_url={username}",
             "checkType": "message",
             "presenseStrs": [
@@ -10403,8 +10329,7 @@
         },
         "Globalvoices": {
             "tags": [
-                "sv",
-                "us"
+                "news"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -10430,8 +10355,7 @@
         "forums.bulbagarden.net": {
             "disabled": true,
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "http://forums.bulbagarden.net",
@@ -10440,12 +10364,13 @@
         },
         "Wykop": {
             "tags": [
-                "pl"
+                "pl",
+                "social"
             ],
             "checkType": "message",
             "alexaRank": 9438,
             "presenseStrs": [
-                "Aktywno\u015b\u0107 u\u017cytkownika"
+                "Aktywność użytkownika"
             ],
             "urlMain": "https://www.wykop.pl",
             "url": "https://www.wykop.pl/ludzie/{username}/",
@@ -10454,8 +10379,7 @@
         },
         "Warrior Forum": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "alexaRank": 9467,
@@ -10468,8 +10392,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "gb",
-                "us"
+                "gb"
             ],
             "checkType": "status_code",
             "urlMain": "https://fifaforums.easports.com/",
@@ -10479,7 +10402,8 @@
         },
         "write.as": {
             "tags": [
-                "writefreely"
+                "blog",
+                "writing"
             ],
             "checkType": "status_code",
             "url": "https://write.as/{username}",
@@ -10494,12 +10418,16 @@
             "checkType": "status_code",
             "usernameClaimed": "MagicLike",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 9644
+            "alexaRank": 9644,
+            "tags": [
+                "social"
+            ]
         },
         "Taringa": {
             "disabled": true,
             "tags": [
-                "ar"
+                "ar",
+                "social"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10518,7 +10446,7 @@
         },
         "ResidentAdvisor": {
             "tags": [
-                "us"
+                "music"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10536,8 +10464,7 @@
         "Waveapps": {
             "disabled": true,
             "tags": [
-                "ca",
-                "us"
+                "ca"
             ],
             "checkType": "status_code",
             "urlMain": "https://community.waveapps.com",
@@ -10545,7 +10472,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "jeuxvideo": {
+        "JeuxVideo": {
             "tags": [
                 "fr",
                 "gaming"
@@ -10555,7 +10482,7 @@
                 "Messages Forums"
             ],
             "absenceStrs": [
-                "Vous \u00eates"
+                "Vous êtes"
             ],
             "alexaRank": 9808,
             "urlMain": "http://www.jeuxvideo.com",
@@ -10565,8 +10492,7 @@
         },
         "Sporcle": {
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 9827,
@@ -10577,7 +10503,7 @@
         },
         "Coroflot": {
             "tags": [
-                "us"
+                "design"
             ],
             "checkType": "status_code",
             "alexaRank": 9837,
@@ -10586,7 +10512,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "BOOTH": {
+        "Booth": {
             "tags": [
                 "jp",
                 "shopping"
@@ -10599,9 +10525,10 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "teamtreehouse.com": {
+        "Treehouse": {
             "tags": [
-                "us"
+                "coding",
+                "education"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10618,7 +10545,8 @@
         },
         "are.na": {
             "tags": [
-                "us"
+                "art",
+                "sharing"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10635,7 +10563,7 @@
         },
         "Anime-planet": {
             "tags": [
-                "us"
+                "anime"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -10647,9 +10575,10 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "depop.com": {
+        "Depop": {
             "tags": [
-                "us"
+                "shopping",
+                "fashion"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10671,12 +10600,14 @@
             "regexCheck": "^[a-zA-Z0-9-]{1,63}$",
             "usernameClaimed": "jonasjacobsson",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 10207
+            "alexaRank": 10207,
+            "tags": [
+                "photo"
+            ]
         },
         "Blu-ray": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "vBulletin",
             "urlMain": "https://forum.blu-ray.com/",
@@ -10684,7 +10615,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "disabled": true
         },
-        "lyricstranslate.com": {
+        "LyricsTranslate": {
             "absenceStrs": [
                 "Page not found | Lyrics Translate"
             ],
@@ -10703,7 +10634,7 @@
         },
         "VSCO": {
             "tags": [
-                "us"
+                "photo"
             ],
             "checkType": "status_code",
             "alexaRank": 10377,
@@ -10719,7 +10650,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0410\u0432\u0442\u043e\u0440 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Автор не найден"
             ],
             "alexaRank": 10403,
             "urlMain": "https://www.stihi.ru/",
@@ -10750,7 +10681,11 @@
             "absenceStrs": [
                 "Page Not Found"
             ],
-            "urlProbe": "https://rarible.com/marketplace/api/v4/urls/{username}"
+            "urlProbe": "https://rarible.com/marketplace/api/v4/urls/{username}",
+            "tags": [
+                "nft",
+                "crypto"
+            ]
         },
         "Computerbase": {
             "disabled": true,
@@ -10759,7 +10694,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "Das gew\u00fcnschte Mitglied kann nicht gefunden werden"
+                "Das gewünschte Mitglied kann nicht gefunden werden"
             ],
             "alexaRank": 10518,
             "urlMain": "https://www.computerbase.de",
@@ -10769,8 +10704,7 @@
         },
         "DiscoursePi-hole": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://discourse.pi-hole.net",
@@ -10784,11 +10718,15 @@
             "regexCheck": "^[^.]*?$",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 10808
+            "alexaRank": 10808,
+            "tags": [
+                "3d",
+                "shopping"
+            ]
         },
         "Guru": {
             "tags": [
-                "in"
+                "freelance"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10806,8 +10744,7 @@
         },
         "YouPorn": {
             "tags": [
-                "porn",
-                "us"
+                "porn"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -10824,7 +10761,7 @@
         },
         "Bookcrossing": {
             "tags": [
-                "in"
+                "books"
             ],
             "checkType": "status_code",
             "alexaRank": 10927,
@@ -10914,15 +10851,16 @@
             "checkType": "status_code",
             "usernameClaimed": "gutefrage",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 10985
+            "alexaRank": 10985,
+            "tags": [
+                "forum",
+                "de"
+            ]
         },
         "Badoo": {
             "disabled": true,
             "tags": [
-                "dating",
-                "de",
-                "pl",
-                "ve"
+                "dating"
             ],
             "checkType": "status_code",
             "alexaRank": 11043,
@@ -10937,7 +10875,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "По вашему запросу ничего не найдено."
             ],
             "urlMain": "http://gribnikikybani.mybb.ru",
             "url": "http://gribnikikybani.mybb.ru/search.php?action=search&keywords=&author={username}",
@@ -10951,7 +10889,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "По вашему запросу ничего не найдено."
             ],
             "urlMain": "https://waytothelight.mybb.ru/",
             "url": "https://waytothelight.mybb.ru/search.php?action=search&keywords=&author={username}",
@@ -10960,9 +10898,7 @@
         },
         "AllKPop": {
             "tags": [
-                "de",
-                "kr",
-                "us"
+                "kr"
             ],
             "checkType": "response_url",
             "alexaRank": 11166,
@@ -10973,13 +10909,12 @@
         },
         "Diary.ru": {
             "tags": [
-                "blog",
-                "nl",
-                "ru"
+                "ru",
+                "blog"
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title> &mdash; @\u0434\u043d\u0435\u0432\u043d\u0438\u043a\u0438: \u0430\u0441\u043e\u0446\u0438\u0430\u043b\u044c\u043d\u0430\u044f \u0441\u0435\u0442\u044c</title>"
+                "<title> &mdash; @дневники: асоциальная сеть</title>"
             ],
             "alexaRank": 11260,
             "urlMain": "https://diary.ru",
@@ -11005,15 +10940,14 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "checkType": "message",
             "tags": [
-                "networking"
+                "social"
             ],
             "alexaRank": 11308
         },
         "Scala-lang": {
             "tags": [
                 "coding",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://users.scala-lang.org",
@@ -11026,15 +10960,12 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "AdvancedCustomFields": {
             "tags": [
-                "au",
-                "in",
-                "us"
+                "au"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -11048,10 +10979,8 @@
         "community.asterisk.org": {
             "tags": [
                 "forum",
-                "in",
                 "ir",
-                "jp",
-                "us"
+                "jp"
             ],
             "engine": "Discourse",
             "urlMain": "https://community.asterisk.org",
@@ -11060,9 +10989,7 @@
         },
         "Aufeminin": {
             "tags": [
-                "fr",
-                "ma",
-                "mg"
+                "fr"
             ],
             "checkType": "response_url",
             "alexaRank": 11409,
@@ -11097,7 +11024,8 @@
         "PCPartPicker": {
             "disabled": true,
             "tags": [
-                "us"
+                "tech",
+                "shopping"
             ],
             "checkType": "status_code",
             "alexaRank": 11598,
@@ -11106,9 +11034,9 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "fotolog.com": {
+        "Fotolog": {
             "tags": [
-                "in"
+                "photo"
             ],
             "engine": "engine404get",
             "urlMain": "http://fotolog.com",
@@ -11152,10 +11080,10 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0412\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e"
+                "По Вашему запросу ничего не найдено"
             ],
             "presenseStrs": [
-                "<span>\u041b\u044e\u0434\u0438</span>"
+                "<span>Люди</span>"
             ],
             "alexaRank": 6409,
             "urlMain": "https://mirtesen.ru",
@@ -11166,8 +11094,7 @@
         "BikeRadar": {
             "tags": [
                 "forum",
-                "gb",
-                "us"
+                "gb"
             ],
             "checkType": "status_code",
             "urlMain": "https://forum.bikeradar.com",
@@ -11190,8 +11117,7 @@
         "catholic": {
             "disabled": true,
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forums.catholic.com",
@@ -11200,8 +11126,7 @@
         },
         "Coderwall": {
             "tags": [
-                "coding",
-                "in"
+                "coding"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -11239,18 +11164,16 @@
         },
         "InfosecInstitute": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://community.infosecinstitute.com",
             "url": "https://community.infosecinstitute.com/profile/{username}",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "lomography": {
+        "Lomography": {
             "absenceStrs": [
-                "<title>404 \u00b7 Lomography</title>"
+                "<title>404 · Lomography</title>"
             ],
             "presenseStrs": [
                 "Lomography",
@@ -11285,8 +11208,7 @@
         },
         "Codementor": {
             "tags": [
-                "coding",
-                "in"
+                "coding"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -11320,7 +11242,8 @@
         },
         "Neoseeker": {
             "tags": [
-                "us"
+                "gaming",
+                "forum"
             ],
             "checkType": "status_code",
             "alexaRank": 13021,
@@ -11336,10 +11259,10 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u0418\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u044f \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430"
+                "Информация участника"
             ],
             "absenceStrs": [
-                "\u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "не существует"
             ],
             "urlMain": "https://forum.guns.ru/",
             "url": "https://forum.guns.ru/forummisc/show_profile/00098415?username={username}",
@@ -11379,7 +11302,7 @@
         },
         "Lookbook": {
             "tags": [
-                "in"
+                "fashion"
             ],
             "regexCheck": "^[^.]{1,}$",
             "checkType": "message",
@@ -11395,8 +11318,7 @@
         },
         "Redtube": {
             "tags": [
-                "porn",
-                "us"
+                "porn"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -11413,7 +11335,7 @@
         },
         "Edocr": {
             "tags": [
-                "in"
+                "documents"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -11428,8 +11350,7 @@
         "N4g": {
             "tags": [
                 "gaming",
-                "news",
-                "us"
+                "news"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -11446,9 +11367,8 @@
         },
         "Listal": {
             "tags": [
-                "gb",
-                "in",
-                "us"
+                "movies",
+                "music"
             ],
             "checkType": "response_url",
             "urlMain": "https://listal.com/",
@@ -11460,7 +11380,7 @@
         "pixelfed.social": {
             "tags": [
                 "art",
-                "pixelfed"
+                "photo"
             ],
             "checkType": "status_code",
             "usernameClaimed": "pylapp",
@@ -11503,9 +11423,7 @@
         },
         "Bukkit": {
             "tags": [
-                "at",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 13700,
@@ -11515,10 +11433,7 @@
         },
         "notabug.org": {
             "tags": [
-                "in",
-                "ma",
-                "ro",
-                "us"
+                "coding"
             ],
             "urlProbe": "https://notabug.org/{username}/followers",
             "checkType": "status_code",
@@ -11542,12 +11457,7 @@
         },
         "Liberapay": {
             "tags": [
-                "eg",
-                "finance",
-                "in",
-                "pk",
-                "us",
-                "za"
+                "finance"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -11573,7 +11483,6 @@
         },
         "Huntingnet": {
             "tags": [
-                "in",
                 "us"
             ],
             "checkType": "message",
@@ -11614,8 +11523,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "forums.battlefield.com": {
@@ -11623,8 +11531,7 @@
             "tags": [
                 "forum",
                 "gaming",
-                "gb",
-                "us"
+                "gb"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.battlefield.com",
@@ -11632,7 +11539,7 @@
             "usernameClaimed": "NLBartmaN",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "sparkpeople": {
+        "SparkPeople": {
             "tags": [
                 "us"
             ],
@@ -11649,9 +11556,7 @@
         },
         "Sythe": {
             "tags": [
-                "ca",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 14156,
@@ -11680,12 +11585,15 @@
             ],
             "usernameClaimed": "elhadidy12398",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 14425
+            "alexaRank": 14425,
+            "tags": [
+                "movies",
+                "kr"
+            ]
         },
         "MeetMe": {
             "tags": [
-                "in",
-                "us"
+                "social"
             ],
             "errors": {
                 "fa fa-spinner fa-pulse loading-icon-lg": "Registration page"
@@ -11700,7 +11608,7 @@
         },
         "Joomlart": {
             "tags": [
-                "us"
+                "coding"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -11721,7 +11629,7 @@
             "usernameClaimed": "rixx",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "networking"
+                "social"
             ]
         },
         "mastodon.social": {
@@ -11733,7 +11641,7 @@
             "usernameClaimed": "Gargron",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "networking"
+                "social"
             ]
         },
         "iRecommend.RU": {
@@ -11749,8 +11657,7 @@
         },
         "Pinkbike": {
             "tags": [
-                "hobby",
-                "us"
+                "hobby"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -11762,10 +11669,8 @@
         },
         "GBAtemp.net": {
             "tags": [
-                "de",
                 "forum",
-                "gaming",
-                "us"
+                "gaming"
             ],
             "engine": "XenForo",
             "alexaRank": 14832,
@@ -11775,7 +11680,7 @@
         },
         "Thechive": {
             "tags": [
-                "us"
+                "sharing"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -11790,10 +11695,10 @@
             "usernameClaimed": "bhgilliland",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "tripit.com": {
+        "TripIt": {
             "disabled": true,
             "tags": [
-                "us"
+                "travel"
             ],
             "engine": "engineRedirect",
             "urlMain": "https://tripit.com",
@@ -11804,7 +11709,7 @@
         },
         "Vivino": {
             "tags": [
-                "us"
+                "review"
             ],
             "checkType": "status_code",
             "alexaRank": 15130,
@@ -11815,7 +11720,7 @@
         },
         "Flyertalk": {
             "tags": [
-                "us"
+                "travel"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -11829,7 +11734,7 @@
         },
         "Goldderby": {
             "tags": [
-                "us"
+                "movies"
             ],
             "checkType": "status_code",
             "alexaRank": 15258,
@@ -11840,7 +11745,6 @@
         },
         "BLIP.fm": {
             "tags": [
-                "in",
                 "music"
             ],
             "regexCheck": "^[a-zA-Z0-9_]{1,30}$",
@@ -11854,8 +11758,7 @@
         "Librusec": {
             "tags": [
                 "br",
-                "ru",
-                "us"
+                "ru"
             ],
             "disabled": true,
             "checkType": "message",
@@ -11882,8 +11785,7 @@
         },
         "social.tchncs.de": {
             "tags": [
-                "de",
-                "in"
+                "de"
             ],
             "checkType": "status_code",
             "regexCheck": "^[a-zA-Z0-9_]+$",
@@ -11897,10 +11799,8 @@
             "tags": [
                 "forum",
                 "gb",
-                "in",
                 "jp",
                 "tr",
-                "us",
                 "uz"
             ],
             "engine": "vBulletin",
@@ -11914,7 +11814,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041a \u0441\u043e\u0436\u0430\u043b\u0435\u043d\u0438\u044e, \u0412\u0430\u0448 \u043f\u043e\u0438\u0441\u043a \u043d\u0435 \u0434\u0430\u043b \u043d\u0438\u043a\u0430\u043a\u0438\u0445 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432."
+                "К сожалению, Ваш поиск не дал никаких результатов."
             ],
             "alexaRank": 16651,
             "urlMain": "https://4pda.ru/",
@@ -11926,8 +11826,7 @@
         "GameRevolution": {
             "tags": [
                 "forum",
-                "gaming",
-                "us"
+                "gaming"
             ],
             "engine": "XenForo",
             "urlMain": "https://forums.gamerevolution.com",
@@ -11936,8 +11835,7 @@
         },
         "Pathofexile": {
             "tags": [
-                "ru",
-                "us"
+                "ru"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -11953,9 +11851,8 @@
         },
         "Avforums": {
             "tags": [
-                "forum",
                 "gb",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -11992,7 +11889,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "akniga": {
+        "Akniga": {
             "tags": [
                 "ru"
             ],
@@ -12005,7 +11902,7 @@
         },
         "TrueAchievements": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 16959,
@@ -12044,7 +11941,6 @@
         },
         "Cont": {
             "tags": [
-                "be",
                 "ru"
             ],
             "checkType": "status_code",
@@ -12057,8 +11953,7 @@
         },
         "Pinboard": {
             "tags": [
-                "in",
-                "us"
+                "bookmarks"
             ],
             "checkType": "status_code",
             "alexaRank": 17310,
@@ -12076,7 +11971,7 @@
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
-                "The Village: \u043e\u0448\u0438\u0431\u043a\u0430 404, \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430"
+                "The Village: ошибка 404, страница не найдена"
             ],
             "alexaRank": 17452,
             "urlMain": "https://www.the-village.ru/",
@@ -12085,16 +11980,14 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Justlanded": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://community.justlanded.com",
             "url": "https://community.justlanded.com/en/profile/{username}",
             "usernameClaimed": "rahul-vaidya",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "dlive.tv": {
+        "DLive": {
             "absenceStrs": [
                 "Channel not found"
             ],
@@ -12147,9 +12040,9 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "ifunny.co": {
+        "iFunny": {
             "tags": [
-                "us"
+                "sharing"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -12174,8 +12067,7 @@
         },
         "Trakt": {
             "tags": [
-                "de",
-                "fr"
+                "movies"
             ],
             "checkType": "status_code",
             "alexaRank": 18040,
@@ -12186,8 +12078,7 @@
         },
         "Physicsforums": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -12206,7 +12097,11 @@
             "usernameClaimed": "Blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 18203,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "shopping",
+                "gb"
+            ]
         },
         "TJournal": {
             "disabled": true,
@@ -12216,7 +12111,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041c\u044b \u0432\u0441\u0435 \u0432\u043d\u0438\u043c\u0430\u0442\u0435\u043b\u044c\u043d\u043e \u043f\u043e\u0441\u043c\u043e\u0442\u0440\u0435\u043b\u0438, \u043d\u043e \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0448\u043b\u0438 :("
+                "Мы все внимательно посмотрели, но ничего не нашли :("
             ],
             "alexaRank": 18235,
             "urlMain": "https://tjournal.ru",
@@ -12237,8 +12132,7 @@
         },
         "AdultFriendFinder": {
             "tags": [
-                "dating",
-                "us"
+                "dating"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -12288,8 +12182,8 @@
         },
         "codeforces.com": {
             "tags": [
-                "coding",
-                "in"
+                "ru",
+                "coding"
             ],
             "errors": {
                 "The page is temporarily blocked by administrator.": "IP ban"
@@ -12343,7 +12237,7 @@
         },
         "Eksisozluk": {
             "absenceStrs": [
-                "  <h1>b\u00f6yle bir yazar yok</h1>\r"
+                "  <h1>böyle bir yazar yok</h1>\r"
             ],
             "presenseStrs": [
                 "profile-dots",
@@ -12364,8 +12258,7 @@
         },
         "TryHackMe": {
             "tags": [
-                "hacking",
-                "us"
+                "hacking"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -12399,13 +12292,12 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
                 "forum",
-                "tech",
-                "us"
+                "tech"
             ]
         },
         "Voices": {
             "tags": [
-                "us"
+                "freelance"
             ],
             "checkType": "status_code",
             "alexaRank": 19556,
@@ -12417,9 +12309,7 @@
         "SevenForums": {
             "disabled": true,
             "tags": [
-                "forum",
-                "gb",
-                "us"
+                "forum"
             ],
             "engine": "vBulletin",
             "alexaRank": 19566,
@@ -12433,7 +12323,11 @@
             "checkType": "status_code",
             "usernameClaimed": "anrbrb",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 19684
+            "alexaRank": 19684,
+            "tags": [
+                "forum",
+                "kr"
+            ]
         },
         "forum.eksmo.ru": {
             "urlMain": "http://forum.eksmo.ru",
@@ -12447,8 +12341,7 @@
         },
         "Repl.it": {
             "tags": [
-                "coding",
-                "us"
+                "coding"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -12462,9 +12355,7 @@
         },
         "{username}.portfoliobox.net": {
             "tags": [
-                "in",
-                "jp",
-                "us"
+                "design"
             ],
             "engine": "engine404",
             "urlMain": "https://portfoliobox.net",
@@ -12492,8 +12383,7 @@
         },
         "Codewars": {
             "tags": [
-                "coding",
-                "us"
+                "coding"
             ],
             "checkType": "status_code",
             "alexaRank": 20055,
@@ -12536,8 +12426,7 @@
         },
         "forums.digitalpoint.com": {
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://forums.digitalpoint.com/",
@@ -12571,11 +12460,8 @@
         },
         "cfd-online": {
             "tags": [
-                "ca",
-                "de",
-                "fr",
-                "in",
-                "us"
+                "forum",
+                "science"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -12593,14 +12479,11 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Storycorps": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://archive.storycorps.org",
             "url": "https://archive.storycorps.org/user/{username}/",
@@ -12613,11 +12496,15 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 21854
+            "alexaRank": 21854,
+            "tags": [
+                "shopping",
+                "ar"
+            ]
         },
         "fixya": {
             "tags": [
-                "us"
+                "tech"
             ],
             "checkType": "status_code",
             "alexaRank": 22024,
@@ -12629,7 +12516,7 @@
         "Bibsonomy": {
             "disabled": true,
             "tags": [
-                "in"
+                "research"
             ],
             "checkType": "status_code",
             "alexaRank": 22062,
@@ -12640,7 +12527,7 @@
         },
         "Nitter": {
             "tags": [
-                "messaging"
+                "social"
             ],
             "headers": {
                 "Accept-Language": "en-US,en;q=0.5"
@@ -12671,8 +12558,7 @@
         "forums.serebii.net": {
             "disabled": true,
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://forums.serebii.net",
@@ -12681,9 +12567,7 @@
         },
         "Asciinema": {
             "tags": [
-                "in",
-                "tr",
-                "us"
+                "coding"
             ],
             "checkType": "status_code",
             "alexaRank": 22510,
@@ -12694,8 +12578,7 @@
         },
         "Funnyjunk": {
             "tags": [
-                "gb",
-                "us"
+                "sharing"
             ],
             "checkType": "response_url",
             "alexaRank": 22534,
@@ -12728,8 +12611,7 @@
         },
         "Ficwad": {
             "tags": [
-                "gb",
-                "in"
+                "writing"
             ],
             "checkType": "status_code",
             "alexaRank": 22776,
@@ -12765,7 +12647,7 @@
         "Influenster": {
             "disabled": true,
             "tags": [
-                "us"
+                "review"
             ],
             "errors": {
                 "<title>Attention Required! | Cloudflare</title>": "Cloudflare security protection detected",
@@ -12783,11 +12665,7 @@
         },
         "gloria.tv": {
             "tags": [
-                "ar",
-                "mx",
-                "pl",
-                "sk",
-                "us"
+                "video"
             ],
             "checkType": "status_code",
             "alexaRank": 23199,
@@ -12796,16 +12674,15 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "opennet": {
+        "OpenNet": {
             "disabled": true,
             "tags": [
-                "fr",
                 "ru"
             ],
             "regexCheck": "^[^-]+$",
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u043c\u044f \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e"
+                "Имя участника не найдено"
             ],
             "alexaRank": 23221,
             "urlMain": "https://www.opennet.ru/",
@@ -12847,15 +12724,14 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "de"
+                "fr"
             ],
             "alexaRank": 23441
         },
         "Lobsters": {
             "tags": [
-                "in",
-                "us",
-                "vn"
+                "news",
+                "coding"
             ],
             "regexCheck": "[A-Za-z0-9][A-Za-z0-9_-]{0,24}",
             "checkType": "status_code",
@@ -12867,7 +12743,7 @@
         },
         "Tripline": {
             "tags": [
-                "in"
+                "travel"
             ],
             "checkType": "status_code",
             "alexaRank": 23648,
@@ -12882,14 +12758,12 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Wishlistr": {
             "tags": [
-                "in",
-                "se"
+                "shopping"
             ],
             "checkType": "response_url",
             "alexaRank": 23882,
@@ -12900,8 +12774,7 @@
         },
         "forums.golfmonthly.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://forums.golfmonthly.com",
@@ -12914,8 +12787,7 @@
             "usernameClaimed": "admin",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "Lurkmore": {
@@ -12931,9 +12803,7 @@
         },
         "NotebookReview": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "http://forum.notebookreview.com",
@@ -13028,8 +12898,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "xakep.ru": {
@@ -13056,8 +12925,7 @@
         },
         "Hr": {
             "tags": [
-                "in",
-                "us"
+                "career"
             ],
             "checkType": "status_code",
             "urlMain": "https://www.hr.com",
@@ -13071,8 +12939,7 @@
             "tags": [
                 "de",
                 "forum",
-                "gb",
-                "us"
+                "gb"
             ],
             "engine": "vBulletin",
             "alexaRank": 25196,
@@ -13085,7 +12952,7 @@
                 "l-page-404__text-not-found"
             ],
             "presenseStrs": [
-                "\u0412\u0432\u0435\u0434\u0438\u0442\u0435 e-mail"
+                "Введите e-mail"
             ],
             "url": "https://mel.fm/blog/{username}",
             "urlMain": "https://mel.fm",
@@ -13115,8 +12982,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "freelance.ru": {
@@ -13144,12 +13010,14 @@
             "urlMain": "https://deepdreamgenerator.com",
             "usernameClaimed": "sparkles99",
             "usernameUnclaimed": "lyazybfqoh",
-            "alexaRank": 25555
+            "alexaRank": 25555,
+            "tags": [
+                "art"
+            ]
         },
         "Fatsecret": {
             "tags": [
-                "au",
-                "us"
+                "au"
             ],
             "checkType": "response_url",
             "alexaRank": 25593,
@@ -13165,7 +13033,10 @@
             "url": "http://phrack.org/author_{username}.html",
             "usernameClaimed": "Dispater",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "disabled": true
+            "disabled": true,
+            "tags": [
+                "hacking"
+            ]
         },
         "forums.scummvm.org": {
             "urlMain": "https://forums.scummvm.org",
@@ -13180,7 +13051,6 @@
         "mastodon.cloud": {
             "disabled": true,
             "tags": [
-                "in",
                 "pk"
             ],
             "checkType": "status_code",
@@ -13225,7 +13095,7 @@
                 "create_exhibition_name"
             ],
             "absenceStrs": [
-                "1x.com \u2022 In Pursuit of the Sublime",
+                "1x.com • In Pursuit of the Sublime",
                 " >404</div>"
             ],
             "urlMain": "https://1x.com",
@@ -13256,9 +13126,7 @@
         "prosportsdaily": {
             "disabled": true,
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "vBulletin",
             "urlMain": "https://forums.prosportsdaily.com",
@@ -13266,9 +13134,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "osu!": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://osu.ppy.sh/",
             "url": "https://osu.ppy.sh/users/{username}",
@@ -13282,7 +13148,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u0440\u0435\u043a\u0440\u0430\u0441\u043d\u0430\u044f \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430, \u043a\u0430\u043a\u0438\u0445 \u0431\u043e\u043b\u044c\u0448\u0435 \u043d\u0435 \u0434\u0435\u043b\u0430\u044e\u0442"
+                "Прекрасная страница, каких больше не делают"
             ],
             "urlMain": "https://moscow.flamp.ru/",
             "url": "https://moscow.flamp.ru/{username}",
@@ -13322,7 +13188,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 27022,
             "urlMain": "https://www.vxzone.com",
@@ -13410,8 +13276,7 @@
         },
         "forum.nameberry.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.nameberry.com",
@@ -13443,9 +13308,7 @@
         },
         "Androidforums": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 27921,
@@ -13465,7 +13328,7 @@
         },
         "Pling": {
             "tags": [
-                "in"
+                "coding"
             ],
             "checkType": "response_url",
             "alexaRank": 28461,
@@ -13519,10 +13382,8 @@
         "Comedy": {
             "tags": [
                 "gb",
-                "in",
                 "movies",
-                "pk",
-                "us"
+                "pk"
             ],
             "checkType": "status_code",
             "alexaRank": 29265,
@@ -13538,7 +13399,11 @@
             "usernameClaimed": "freddier",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 30029,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "education",
+                "es"
+            ]
         },
         "forum.ykt.ru": {
             "tags": [
@@ -13551,10 +13416,9 @@
             "usernameClaimed": "NINJA",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "eintracht": {
+        "Eintracht": {
             "tags": [
-                "tr",
-                "us"
+                "tr"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -13564,7 +13428,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.tagged.com": {
+        "Tagged": {
             "absenceStrs": [
                 "lastName",
                 "birthDay",
@@ -13589,9 +13453,7 @@
         },
         "Nxp": {
             "tags": [
-                "be",
-                "in",
-                "us"
+                "be"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -13603,10 +13465,9 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "polarsteps": {
+        "Polarsteps": {
             "tags": [
-                "in",
-                "us"
+                "travel"
             ],
             "urlProbe": "https://api.polarsteps.com/users/byusername/{username}",
             "checkType": "status_code",
@@ -13616,7 +13477,7 @@
             "usernameClaimed": "james",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "fl": {
+        "FL.ru": {
             "tags": [
                 "ru"
             ],
@@ -13651,7 +13512,6 @@
         },
         "EyeEm": {
             "tags": [
-                "in",
                 "it",
                 "photo",
                 "sd"
@@ -13674,7 +13534,7 @@
             ],
             "checkType": "status_code",
             "absenceStrs": [
-                "\u06f4\u06f0\u06f4"
+                "۴۰۴"
             ],
             "alexaRank": 31518,
             "urlMain": "https://virgool.io/",
@@ -13685,8 +13545,8 @@
         "Chatujme.cz": {
             "checkType": "message",
             "absenceStrs": [
-                "Neexistujic\u00ed profil",
-                "Str\u00e1nka nebyla nalezena"
+                "Neexistujicí profil",
+                "Stránka nebyla nalezena"
             ],
             "alexaRank": 31541,
             "urlMain": "https://chatujme.cz/",
@@ -13704,8 +13564,7 @@
             "usernameClaimed": "Bnim81",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "dumskaya.net": {
@@ -13751,9 +13610,7 @@
         "Gardenstew": {
             "disabled": true,
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 32707,
@@ -13774,7 +13631,8 @@
         },
         "Mamot": {
             "tags": [
-                "mastodon"
+                "mastodon",
+                "fr"
             ],
             "checkType": "status_code",
             "urlMain": "https://mamot.fr",
@@ -13825,7 +13683,11 @@
             ],
             "usernameClaimed": "mango-juice",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 34002
+            "alexaRank": 34002,
+            "tags": [
+                "blog",
+                "crypto"
+            ]
         },
         "Alexgyver": {
             "tags": [
@@ -13919,7 +13781,10 @@
             "urlMain": "https://manifold.markets/",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 34826
+            "alexaRank": 34826,
+            "tags": [
+                "finance"
+            ]
         },
         "forums.stevehoffman.tv": {
             "urlMain": "https://forums.stevehoffman.tv",
@@ -13934,9 +13799,7 @@
             "alexaRank": 35942
         },
         "TalkDrugabuse": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "The specified member cannot be found"
@@ -13946,7 +13809,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis777"
         },
-        "spletnik": {
+        "Spletnik": {
             "tags": [
                 "ru"
             ],
@@ -13970,8 +13833,7 @@
         },
         "Antiquers": {
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 36676,
@@ -13981,7 +13843,7 @@
         },
         "Smogon": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -14043,14 +13905,13 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "checkType": "message",
             "tags": [
-                "ai"
+                "tech",
+                "llm"
             ],
             "alexaRank": 37110
         },
         "Insanejournal": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "<TITLE>404 Not Found</TITLE>",
@@ -14063,8 +13924,7 @@
         },
         "Fredmiranda": {
             "tags": [
-                "de",
-                "us"
+                "de"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -14083,7 +13943,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "Sorry! We couldn\u2019t find what you were looking for",
+                "Sorry! We couldn’t find what you were looking for",
                 "error-cartoon__image"
             ],
             "urlMain": "https://ru.bookmate.com",
@@ -14107,7 +13967,7 @@
                 "business"
             ]
         },
-        "https:": {
+        "Skyblock": {
             "engine": "XenForo",
             "urlMain": "https://skyblock.net",
             "usernameClaimed": "alex",
@@ -14133,8 +13993,7 @@
         },
         "operationsports": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.operationsports.com",
@@ -14176,7 +14035,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis"
         },
-        "viewbug": {
+        "ViewBug": {
             "absenceStrs": [
                 "missing-photos"
             ],
@@ -14200,7 +14059,10 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 39020
+            "alexaRank": 39020,
+            "tags": [
+                "gaming"
+            ]
         },
         "Mouthshut": {
             "tags": [
@@ -14237,7 +14099,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u0430\u0441\u043f\u043e\u0440\u0442 -  - \u0415\u0432\u0430.\u0420\u0443"
+                "Паспорт -  - Ева.Ру"
             ],
             "alexaRank": 40463,
             "urlMain": "https://eva.ru/",
@@ -14248,8 +14110,7 @@
         "TravellersPoint": {
             "disabled": true,
             "tags": [
-                "in",
-                "us"
+                "travel"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -14263,7 +14124,7 @@
         },
         "Videosift": {
             "tags": [
-                "us"
+                "video"
             ],
             "checkType": "status_code",
             "alexaRank": 40884,
@@ -14273,7 +14134,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "disabled": true
         },
-        "SOOP": {
+        "Soop": {
             "url": "https://www.sooplive.co.kr/station/{username}",
             "urlMain": "https://www.sooplive.co.kr/",
             "urlProbe": "https://api-channel.sooplive.co.kr/v1.1/channel/{username}/station",
@@ -14351,7 +14212,7 @@
                 "<title></title>"
             ],
             "presenseStrs": [
-                "<title>\u041f\u0440\u043e\u0444\u0438\u043b\u044c"
+                "<title>Профиль"
             ],
             "url": "https://partnerkin.com/user/{username}",
             "urlMain": "https://partnerkin.com",
@@ -14381,7 +14242,8 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "in"
+                "coding",
+                "forum"
             ],
             "alexaRank": 44533
         },
@@ -14422,7 +14284,6 @@
         },
         "Publiclab": {
             "tags": [
-                "in",
                 "science"
             ],
             "checkType": "response_url",
@@ -14487,9 +14348,7 @@
         "EasyEDA": {
             "tags": [
                 "de",
-                "in",
-                "mx",
-                "us"
+                "mx"
             ],
             "checkType": "status_code",
             "alexaRank": 46844,
@@ -14498,7 +14357,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "interpals": {
+        "InterPals": {
             "tags": [
                 "dating"
             ],
@@ -14514,9 +14373,7 @@
         },
         "Ecoustics": {
             "tags": [
-                "hk",
-                "in",
-                "us"
+                "hk"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -14568,8 +14425,8 @@
         },
         "Gapyear": {
             "tags": [
-                "gb",
-                "in"
+                "travel",
+                "gb"
             ],
             "checkType": "status_code",
             "alexaRank": 47746,
@@ -14580,8 +14437,7 @@
         },
         "funcom": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forums.funcom.com",
@@ -14600,9 +14456,7 @@
         },
         "PacketStormSecurity": {
             "tags": [
-                "in",
-                "tr",
-                "us"
+                "tr"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -14628,8 +14482,7 @@
         },
         "Mapillary Forum": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.mapillary.com",
@@ -14654,9 +14507,7 @@
         "Mybuilder": {
             "tags": [
                 "gb",
-                "hk",
-                "in",
-                "us"
+                "hk"
             ],
             "checkType": "status_code",
             "alexaRank": 50027,
@@ -14665,7 +14516,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.tnaflix.com": {
+        "TNAFlix": {
             "checkType": "message",
             "absenceStrs": [
                 "Not Found"
@@ -14679,7 +14530,10 @@
             "usernameClaimed": "luna92",
             "usernameUnclaimed": "krjmekrmlp",
             "disabled": true,
-            "alexaRank": 50293
+            "alexaRank": 50293,
+            "tags": [
+                "porn"
+            ]
         },
         "reality-check.ca": {
             "disabled": true,
@@ -14700,7 +14554,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041d\u0435\u0442 \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Нет такого пользователя"
             ],
             "alexaRank": 50460,
             "urlMain": "https://www.oper.ru/",
@@ -14747,12 +14601,11 @@
         },
         "Vero": {
             "tags": [
-                "in",
-                "us"
+                "social"
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title>Error Page - VERO\u2122 \u2013 True Social</title>"
+                "<title>Error Page - VERO™ – True Social</title>"
             ],
             "alexaRank": 50828,
             "urlMain": "https://vero.co",
@@ -14810,7 +14663,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "Tra\u017eeni \u010dlan nije prona\u0111en. Molimo unesite puno ime \u010dlana i poku\u0161ajte ponovo."
+                "Traženi član nije pronađen. Molimo unesite puno ime člana i pokušajte ponovo."
             ],
             "urlMain": "https://forum.krstarica.com",
             "url": "https://forum.krstarica.com/members/?username={username}",
@@ -14860,10 +14713,10 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "presenseStrs": [
-                "\u0420\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432 \u043f\u043e\u0438\u0441\u043a\u0430:"
+                "Результатов поиска:"
             ],
             "urlMain": "https://forum.awd.ru",
             "url": "https://forum.awd.ru/search.php?keywords=&terms=all&author={username}",
@@ -14873,10 +14726,8 @@
         "Whonix Forum": {
             "tags": [
                 "forum",
-                "in",
                 "ir",
-                "tech",
-                "us"
+                "tech"
             ],
             "engine": "Discourse",
             "urlMain": "https://forums.whonix.org/",
@@ -14888,11 +14739,15 @@
             "urlMain": "https://aniworld.to/",
             "checkType": "message",
             "absenceStrs": [
-                "Dieses Profil ist nicht verf\u00fcgbar"
+                "Dieses Profil ist nicht verfügbar"
             ],
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 52153
+            "alexaRank": 52153,
+            "tags": [
+                "anime",
+                "de"
+            ]
         },
         "smokingmeatforums.com": {
             "urlMain": "https://smokingmeatforums.com",
@@ -14911,13 +14766,11 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Icobench": {
             "tags": [
-                "in",
                 "kr",
                 "ru"
             ],
@@ -14933,14 +14786,11 @@
             "engine": "Flarum",
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "tags": [
-                "in"
-            ]
+            "tags": []
         },
         "ProfilesTigweb": {
             "tags": [
                 "ca",
-                "in",
                 "pk"
             ],
             "checkType": "status_code",
@@ -14966,8 +14816,7 @@
         "Infura": {
             "tags": [
                 "forum",
-                "kr",
-                "us"
+                "kr"
             ],
             "engine": "Discourse",
             "urlMain": "https://community.infura.io",
@@ -14993,8 +14842,7 @@
             "usernameClaimed": "red",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "AfreecaTV": {
@@ -15019,7 +14867,7 @@
         },
         "Jetpunk": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -15033,8 +14881,7 @@
         },
         "Blogmarks": {
             "tags": [
-                "fr",
-                "in"
+                "fr"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -15076,8 +14923,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "pk",
-                "us"
+                "pk"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -15104,7 +14950,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://forum.podolsk.ru",
             "url": "https://forum.podolsk.ru/search.php?keywords=&terms=all&author={username}",
@@ -15120,7 +14966,10 @@
             ],
             "usernameClaimed": "hacker",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 56175
+            "alexaRank": 56175,
+            "tags": [
+                "porn"
+            ]
         },
         "Atcoder": {
             "url": "https://atcoder.jp/users/{username}",
@@ -15162,15 +15011,12 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Rasa": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.rasa.com",
@@ -15187,7 +15033,7 @@
                 "channel:{title:\""
             ],
             "absenceStrs": [
-                "\u041d\u0435 \u043d\u0430\u0448\u043b\u0438 \u0447\u0430\u0442 \u043f\u043e \u044d\u0442\u043e\u0439 \u0441\u0441\u044b\u043b\u043a\u0435"
+                "Не нашли чат по этой ссылке"
             ],
             "urlMain": "https://max.ru",
             "url": "https://max.ru/{username}",
@@ -15202,8 +15048,8 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041e\u0428\u0418\u0411\u041a\u0410 50x",
-                "\u041e\u0428\u0418\u0411\u041a\u0410 404"
+                "ОШИБКА 50x",
+                "ОШИБКА 404"
             ],
             "alexaRank": 57906,
             "urlMain": "https://maxpark.com",
@@ -15214,8 +15060,7 @@
         "Wanelo": {
             "disabled": true,
             "tags": [
-                "in",
-                "us"
+                "shopping"
             ],
             "checkType": "status_code",
             "alexaRank": 57955,
@@ -15310,7 +15155,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title> - \u0416\u0435\u043d\u0441\u043a\u0438\u0435 \u0444\u043e\u0440\u0443\u043c\u044b myJane</title>"
+                "<title> - Женские форумы myJane</title>"
             ],
             "urlMain": "http://forum.myjane.ru/",
             "url": "http://forum.myjane.ru/profile.php?mode=viewprofile&u={username}",
@@ -15321,8 +15166,7 @@
             "tags": [
                 "ch",
                 "cr",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "alexaRank": 59783,
@@ -15336,8 +15180,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "in",
-                "us"
+                "finance"
             ],
             "alexaRank": 59798
         },
@@ -15347,14 +15190,21 @@
             "checkType": "status_code",
             "usernameClaimed": "tokitsukaze",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 60366
+            "alexaRank": 60366,
+            "tags": [
+                "coding"
+            ]
         },
         "homebrewtalk.com": {
             "urlMain": "https://www.homebrewtalk.com",
             "engine": "XenForo",
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 60718
+            "alexaRank": 60718,
+            "tags": [
+                "forum",
+                "hobby"
+            ]
         },
         "forum.scssoft.com": {
             "urlMain": "https://forum.scssoft.com",
@@ -15387,12 +15237,15 @@
             ],
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 62165
+            "alexaRank": 62165,
+            "tags": [
+                "discussion",
+                "lemmy"
+            ]
         },
         "Railfan": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -15419,8 +15272,7 @@
             "urlSubpath": "/vbts",
             "disabled": true,
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "vBulletin",
             "alexaRank": 63070,
@@ -15442,7 +15294,6 @@
             "tags": [
                 "ch",
                 "forum",
-                "in",
                 "it"
             ],
             "engine": "phpBB",
@@ -15452,8 +15303,7 @@
         },
         "forum.endeavouros.com": {
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.endeavouros.com",
@@ -15475,8 +15325,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ]
         },
         "Vgtimes/Games": {
@@ -15493,7 +15342,7 @@
         },
         "Vgtimes": {
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Пользователь с таким именем не найден"
             ],
             "presenseStrs": [
                 "user_profile"
@@ -15537,17 +15386,13 @@
             "engine": "Flarum",
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "tags": [
-                "in"
-            ]
+            "tags": []
         },
         "Root-me": {
             "tags": [
                 "hacking",
-                "in",
                 "ir",
-                "pk",
-                "us"
+                "pk"
             ],
             "errors": {
                 "429 Too Many Requests": "Too many requests"
@@ -15634,7 +15479,7 @@
         },
         "Chessclub": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -15665,8 +15510,7 @@
         },
         "Libraries": {
             "tags": [
-                "coding",
-                "in"
+                "coding"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "status_code",
@@ -15689,8 +15533,7 @@
         },
         "devRant": {
             "tags": [
-                "coding",
-                "in"
+                "coding"
             ],
             "checkType": "response_url",
             "alexaRank": 69493,
@@ -15702,8 +15545,7 @@
         },
         "openframeworks": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.openframeworks.cc",
@@ -15716,8 +15558,7 @@
                 "de",
                 "forum",
                 "gaming",
-                "gb",
-                "us"
+                "gb"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.futbin.com",
@@ -15731,7 +15572,10 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 70556
+            "alexaRank": 70556,
+            "tags": [
+                "freelance"
+            ]
         },
         "Image Fap": {
             "url": "https://www.imagefap.com/profile/{username}",
@@ -15742,13 +15586,14 @@
             ],
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 70745
+            "alexaRank": 70745,
+            "tags": [
+                "porn"
+            ]
         },
         "Windowsforum": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -15779,8 +15624,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "lt",
-                "us"
+                "lt"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -15797,8 +15641,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Erome": {
@@ -15807,7 +15650,10 @@
             "checkType": "status_code",
             "usernameClaimed": "bob",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 72328
+            "alexaRank": 72328,
+            "tags": [
+                "porn"
+            ]
         },
         "tks": {
             "tags": [
@@ -15825,12 +15671,14 @@
             "checkType": "status_code",
             "usernameClaimed": "optms",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 72530
+            "alexaRank": 72530,
+            "tags": [
+                "gaming"
+            ]
         },
         "collectors.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.collectors.com",
@@ -15841,7 +15689,6 @@
         "Cent": {
             "tags": [
                 "art",
-                "us",
                 "writing"
             ],
             "urlProbe": "https://beta.cent.co/data/user/profile?userHandles={username}",
@@ -15866,7 +15713,7 @@
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430 \u0441\u0432\u044f\u0436\u0438\u0442\u0435\u0441\u044c \u0441 \u0430\u0434\u043c\u0438\u043d\u0438\u0441\u0442\u0440\u0430\u0442\u043e\u0440\u043e\u043c"
+                "пожалуйста свяжитесь с администратором"
             ],
             "alexaRank": 73195,
             "urlMain": "https://www.politforums.net/",
@@ -15903,7 +15750,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "По вашему запросу ничего не найдено."
             ],
             "urlMain": "http://sexforum.ixbb.ru",
             "url": "http://sexforum.ixbb.ru/search.php?action=search&keywords=&author={username}",
@@ -15922,7 +15769,7 @@
         },
         "Pokemon Showdown": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "status_code",
             "alexaRank": 74994,
@@ -15956,11 +15803,11 @@
                 "ua"
             ],
             "errors": {
-                "\u0412\u044b \u043d\u0435 \u043c\u043e\u0436\u0435\u0442\u0435 \u043f\u0440\u043e\u0438\u0437\u0432\u0435\u0441\u0442\u0438 \u043f\u043e\u0438\u0441\u043a \u0441\u0440\u0430\u0437\u0443 \u043f\u043e\u0441\u043b\u0435 \u043f\u0440\u0435\u0434\u044b\u0434\u0443\u0449\u0435\u0433\u043e": "Rate limit"
+                "Вы не можете произвести поиск сразу после предыдущего": "Rate limit"
             },
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 75697,
             "urlMain": "https://www.medikforum.ru",
@@ -15970,7 +15817,6 @@
         },
         "Partyflock": {
             "tags": [
-                "in",
                 "nl"
             ],
             "checkType": "status_code",
@@ -15986,7 +15832,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "alexaRank": 76500,
             "urlMain": "http://astraclub.ru",
@@ -16006,9 +15852,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "KanoWorld": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://world.kano.me/",
             "url": "https://api.kano.me/progress/user/{username}",
@@ -16018,8 +15862,7 @@
         },
         "MoiKrug": {
             "tags": [
-                "career",
-                "us"
+                "career"
             ],
             "checkType": "status_code",
             "alexaRank": 77538,
@@ -16030,7 +15873,7 @@
         },
         "HackingWithSwift": {
             "tags": [
-                "us"
+                "coding"
             ],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
@@ -16043,7 +15886,7 @@
             "usernameClaimed": "davextreme",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "TRASHBOX.RU": {
+        "Trashbox.ru": {
             "tags": [
                 "az",
                 "ru"
@@ -16051,7 +15894,7 @@
             "regexCheck": "^[A-Za-z0-9_-]{3,16}$",
             "checkType": "message",
             "absenceStrs": [
-                "404 \u2014 Not found"
+                "404 — Not found"
             ],
             "urlMain": "https://trashbox.ru/",
             "url": "https://trashbox.ru/users/{username}",
@@ -16062,8 +15905,7 @@
         "RPGGeek": {
             "ignore403": true,
             "tags": [
-                "gaming",
-                "us"
+                "gaming"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -16080,8 +15922,7 @@
             "urlSubpath": "/forums",
             "disabled": true,
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "vBulletin",
             "alexaRank": 80201,
@@ -16102,8 +15943,7 @@
         },
         "Trisquel": {
             "tags": [
-                "eu",
-                "in"
+                "eu"
             ],
             "checkType": "status_code",
             "alexaRank": 80641,
@@ -16140,11 +15980,11 @@
                 "ru"
             ],
             "errors": {
-                "\u0432\u044b \u043c\u043e\u0436\u0435\u0442\u0435 \u0438\u0441\u043a\u0430\u0442\u044c \u043d\u0435 \u0447\u0430\u0449\u0435, \u0447\u0435\u043c \u0440\u0430\u0437 \u0432 10 \u0441\u0435\u043a\u0443\u043d\u0434": "Too many requests"
+                "вы можете искать не чаще, чем раз в 10 секунд": "Too many requests"
             },
             "checkType": "message",
             "absenceStrs": [
-                "\u041d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e!"
+                "Ничего не найдено!"
             ],
             "alexaRank": 83107,
             "urlMain": "http://www.radioscanner.ru",
@@ -16159,11 +15999,11 @@
                 "ru"
             ],
             "errors": {
-                "\u041a \u0441\u043e\u0436\u0430\u043b\u0435\u043d\u0438\u044e, \u0432\u043e\u0437\u043d\u0438\u043a\u043b\u0430 \u043f\u0440\u043e\u0431\u043b\u0435\u043c\u0430": "Too many reqeusts"
+                "К сожалению, возникла проблема": "Too many reqeusts"
             },
             "checkType": "message",
             "absenceStrs": [
-                "\u041d\u0430\u0439\u0434\u0435\u043d\u043e 0 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432"
+                "Найдено 0 результатов"
             ],
             "urlMain": "https://forum.cxem.net/",
             "url": "https://forum.cxem.net/index.php?/search/&q={username}&quick=1&type=core_members",
@@ -16216,7 +16056,10 @@
             "urlMain": "https://mynickname.com",
             "usernameClaimed": "godbrithil",
             "usernameUnclaimed": "fqiakbtdhu",
-            "alexaRank": 84236
+            "alexaRank": 84236,
+            "tags": [
+                "social"
+            ]
         },
         "forum.rzn.info": {
             "urlMain": "https://forum.rzn.info",
@@ -16259,7 +16102,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "alexaRank": 85461,
             "urlMain": "http://www.cqham.ru",
@@ -16267,7 +16110,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.polywork.com": {
+        "Polywork": {
             "checkType": "message",
             "absenceStrs": [
                 ">404</h3>",
@@ -16287,7 +16130,10 @@
             "urlMain": "https://www.polywork.com",
             "usernameClaimed": "zoey123",
             "usernameUnclaimed": "timhhdgent",
-            "alexaRank": 86045
+            "alexaRank": 86045,
+            "tags": [
+                "career"
+            ]
         },
         "EuroFootball": {
             "tags": [
@@ -16343,8 +16189,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Wakatime": {
@@ -16369,7 +16214,10 @@
             "usernameClaimed": "Aimilios",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 89235,
-            "disabled": true
+            "disabled": true,
+            "tags": [
+                "streaming"
+            ]
         },
         "Icheckmovies": {
             "tags": [
@@ -16385,8 +16233,7 @@
         "Tl": {
             "tags": [
                 "de",
-                "dk",
-                "us"
+                "dk"
             ],
             "checkType": "status_code",
             "alexaRank": 89601,
@@ -16401,13 +16248,14 @@
             "url": "https://www.designspiration.net/{username}/",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 89939
+            "alexaRank": 89939,
+            "tags": [
+                "design"
+            ]
         },
         "forum.garudalinux.org": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.garudalinux.org",
@@ -16417,9 +16265,7 @@
         "AnimeSuperHero": {
             "disabled": true,
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 90814,
@@ -16446,7 +16292,7 @@
         },
         "NameMC": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "regexCheck": "^.{3,16}$",
             "checkType": "message",
@@ -16465,10 +16311,8 @@
         "beyond3d": {
             "tags": [
                 "forum",
-                "in",
                 "pk",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "XenForo",
             "urlMain": "https://forum.beyond3d.com",
@@ -16599,7 +16443,6 @@
         },
         "sa-mp.ucoz.de": {
             "tags": [
-                "in",
                 "ua"
             ],
             "engine": "uCoz",
@@ -16610,7 +16453,6 @@
         "Movieforums": {
             "tags": [
                 "forum",
-                "in",
                 "la"
             ],
             "checkType": "message",
@@ -16625,8 +16467,7 @@
         },
         "Crevado": {
             "tags": [
-                "in",
-                "us"
+                "design"
             ],
             "checkType": "status_code",
             "alexaRank": 102794,
@@ -16682,8 +16523,7 @@
         },
         "IRC-Galleria": {
             "tags": [
-                "fi",
-                "us"
+                "fi"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -16702,7 +16542,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041a \u0441\u043e\u0436\u0430\u043b\u0435\u043d\u0438\u044e, \u043c\u044b \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0448\u043b\u0438 \u0434\u043b\u044f \u0432\u0430\u0441.."
+                "К сожалению, мы ничего не нашли для вас.."
             ],
             "urlMain": "https://are.kamrbb.ru",
             "url": "https://are.kamrbb.ru/?x=find&f={username}#top",
@@ -16715,7 +16555,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041a \u0441\u043e\u0436\u0430\u043b\u0435\u043d\u0438\u044e, \u043c\u044b \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0448\u043b\u0438 \u0434\u043b\u044f \u0432\u0430\u0441"
+                "К сожалению, мы ничего не нашли для вас"
             ],
             "urlMain": "https://hyundaitruckclub.kamrbb.ru",
             "url": "https://hyundaitruckclub.kamrbb.ru/?x=find&f={username}&type=topics&nick=on#top",
@@ -16724,10 +16564,7 @@
         },
         "Mylot": {
             "tags": [
-                "fr",
-                "in",
-                "pl",
-                "us"
+                "pl"
             ],
             "checkType": "status_code",
             "alexaRank": 105084,
@@ -16738,7 +16575,7 @@
         },
         "GuruShots": {
             "tags": [
-                "us"
+                "photo"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -16752,9 +16589,7 @@
         },
         "SeoClerks": {
             "tags": [
-                "in",
-                "jp",
-                "us"
+                "jp"
             ],
             "checkType": "response_url",
             "alexaRank": 105432,
@@ -16776,7 +16611,7 @@
         },
         "E621": {
             "tags": [
-                "us"
+                "art"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -16798,7 +16633,10 @@
             "checkType": "status_code",
             "usernameClaimed": "Lost_Arrow",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 106344
+            "alexaRank": 106344,
+            "tags": [
+                "gaming"
+            ]
         },
         "Gingerbread": {
             "tags": [
@@ -16816,7 +16654,7 @@
         },
         "rive.app": {
             "tags": [
-                "in"
+                "design"
             ],
             "engine": "engine404",
             "urlMain": "https://rive.app",
@@ -16847,7 +16685,10 @@
             "url": "https://cash.me/${username}",
             "usernameClaimed": "Jenny",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 108253
+            "alexaRank": 108253,
+            "tags": [
+                "finance"
+            ]
         },
         "forum.kineshemec.ru": {
             "disabled": true,
@@ -16875,12 +16716,15 @@
             "urlMain": "https://mstdn.io/",
             "url": "https://mstdn.io/@{username}",
             "usernameClaimed": "blue",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "tags": [
+                "social",
+                "mastodon"
+            ]
         },
         "HackTheBox": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "urlMain": "https://forum.hackthebox.eu/",
@@ -16903,7 +16747,6 @@
             "tags": [
                 "forum",
                 "gb",
-                "in",
                 "pk"
             ],
             "engine": "XenForo",
@@ -16919,9 +16762,9 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0420\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u044b \u043e\u0442\u0441\u0443\u0442\u0441\u0442\u0432\u0443\u044e\u0442",
-                "\u041f\u043e\u0438\u0441\u043a \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u043e \u043e\u0442\u043a\u043b\u044e\u0447\u0435\u043d",
-                "<h2>\u041f\u043e\u0438\u0441\u043a \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u043e \u043e\u0442\u043a\u043b\u044e\u0447\u0435\u043d</h2>"
+                "Результаты отсутствуют",
+                "Поиск временно отключен",
+                "<h2>Поиск временно отключен</h2>"
             ],
             "alexaRank": 113055,
             "urlMain": "https://dota2.ru/",
@@ -16932,7 +16775,7 @@
         "Quibblo": {
             "disabled": true,
             "tags": [
-                "in"
+                "discussion"
             ],
             "checkType": "response_url",
             "alexaRank": 113120,
@@ -17011,8 +16854,7 @@
         },
         "YouNow": {
             "tags": [
-                "be",
-                "us"
+                "be"
             ],
             "urlProbe": "https://api.younow.com/php/api/broadcast/info/user={username}/",
             "checkType": "message",
@@ -17028,8 +16870,7 @@
         "CapFriendly": {
             "disabled": true,
             "tags": [
-                "ca",
-                "us"
+                "ca"
             ],
             "regexCheck": "^[a-zA-z][a-zA-Z0-9_]{2,79}$",
             "checkType": "message",
@@ -17073,8 +16914,7 @@
         },
         "Quartertothree": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.quartertothree.com",
@@ -17083,7 +16923,7 @@
         },
         "Weasyl": {
             "tags": [
-                "in"
+                "art"
             ],
             "checkType": "status_code",
             "alexaRank": 115562,
@@ -17108,7 +16948,7 @@
         },
         "Touristlink": {
             "tags": [
-                "in"
+                "travel"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -17171,7 +17011,10 @@
             "urlMain": "https://massagerepublic.com",
             "usernameClaimed": "lily88",
             "usernameUnclaimed": "xzhsxfyfzi",
-            "alexaRank": 120861
+            "alexaRank": 120861,
+            "tags": [
+                "erotic"
+            ]
         },
         "AllTheLyrics": {
             "urlSubpath": "/forum",
@@ -17213,8 +17056,7 @@
         },
         "Gvectors": {
             "tags": [
-                "in",
-                "us"
+                "forum"
             ],
             "checkType": "status_code",
             "alexaRank": 123716,
@@ -17225,9 +17067,7 @@
         },
         "Droidforums": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "errors": {
                 "You must be logged-in to do that.": "Login required"
@@ -17255,7 +17095,7 @@
         },
         "Clozemaster": {
             "tags": [
-                "us"
+                "education"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -17314,7 +17154,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "alexaRank": 130840,
             "urlMain": "https://www.old-games.ru",
@@ -17322,7 +17162,7 @@
             "usernameClaimed": "viktort",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "getmyuni": {
+        "GetMyUni": {
             "tags": [
                 "in"
             ],
@@ -17342,8 +17182,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "jp",
-                "us"
+                "jp"
             ],
             "engine": "vBulletin",
             "alexaRank": 131722,
@@ -17353,12 +17192,11 @@
         },
         "ForumTauck": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u2014 Tauck Community"
+                "— Tauck Community"
             ],
             "urlMain": "https://forums.tauck.com",
             "url": "https://forums.tauck.com/profile/{username}",
@@ -17373,7 +17211,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title>\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d</title"
+                "<title>Пользователь не найден</title"
             ],
             "alexaRank": 134674,
             "urlMain": "https://au.ru",
@@ -17405,7 +17243,6 @@
             "tags": [
                 "ca",
                 "forum",
-                "in",
                 "pk"
             ],
             "engine": "vBulletin",
@@ -17420,7 +17257,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Пользователь с таким именем не найден"
             ],
             "alexaRank": 138886,
             "urlMain": "https://www.rusfootball.info/",
@@ -17445,16 +17282,16 @@
                 "streaming"
             ]
         },
-        "www.freelancejob.ru": {
+        "FreelanceJob": {
             "tags": [
                 "ru"
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u041a\u043e\u043b-\u0432\u043e \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u043e\u0432 \u0430\u043a\u043a\u0430\u0443\u043d\u0442\u0430  \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Кол-во просмотров аккаунта  пользователя"
             ],
             "absenceStrs": [
-                "<h1>\u041e\u0448\u0438\u0431\u043a\u0430 404</h1>"
+                "<h1>Ошибка 404</h1>"
             ],
             "urlMain": "https://www.freelancejob.ru",
             "url": "https://www.freelancejob.ru/users/{username}/",
@@ -17466,9 +17303,7 @@
             "tags": [
                 "co",
                 "forum",
-                "in",
-                "sg",
-                "us"
+                "sg"
             ],
             "engine": "XenForo",
             "urlMain": "https://forum.popjustice.com",
@@ -17477,7 +17312,7 @@
         },
         "1001tracklists": {
             "tags": [
-                "us"
+                "music"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -17504,8 +17339,7 @@
         },
         "EthicalHacker": {
             "tags": [
-                "in",
-                "us"
+                "hacking"
             ],
             "checkType": "status_code",
             "presenseStrs": [
@@ -17549,7 +17383,6 @@
                 "ca",
                 "forum",
                 "gb",
-                "in",
                 "pk"
             ],
             "engine": "XenForo",
@@ -17584,7 +17417,10 @@
             ],
             "usernameClaimed": "kilroy222",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 151421
+            "alexaRank": 151421,
+            "tags": [
+                "porn"
+            ]
         },
         "999.md": {
             "absenceStrs": [
@@ -17619,7 +17455,7 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.livios.be": {
+        "Livios": {
             "checkType": "message",
             "absenceStrs": [
                 "not found",
@@ -17639,7 +17475,11 @@
             "urlMain": "https://www.livios.be",
             "usernameClaimed": "lily88",
             "usernameUnclaimed": "ldbdpisozv",
-            "alexaRank": 155125
+            "alexaRank": 155125,
+            "tags": [
+                "forum",
+                "be"
+            ]
         },
         "Kwejk": {
             "tags": [
@@ -17657,8 +17497,7 @@
                 "forum",
                 "jp",
                 "tech",
-                "tw",
-                "us"
+                "tw"
             ],
             "checkType": "status_code",
             "alexaRank": 161262,
@@ -17672,7 +17511,11 @@
             "alexaRank": 163014,
             "urlMain": "http://millerovo161.ru",
             "usernameClaimed": "alex",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "tags": [
+                "forum",
+                "ru"
+            ]
         },
         "Pepper NL": {
             "url": "https://nl.pepper.com/profile/{username}",
@@ -17700,7 +17543,10 @@
             "checkType": "status_code",
             "usernameClaimed": "andrea",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 165029
+            "alexaRank": 165029,
+            "tags": [
+                "social"
+            ]
         },
         "programming.dev": {
             "tags": [
@@ -17741,10 +17587,8 @@
                 "be",
                 "de",
                 "es",
-                "in",
                 "pt",
-                "ru",
-                "us"
+                "ru"
             ],
             "checkType": "response_url",
             "alexaRank": 167798,
@@ -17768,9 +17612,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "in",
-                "pk",
-                "us"
+                "pk"
             ],
             "engine": "vBulletin",
             "urlMain": "https://forum.mt5.com",
@@ -17798,8 +17640,8 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e.",
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено.",
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 168544,
             "urlMain": "https://www.radiokot.ru",
@@ -17824,8 +17666,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "sg",
-                "us"
+                "sg"
             ],
             "engine": "vBulletin",
             "alexaRank": 170454,
@@ -17864,9 +17705,7 @@
             "tags": [
                 "forum",
                 "gb",
-                "in",
-                "sg",
-                "us"
+                "sg"
             ],
             "checkType": "status_code",
             "urlMain": "https://forums.footballindex.co.uk",
@@ -17877,8 +17716,7 @@
         },
         "thewholesaleforums.co.uk": {
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "http://www.thewholesaleforums.co.uk/",
@@ -17892,7 +17730,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435"
+                "Извините"
             ],
             "urlMain": "https://forum.sibmama.ru/",
             "url": "https://forum.sibmama.ru/profile.php?mode=viewprofile&u={username}",
@@ -17921,7 +17759,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d."
+                "Пользователь не найден."
             ],
             "urlMain": "http://forum.mfd.ru",
             "url": "http://forum.mfd.ru/forum/search/?query=&method=And&userQuery={username}",
@@ -17941,8 +17779,7 @@
         },
         "Mylespaul": {
             "tags": [
-                "cl",
-                "us"
+                "cl"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -17987,7 +17824,7 @@
         },
         "Listography": {
             "tags": [
-                "in"
+                "sharing"
             ],
             "errors": {
                 "An error has occurred.": "Site error"
@@ -18014,7 +17851,7 @@
             "usernameClaimed": "mark",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.liinks.co": {
+        "Liinks": {
             "disabled": true,
             "tags": [
                 "links"
@@ -18055,7 +17892,7 @@
                 "profile-content"
             ],
             "absenceStrs": [
-                "\u0423\u043f\u0441! \u0412\u043e\u0442 \u044d\u0442\u043e \u043f\u043e\u0432\u043e\u0440\u043e\u0442!"
+                "Упс! Вот это поворот!"
             ],
             "alexaRank": 180260,
             "urlMain": "https://kosmetista.ru",
@@ -18066,8 +17903,7 @@
         "Riftgame": {
             "tags": [
                 "cr",
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -18080,8 +17916,7 @@
         },
         "Fluther": {
             "tags": [
-                "in",
-                "us"
+                "q&a"
             ],
             "checkType": "status_code",
             "alexaRank": 180379,
@@ -18105,8 +17940,7 @@
         "juce": {
             "tags": [
                 "ca",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.juce.com",
@@ -18193,8 +18027,7 @@
         "Antichat": {
             "tags": [
                 "forum",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "XenForo",
             "urlMain": "https://forum.antichat.ru/",
@@ -18247,8 +18080,7 @@
             "ignore403": true,
             "disabled": true,
             "tags": [
-                "ca",
-                "us"
+                "ca"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -18279,7 +18111,11 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 188982,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "shopping",
+                "es"
+            ]
         },
         "forum.hr": {
             "tags": [
@@ -18329,8 +18165,7 @@
         },
         "Runitonce": {
             "tags": [
-                "ca",
-                "us"
+                "ca"
             ],
             "checkType": "response_url",
             "alexaRank": 194576,
@@ -18386,8 +18221,7 @@
             "tags": [
                 "forum",
                 "gb",
-                "sg",
-                "us"
+                "sg"
             ],
             "engine": "XenForo",
             "alexaRank": 200368,
@@ -18397,7 +18231,6 @@
         },
         "Pregame": {
             "tags": [
-                "in",
                 "us"
             ],
             "checkType": "response_url",
@@ -18423,10 +18256,10 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041e\u0448\u0438\u0431\u043a\u0430 404"
+                "Ошибка 404"
             ],
             "presenseStrs": [
-                "\u041b\u0438\u0447\u043d\u043e\u0435"
+                "Личное"
             ],
             "alexaRank": 200882,
             "urlMain": "https://vapenews.ru/",
@@ -18437,10 +18270,8 @@
         "bbs.evony.com": {
             "tags": [
                 "forum",
-                "in",
                 "pk",
-                "tr",
-                "us"
+                "tr"
             ],
             "engine": "vBulletin",
             "urlMain": "http://bbs.evony.com",
@@ -18468,7 +18299,10 @@
             "urlMain": "https://oshwlab.com",
             "usernameClaimed": "zoey123",
             "usernameUnclaimed": "uckupswapv",
-            "alexaRank": 202371
+            "alexaRank": 202371,
+            "tags": [
+                "tech"
+            ]
         },
         "forum.vectric.com": {
             "urlMain": "https://forum.vectric.com",
@@ -18476,8 +18310,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "sevenstring.org": {
@@ -18510,7 +18343,6 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "in",
                 "pk",
                 "us"
             ],
@@ -18523,7 +18355,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "pr0gramm": {
+        "Pr0gramm": {
             "tags": [
                 "de"
             ],
@@ -18541,7 +18373,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "http://forum.bratsk.org",
             "url": "http://forum.bratsk.org/member.php?username={username}",
@@ -18561,7 +18393,7 @@
             "usernameClaimed": "Yamiha",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.opendiary.com": {
+        "OpenDiary": {
             "urlSubpath": "/m",
             "urlMain": "https://www.opendiary.com",
             "engine": "Wordpress/Author",
@@ -18574,8 +18406,7 @@
         },
         "Showme": {
             "tags": [
-                "in",
-                "us"
+                "education"
             ],
             "checkType": "status_code",
             "alexaRank": 207957,
@@ -18660,7 +18491,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://forum.qwas.ru",
             "url": "http://forum.qwas.ru/search.php?keywords=&terms=all&author={username}",
@@ -18683,9 +18514,7 @@
         },
         "Office-forums": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 214742,
@@ -18773,8 +18602,8 @@
                 "has been temporarily blocked": "IP ban"
             },
             "absenceStrs": [
-                "\u0417\u0430\u043f\u0440\u043e\u0448\u0435\u043d\u043d\u0430\u044f \u0432\u0430\u043c\u0438 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430.",
-                "\u0414\u0430\u043d\u043d\u044b\u0435 \u043e \u0432\u044b\u0431\u0440\u0430\u043d\u043d\u043e\u043c \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u0435 \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u044e\u0442",
+                "Запрошенная вами страница не найдена.",
+                "Данные о выбранном пользователе не существуют",
                 "Information on selected user does not exist"
             ],
             "alexaRank": 218186,
@@ -18800,9 +18629,7 @@
                 "ca",
                 "forum",
                 "gaming",
-                "gb",
-                "in",
-                "us"
+                "gb"
             ],
             "engine": "vBulletin",
             "urlMain": "https://forums.eagle.ru",
@@ -18854,17 +18681,16 @@
         "Bobrdobr": {
             "tags": [
                 "az",
-                "in",
                 "ru",
                 "tr",
                 "ua"
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u0417\u0430\u043a\u043b\u0430\u0434\u043a\u0438 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Закладки пользователя"
             ],
             "absenceStrs": [
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430."
+                "Страница не найдена."
             ],
             "alexaRank": 225698,
             "urlMain": "https://bobrdobr.ru",
@@ -18920,7 +18746,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "По вашему запросу ничего не найдено."
             ],
             "urlMain": "http://ramta.0pk.ru",
             "url": "http://ramta.0pk.ru/search.php?action=search&keywords=&author={username}",
@@ -18934,8 +18760,8 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title> \u0418\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u044f</title>",
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "<title> Информация</title>",
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 226961,
             "urlMain": "https://gotovim-doma.ru",
@@ -18943,7 +18769,7 @@
             "usernameClaimed": "Maxxi",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "bliphoto": {
+        "Blipfoto": {
             "absenceStrs": [
                 "<title>Your photo journal | Blipfoto</title>"
             ],
@@ -18969,7 +18795,6 @@
             "tags": [
                 "forum",
                 "pk",
-                "us",
                 "vn"
             ],
             "engine": "vBulletin",
@@ -18990,12 +18815,11 @@
         },
         "Hpc": {
             "tags": [
-                "in",
                 "ru"
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 230335,
             "urlMain": "https://hpc.ru",
@@ -19010,7 +18834,10 @@
             "regexCheck": "^[\\w]{4,30}$",
             "usernameClaimed": "0day",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 230674
+            "alexaRank": 230674,
+            "tags": [
+                "hacking"
+            ]
         },
         "Gribnyemesta": {
             "tags": [
@@ -19019,7 +18846,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0437\u0430\u0431\u0430\u043d\u0435\u043d \u0438\u043b\u0438 \u0443\u0434\u0430\u043b\u0435\u043d"
+                "профиль забанен или удален"
             ],
             "urlMain": "https://gribnyemesta.unoforum.pro",
             "url": "https://gribnyemesta.unoforum.pro/?32-{username}",
@@ -19029,8 +18856,7 @@
         },
         "Ruby-forum": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "alexaRank": 232482,
@@ -19041,8 +18867,7 @@
         "EduGeek": {
             "disabled": true,
             "tags": [
-                "education",
-                "us"
+                "education"
             ],
             "engine": "vBulletin",
             "urlMain": "https://www.edugeek.net",
@@ -19055,7 +18880,11 @@
             "urlMain": "http://justmj.ru",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "usernameClaimed": "alex",
-            "alexaRank": 232953
+            "alexaRank": 232953,
+            "tags": [
+                "blog",
+                "ru"
+            ]
         },
         "forums.immigration.com": {
             "urlMain": "https://forums.immigration.com",
@@ -19063,8 +18892,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Empflix": {
@@ -19082,7 +18910,6 @@
         },
         "Hackenproof": {
             "tags": [
-                "in",
                 "ua"
             ],
             "checkType": "message",
@@ -19135,11 +18962,11 @@
                 "ru"
             ],
             "errors": {
-                "\u0412\u044b \u043d\u0435 \u043c\u043e\u0436\u0435\u0442\u0435 \u043f\u0440\u043e\u0438\u0437\u0432\u0435\u0441\u0442\u0438 \u043f\u043e\u0438\u0441\u043a \u0441\u0440\u0430\u0437\u0443 \u043f\u043e\u0441\u043b\u0435 \u043f\u0440\u0435\u0434\u044b\u0434\u0443\u0449\u0435\u0433\u043e": "Too many requests"
+                "Вы не можете произвести поиск сразу после предыдущего": "Too many requests"
             },
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 241018,
             "urlMain": "https://www.romanticcollection.ru",
@@ -19147,7 +18974,7 @@
             "usernameClaimed": "Prim@",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "www.hsx.com": {
+        "HSX": {
             "checkType": "message",
             "presenseStrs": [
                 "profile-info"
@@ -19188,9 +19015,7 @@
         "Tellonym.me": {
             "tags": [
                 "de",
-                "fr",
-                "sa",
-                "us"
+                "sa"
             ],
             "checkType": "status_code",
             "alexaRank": 246104,
@@ -19226,7 +19051,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0420\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432 \u043f\u043e\u0438\u0441\u043a\u0430 \u043d\u0435\u0442. \u0420\u0430\u0441\u0448\u0438\u0440\u044c\u0442\u0435 \u043a\u0440\u0438\u0442\u0435\u0440\u0438\u0438 \u043f\u043e\u0438\u0441\u043a\u0430."
+                "Результатов поиска нет. Расширьте критерии поиска."
             ],
             "alexaRank": 250214,
             "urlMain": "https://www.chipmaker.ru",
@@ -19263,7 +19088,7 @@
             "usernameClaimed": "Lexx",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "soylentnews": {
+        "SoylentNews": {
             "tags": [
                 "us"
             ],
@@ -19343,14 +19168,22 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 259987,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "shopping",
+                "mx"
+            ]
         },
         "mir-stalkera.ru": {
             "engine": "uCoz",
             "urlMain": "http://mir-stalkera.ru",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "usernameClaimed": "john",
-            "alexaRank": 260295
+            "alexaRank": 260295,
+            "tags": [
+                "gaming",
+                "ru"
+            ]
         },
         "sorento.kia-club.ru": {
             "urlMain": "http://sorento.kia-club.ru/forum",
@@ -19367,7 +19200,11 @@
             "alexaRank": 262389,
             "urlMain": "http://vishivalochka.ru",
             "usernameClaimed": "alex",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "tags": [
+                "hobby",
+                "ru"
+            ]
         },
         "Proshkolu": {
             "tags": [
@@ -19375,7 +19212,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Пользователь не найден"
             ],
             "alexaRank": 263423,
             "urlMain": "https://proshkolu.ru",
@@ -19410,9 +19247,7 @@
         },
         "Gunboards": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "presenseStrs": [
                 "latest-activity"
@@ -19433,17 +19268,17 @@
                 "ua"
             ]
         },
-        "www.sql.ru": {
+        "SQL.ru": {
             "tags": [
                 "ru"
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0430\u0439\u0434\u0435\u043d\u043e"
+                "По вашему запросу найдено"
             ],
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435",
-                " \u043d\u043e \u043f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e"
+                "Извините",
+                " но по вашему запросу ничего не найдено"
             ],
             "url": "https://www.sql.ru/forum/actualsearch.aspx?a={username}&ma=0",
             "urlMain": "https://www.sql.ru",
@@ -19471,7 +19306,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "alexaRank": 271584,
             "urlMain": "http://www.biketrials.ru",
@@ -19486,8 +19321,7 @@
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "Hctorpedo": {
@@ -19543,8 +19377,7 @@
             "urlSubpath": "/forum",
             "tags": [
                 "forum",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "phpBB",
             "alexaRank": 276576,
@@ -19554,7 +19387,7 @@
         },
         "Flashflashrevolution": {
             "tags": [
-                "us"
+                "gaming"
             ],
             "checkType": "response_url",
             "alexaRank": 277587,
@@ -19592,10 +19425,10 @@
             "regexCheck": "^[a-zA-Z0-9-]{3,}$",
             "checkType": "message",
             "presenseStrs": [
-                "\u041f\u0440\u043e\u0444\u0438\u043b\u044c \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Профиль пользователя"
             ],
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "alexaRank": 282337,
             "urlMain": "http://33bru.com/",
@@ -19610,7 +19443,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0422\u0430\u043a\u043e\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Такой пользователь не найден"
             ],
             "alexaRank": 282968,
             "urlMain": "https://avtomarket.ru",
@@ -19657,7 +19490,11 @@
             "regexCheck": "^[a-zA-Z0-9_.-]{3,40}$",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 284423
+            "alexaRank": 284423,
+            "tags": [
+                "forum",
+                "no"
+            ]
         },
         "TheFastlaneForum": {
             "disabled": true,
@@ -19722,9 +19559,7 @@
         },
         "Go365": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://community.go365.com",
             "url": "https://community.go365.com/people/{username}",
@@ -19756,7 +19591,11 @@
             "urlMain": "http://mcfc-fan.ru",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "usernameClaimed": "alex",
-            "alexaRank": 289966
+            "alexaRank": 289966,
+            "tags": [
+                "sport",
+                "ru"
+            ]
         },
         "Pedsovet": {
             "disabled": true,
@@ -19771,9 +19610,7 @@
         },
         "Affiliatefix": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 293573,
@@ -19784,9 +19621,7 @@
         "Hipforums": {
             "tags": [
                 "forum",
-                "in",
-                "ru",
-                "us"
+                "ru"
             ],
             "disabled": true,
             "engine": "XenForo",
@@ -19816,7 +19651,11 @@
             ],
             "usernameClaimed": "junferno",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 294005
+            "alexaRank": 294005,
+            "tags": [
+                "coding",
+                "ca"
+            ]
         },
         "2d-3d": {
             "tags": [
@@ -19847,8 +19686,7 @@
         },
         "nightbot": {
             "tags": [
-                "jp",
-                "us"
+                "jp"
             ],
             "urlProbe": "https://api.nightbot.tv/1/channels/t/{username}",
             "checkType": "status_code",
@@ -19861,8 +19699,7 @@
         "Truesteamachievements": {
             "tags": [
                 "az",
-                "gb",
-                "us"
+                "gb"
             ],
             "checkType": "status_code",
             "alexaRank": 297108,
@@ -19887,8 +19724,7 @@
             "tags": [
                 "forum",
                 "gb",
-                "jp",
-                "us"
+                "jp"
             ],
             "engine": "XenForo",
             "urlMain": "https://forum.questionablequesting.com",
@@ -19946,7 +19782,10 @@
             ],
             "usernameClaimed": "testadmin",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 307326
+            "alexaRank": 307326,
+            "tags": [
+                "hacking"
+            ]
         },
         "ifish.net": {
             "urlMain": "https://ifish.net",
@@ -19968,7 +19807,10 @@
             "usernameClaimed": "admin",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "checkType": "response_url",
-            "alexaRank": 309815
+            "alexaRank": 309815,
+            "tags": [
+                "career"
+            ]
         },
         "drupal.ru": {
             "tags": [
@@ -19976,7 +19818,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430 - 404"
+                "Страница не найдена - 404"
             ],
             "presenseStrs": [
                 "<ul class=\"tabs--primary\">"
@@ -19993,7 +19835,10 @@
             "checkType": "status_code",
             "usernameClaimed": "susurrus",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 312490
+            "alexaRank": 312490,
+            "tags": [
+                "hobby"
+            ]
         },
         "Rusfishing": {
             "disabled": true,
@@ -20003,7 +19848,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "alexaRank": 313350,
             "urlMain": "https://www.rusfishing.ru",
@@ -20013,7 +19858,7 @@
         },
         "mywishboard.com": {
             "tags": [
-                "in"
+                "shopping"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -20072,8 +19917,7 @@
         "forums.sailboatowners.com": {
             "disabled": true,
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "http://forums.sailboatowners.com",
@@ -20121,9 +19965,7 @@
         },
         "Windows10forums": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 322518,
@@ -20145,7 +19987,6 @@
         "Rusforum": {
             "tags": [
                 "forum",
-                "in",
                 "pk",
                 "ru",
                 "ua"
@@ -20164,7 +20005,11 @@
             "usernameClaimed": "Stefan",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 323118,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "shopping",
+                "at"
+            ]
         },
         "Rpgwatch": {
             "urlSubpath": "/forums",
@@ -20172,9 +20017,7 @@
             "tags": [
                 "ca",
                 "forum",
-                "in",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "vBulletin",
             "alexaRank": 324137,
@@ -20188,7 +20031,12 @@
             "url": "https://101010.pl/@{username}",
             "alexaRank": 324627,
             "usernameClaimed": "ueh_kon",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "tags": [
+                "social",
+                "mastodon",
+                "pl"
+            ]
         },
         "House-Mixes.com": {
             "tags": [
@@ -20209,7 +20057,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "title>\u041e\u0448\u0438\u0431\u043a\u0430!</title"
+                "title>Ошибка!</title"
             ],
             "alexaRank": 330837,
             "urlMain": "https://www.pepper.ru/",
@@ -20246,7 +20094,7 @@
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u043f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e! :("
+                "Извините, по вашему запросу ничего не найдено! :("
             ],
             "alexaRank": 331164,
             "urlMain": "https://poembook.ru",
@@ -20278,9 +20126,7 @@
         },
         "Wireclub": {
             "tags": [
-                "in",
-                "tr",
-                "us"
+                "tr"
             ],
             "checkType": "response_url",
             "alexaRank": 336382,
@@ -20291,8 +20137,7 @@
         },
         "m.smutty.com": {
             "tags": [
-                "erotic",
-                "us"
+                "erotic"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -20313,7 +20158,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 337938,
             "urlMain": "https://southklad.ru",
@@ -20323,8 +20168,7 @@
         },
         "community.endlessos.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://community.endlessos.com",
@@ -20334,10 +20178,8 @@
         "Golangbridge": {
             "tags": [
                 "forum",
-                "in",
                 "sa",
                 "ua",
-                "us",
                 "vn"
             ],
             "engine": "Discourse",
@@ -20432,7 +20274,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title>\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430!</title>"
+                "<title>Страница не найдена!</title>"
             ],
             "urlMain": "https://freelance.codeby.net",
             "url": "https://freelance.codeby.net/user/{username}/portfolio/",
@@ -20456,7 +20298,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "urlMain": "https://forum.mau.ru",
             "url": "https://forum.mau.ru/profile.php?mode=viewprofile&u={username}",
@@ -20473,7 +20315,10 @@
             "url": "https://www.magix.info/us/users/profile/{username}/",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "disabled": true
+            "disabled": true,
+            "tags": [
+                "tech"
+            ]
         },
         "Gpodder": {
             "checkType": "status_code",
@@ -20481,7 +20326,10 @@
             "urlMain": "https://gpodder.net/",
             "url": "https://gpodder.net/user/{username}",
             "usernameClaimed": "blue",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "tags": [
+                "music"
+            ]
         },
         "Kvinneguiden": {
             "url": "https://forum.kvinneguiden.no",
@@ -20603,7 +20451,11 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 366287
+            "alexaRank": 366287,
+            "tags": [
+                "video",
+                "social"
+            ]
         },
         "Queer": {
             "tags": [
@@ -20619,8 +20471,7 @@
         "GolfMonthly": {
             "tags": [
                 "forum",
-                "gb",
-                "us"
+                "gb"
             ],
             "engine": "XenForo",
             "urlMain": "https://forums.golf-monthly.co.uk/",
@@ -20664,7 +20515,11 @@
             "urlMain": "http://izobil.ru",
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 370090
+            "alexaRank": 370090,
+            "tags": [
+                "forum",
+                "ru"
+            ]
         },
         "Gps-data-team": {
             "disabled": true,
@@ -20676,7 +20531,10 @@
             "urlMain": "https://www.gps-data-team.com",
             "url": "https://www.gps-data-team.com/pda-gps-navigation/profile.php?mode=viewprofile&u={username}",
             "usernameClaimed": "adam",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "tags": [
+                "maps"
+            ]
         },
         "Elakiri": {
             "tags": [
@@ -20713,7 +20571,11 @@
             "urlMain": "http://school2dobrinka.ru",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "usernameClaimed": "alex",
-            "alexaRank": 376730
+            "alexaRank": 376730,
+            "tags": [
+                "education",
+                "ru"
+            ]
         },
         "Italia": {
             "tags": [
@@ -20757,8 +20619,7 @@
         },
         "officiating": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -20775,7 +20636,11 @@
             "alexaRank": 384090,
             "urlMain": "http://nwo-team.ru",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "usernameClaimed": "alex"
+            "usernameClaimed": "alex",
+            "tags": [
+                "gaming",
+                "ru"
+            ]
         },
         "Armtorg": {
             "urlSubpath": "/forum",
@@ -20808,14 +20673,16 @@
             "checkType": "status_code",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 390150
+            "alexaRank": 390150,
+            "tags": [
+                "blog"
+            ]
         },
         "Arsenal-mania": {
             "tags": [
                 "gb",
                 "hk",
-                "pk",
-                "us"
+                "pk"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -20839,8 +20706,7 @@
         },
         "leasehackr": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.leasehackr.com/",
@@ -20879,7 +20745,7 @@
                 "http://img.combats.com/errs/503.png": "Maintenance"
             },
             "absenceStrs": [
-                "<TITLE>\u041f\u0440\u043e\u0438\u0437\u043e\u0448\u043b\u0430 \u043e\u0448\u0438\u0431\u043a\u0430</TITLE>"
+                "<TITLE>Произошла ошибка</TITLE>"
             ],
             "urlMain": "http://capitalcity.combats.com",
             "url": "http://capitalcity.combats.com/inf.pl?{username}",
@@ -20895,7 +20761,7 @@
                 "http://img.combats.com/errs/503.png": "Maintenance"
             },
             "absenceStrs": [
-                "\u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "не найден"
             ],
             "urlMain": "http://demonscity.combats.com",
             "url": "http://demonscity.combats.com/inf.pl?{username}",
@@ -20976,8 +20842,7 @@
             "disabled": true,
             "similarSearch": true,
             "tags": [
-                "ru",
-                "us"
+                "ru"
             ],
             "regexCheck": "^[^_]{3,}$",
             "checkType": "message",
@@ -21049,7 +20914,7 @@
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "alexaRank": 418878,
             "urlMain": "https://www.kuharka.ru/",
@@ -21068,7 +20933,7 @@
             "usernameClaimed": "fly4life",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "vegalab": {
+        "VegaLab": {
             "disabled": true,
             "tags": [
                 "forum",
@@ -21082,7 +20947,7 @@
         },
         "followus.com": {
             "tags": [
-                "in"
+                "links"
             ],
             "engine": "engine404",
             "urlMain": "https://followus.com",
@@ -21108,7 +20973,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u0438 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u044b."
+                "Пользователи не найдены."
             ],
             "alexaRank": 427747,
             "urlMain": "https://glav.su",
@@ -21140,16 +21005,13 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "clubsnap.com": {
             "tags": [
                 "forum",
-                "in",
-                "sg",
-                "us"
+                "sg"
             ],
             "engine": "XenForo",
             "alexaRank": 441256,
@@ -21220,7 +21082,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e. \u041f\u043e\u043f\u0440\u043e\u0431\u0443\u0439\u0442\u0435 \u0440\u0430\u0441\u0448\u0438\u0440\u0438\u0442\u044c \u043a\u0440\u0438\u0442\u0435\u0440\u0438\u0438 \u043f\u043e\u0438\u0441\u043a\u0430."
+                "По вашему запросу ничего не найдено. Попробуйте расширить критерии поиска."
             ],
             "urlMain": "http://forum.kerch.com.ru",
             "url": "http://forum.kerch.com.ru/search/?q={username}",
@@ -21229,8 +21091,7 @@
         },
         "Qbn": {
             "tags": [
-                "in",
-                "us"
+                "design"
             ],
             "checkType": "status_code",
             "alexaRank": 446555,
@@ -21274,7 +21135,11 @@
             "urlMain": "http://rezzoclub.ru",
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "alexaRank": 453994
+            "alexaRank": 453994,
+            "tags": [
+                "forum",
+                "ru"
+            ]
         },
         "rybnoe.net": {
             "tags": [
@@ -21294,7 +21159,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 455450,
             "urlMain": "https://pogovorim.by",
@@ -21336,14 +21201,12 @@
             "disabled": true,
             "tags": [
                 "cn",
-                "in",
                 "ir",
-                "ru",
-                "us"
+                "ru"
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title>\u63d0\u793a\u4fe1\u606f -  huami\u8bba\u575b -  Powered by Discuz!</title>"
+                "<title>提示信息 -  huami论坛 -  Powered by Discuz!</title>"
             ],
             "urlMain": "https://bbs.huami.com",
             "url": "https://bbs.huami.com/home.php?username={username}",
@@ -21352,7 +21215,7 @@
         },
         "Thelion": {
             "tags": [
-                "us"
+                "blog"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -21390,9 +21253,7 @@
         },
         "cubecraft.net": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://www.cubecraft.net",
@@ -21443,8 +21304,7 @@
         },
         "MaidenFans": {
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://forum.maidenfans.com",
@@ -21462,7 +21322,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 477781
         },
-        "www.xshaker.net": {
+        "XShaker": {
             "checkType": "message",
             "absenceStrs": [
                 "/tube/txxxtv.html"
@@ -21478,12 +21338,15 @@
             "urlMain": "https://www.xshaker.net",
             "usernameClaimed": "tube/lily89",
             "usernameUnclaimed": "cttvtlwifg",
-            "alexaRank": 478701
+            "alexaRank": 478701,
+            "tags": [
+                "forum"
+            ]
         },
         "Gays": {
             "disabled": true,
             "tags": [
-                "in"
+                "dating"
             ],
             "checkType": "status_code",
             "alexaRank": 478828,
@@ -21496,10 +21359,8 @@
             "tags": [
                 "dz",
                 "finance",
-                "in",
                 "ir",
-                "tr",
-                "us"
+                "tr"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -21600,7 +21461,7 @@
                 "gaming"
             ]
         },
-        "www.turpravda.com": {
+        "TurPravda": {
             "tags": [
                 "ua"
             ],
@@ -21694,8 +21555,7 @@
         "Hitmanforum": {
             "tags": [
                 "forum",
-                "rs",
-                "us"
+                "rs"
             ],
             "engine": "Discourse",
             "alexaRank": 498455,
@@ -21710,7 +21570,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f."
+                "Указанный пользователь не найден. Пожалуйста, введите другое имя."
             ],
             "alexaRank": 500151,
             "urlMain": "https://www.hunting.ru/forum/",
@@ -21724,7 +21584,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d."
+                "Пользователь с таким именем не найден."
             ],
             "alexaRank": 501005,
             "urlMain": "https://zagony.ru",
@@ -21746,8 +21606,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "XenForo",
             "alexaRank": 501903,
@@ -21761,7 +21620,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0432\u044b\u0431\u0440\u0430\u043d"
+                "Пользователь не выбран"
             ],
             "alexaRank": 502541,
             "urlMain": "https://www.aqa.ru/",
@@ -21771,8 +21630,7 @@
         },
         "Byte": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://community.byte.co",
@@ -21786,7 +21644,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f."
+                "Указанный пользователь не найден. Пожалуйста, введите другое имя."
             ],
             "alexaRank": 504878,
             "urlMain": "http://www.rusarmy.com",
@@ -21833,8 +21691,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "ir",
-                "us"
+                "ir"
             ],
             "engine": "vBulletin",
             "alexaRank": 508154,
@@ -21869,7 +21726,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 508593,
             "urlMain": "https://astrogalaxy.ru",
@@ -21884,7 +21741,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e \u043d\u0438 \u043e\u0434\u043d\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Не найдено ни одного пользователя"
             ],
             "urlMain": "http://new.sexopedia.ru",
             "url": "http://new.sexopedia.ru/club/search.php?flt_login={username}",
@@ -21990,8 +21847,7 @@
         "Volgograd Forum": {
             "tags": [
                 "forum",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "XenForo",
             "alexaRank": 524472,
@@ -22054,7 +21910,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f."
+                "Указанный пользователь не найден. Пожалуйста, введите другое имя."
             ],
             "urlMain": "https://forum.igrarena.ru",
             "url": "https://forum.igrarena.ru/members/?username={username}",
@@ -22062,9 +21918,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Xbox Gamertag": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "errors": {
                 "Something went wrong": "Site error",
                 "Why do I have to complete a CAPTCHA": "Captcha detected"
@@ -22079,8 +21933,7 @@
         "Dating.Ru": {
             "tags": [
                 "dating",
-                "ru",
-                "us"
+                "ru"
             ],
             "checkType": "status_code",
             "alexaRank": 538125,
@@ -22097,7 +21950,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://forum.sanatorii.by",
             "url": "http://forum.sanatorii.by/search.php?keywords=&terms=all&author={username}",
@@ -22117,7 +21970,7 @@
         },
         "soc-life.com": {
             "presenseStrs": [
-                "sc-tabs\"><div>\u041b\u043e\u0433\u0438\u043d:"
+                "sc-tabs\"><div>Логин:"
             ],
             "engine": "uCoz",
             "alexaRank": 541385,
@@ -22131,7 +21984,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title>\u0424\u043e\u0440\u0443\u043c</title>"
+                "<title>Форум</title>"
             ],
             "alexaRank": 543048,
             "urlMain": "https://cad.ru",
@@ -22198,9 +22051,7 @@
         "Gigbucks": {
             "tags": [
                 "dz",
-                "eg",
-                "in",
-                "us"
+                "eg"
             ],
             "checkType": "response_url",
             "alexaRank": 549311,
@@ -22225,8 +22076,7 @@
                 "at",
                 "cz",
                 "forum",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.hiveos.farm",
@@ -22272,7 +22122,6 @@
         "Mactalk": {
             "tags": [
                 "au",
-                "in",
                 "pk"
             ],
             "checkType": "message",
@@ -22320,9 +22169,7 @@
         },
         "Soundgym": {
             "tags": [
-                "il",
-                "in",
-                "us"
+                "il"
             ],
             "checkType": "response_url",
             "urlMain": "https://www.soundgym.co",
@@ -22333,10 +22180,7 @@
         },
         "Playlists": {
             "disabled": true,
-            "tags": [
-                "in",
-                "us"
-            ],
+            "tags": [],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
@@ -22372,10 +22216,10 @@
         },
         "xgm.guru": {
             "presenseStrs": [
-                "\u0410\u043a\u0442\u0438\u0432\u043d\u043e\u0441\u0442\u044c:"
+                "Активность:"
             ],
             "absenceStrs": [
-                "\u0410\u0432\u0442\u043e\u0440\u0438\u0437\u0430\u0446\u0438\u044f"
+                "Авторизация"
             ],
             "url": "https://xgm.guru/user/{username}",
             "urlMain": "https://xgm.guru",
@@ -22410,8 +22254,7 @@
         },
         "Texasguntalk": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 586426,
@@ -22445,7 +22288,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "alexaRank": 588138,
             "urlMain": "https://www.prokoni.ru/",
@@ -22495,8 +22338,7 @@
         "Truthbook": {
             "urlSubpath": "/forum",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "phpBB",
             "alexaRank": 605468,
@@ -22521,7 +22363,7 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u041f\u043e\u0441\u043b\u0435\u0434\u043d\u044f\u044f \u0430\u043a\u0442\u0438\u0432\u043d\u043e\u0441\u0442\u044c"
+                "Последняя активность"
             ],
             "alexaRank": 608165,
             "urlMain": "https://mixupload.com/",
@@ -22531,8 +22373,7 @@
         },
         "Discussfastpitch": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 608236,
@@ -22547,7 +22388,7 @@
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
-                "<title>\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c</title>"
+                "<title>Пользователь</title>"
             ],
             "alexaRank": 612692,
             "urlMain": "http://www.volgogradru.com",
@@ -22593,9 +22434,7 @@
         },
         "Freelanced": {
             "tags": [
-                "freelance",
-                "in",
-                "us"
+                "freelance"
             ],
             "checkType": "status_code",
             "alexaRank": 630839,
@@ -22617,8 +22456,7 @@
         },
         "Antique-bottles": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 637600,
@@ -22690,8 +22528,7 @@
         "Smashcast": {
             "disabled": true,
             "tags": [
-                "gr",
-                "us"
+                "gr"
             ],
             "checkType": "status_code",
             "alexaRank": 660235,
@@ -22713,7 +22550,6 @@
         "DefenceForumIndia": {
             "tags": [
                 "forum",
-                "in",
                 "military"
             ],
             "engine": "XenForo",
@@ -22733,9 +22569,7 @@
             "alexaRank": 665054
         },
         "VegasCreativeSoftware": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "<title>VEGAS Community"
@@ -22755,7 +22589,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Указанного пользователя не существует"
             ],
             "alexaRank": 671960,
             "urlMain": "http://peopleandcountries.com",
@@ -22797,8 +22631,8 @@
                 "ru"
             ],
             "errors": {
-                "\u0412\u044b \u043d\u0435 \u043c\u043e\u0436\u0435\u0442\u0435 \u043f\u0440\u043e\u0438\u0437\u0432\u0435\u0441\u0442\u0438 \u043f\u043e\u0438\u0441\u043a \u0441\u0440\u0430\u0437\u0443 \u043f\u043e\u0441\u043b\u0435 \u043f\u0440\u0435\u0434\u044b\u0434\u0443\u0449\u0435\u0433\u043e": "Too many searhes per IP",
-                "\u0414\u043e\u0441\u0442\u0443\u043f \u043a \u043a\u043e\u043d\u0444\u0435\u0440\u0435\u043d\u0446\u0438\u0438 \u0437\u0430\u043a\u0440\u044b\u0442 \u0434\u043b\u044f \u0432\u0430\u0448\u0435\u0433\u043e IP-\u0430\u0434\u0440\u0435\u0441\u0430.": "IP ban"
+                "Вы не можете произвести поиск сразу после предыдущего": "Too many searhes per IP",
+                "Доступ к конференции закрыт для вашего IP-адреса.": "IP ban"
             },
             "engine": "phpBB/Search",
             "alexaRank": 687662,
@@ -22808,8 +22642,7 @@
         },
         "cowboyszone.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://cowboyszone.com",
@@ -22843,8 +22676,7 @@
         "UMHOOPS": {
             "tags": [
                 "forum",
-                "sport",
-                "us"
+                "sport"
             ],
             "engine": "Discourse",
             "urlMain": "https://forum.umhoops.com",
@@ -22865,12 +22697,11 @@
         },
         "W3challs": {
             "tags": [
-                "tn",
-                "us"
+                "tn"
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title>404 Page not found \u2013 W3Challs Hacking Challenges</title>"
+                "<title>404 Page not found – W3Challs Hacking Challenges</title>"
             ],
             "alexaRank": 702856,
             "urlMain": "https://w3challs.com/",
@@ -22906,10 +22737,10 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u0421\u0434\u0435\u043b\u0430\u0442\u044c \u043f\u043e\u0434\u0430\u0440\u043e\u043a"
+                "Сделать подарок"
             ],
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Пользователь не найден"
             ],
             "alexaRank": 706752,
             "urlMain": "https://spaces.im",
@@ -23066,8 +22897,7 @@
             "disabled": true,
             "tags": [
                 "dating",
-                "ru",
-                "us"
+                "ru"
             ],
             "checkType": "status_code",
             "alexaRank": 734363,
@@ -23088,9 +22918,7 @@
             ]
         },
         "Gentlemint": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "alexaRank": 737334,
             "urlMain": "https://gentlemint.com",
@@ -23115,10 +22943,10 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u043e\u0441\u0442\u0430\u043d\u043d\u0456\u0439 \u0432\u0456\u0437\u0438\u0442"
+                "останній візит"
             ],
             "absenceStrs": [
-                "\u0422\u0430\u043a\u043e\u0457 \u0441\u0442\u043e\u0440\u0456\u043d\u043a\u0438 \u043d\u0435 \u0456\u0441\u043d\u0443\u0454"
+                "Такої сторінки не існує"
             ],
             "urlMain": "https://kloomba.com",
             "url": "https://kloomba.com/users/{username}",
@@ -23198,7 +23026,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0420\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432 \u043f\u043e\u0438\u0441\u043a\u0430 \u043d\u0435\u0442. \u0420\u0430\u0441\u0448\u0438\u0440\u044c\u0442\u0435 \u043a\u0440\u0438\u0442\u0435\u0440\u0438\u0438 \u043f\u043e\u0438\u0441\u043a\u0430."
+                "Результатов поиска нет. Расширьте критерии поиска."
             ],
             "alexaRank": 748792,
             "urlMain": "https://carmasters.org",
@@ -23276,7 +23104,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 754218,
             "urlMain": "http://mathhelpplanet.com",
@@ -23302,7 +23130,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "alexaRank": 756066,
             "urlMain": "https://www.fishingsib.ru/",
@@ -23317,7 +23145,7 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u041f\u0440\u043e\u0441\u043c\u043e\u0442\u0440 \u043f\u0440\u043e\u0444\u0438\u043b\u044f:"
+                "Просмотр профиля:"
             ],
             "alexaRank": 759214,
             "urlMain": "https://www.forumsdrom.ru/",
@@ -23331,8 +23159,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "alexaRank": 759370
         },
@@ -23413,7 +23240,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "alexaRank": 773177,
             "urlMain": "https://maccentre.ru",
@@ -23458,7 +23285,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "По вашему запросу ничего не найдено."
             ],
             "alexaRank": 779952,
             "urlMain": "https://www.caduser.ru/",
@@ -23511,7 +23338,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "alexaRank": 802004,
             "urlMain": "https://nhl.ru",
@@ -23614,7 +23441,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 837428,
             "urlMain": "https://www.sevportal.info",
@@ -23660,9 +23487,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Hellboundhackers": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "response_url",
             "alexaRank": 841598,
             "urlMain": "https://www.hellboundhackers.org",
@@ -23673,8 +23498,7 @@
         "Caves": {
             "tags": [
                 "forum",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "XenForo",
             "alexaRank": 842010,
@@ -23703,9 +23527,7 @@
             "alexaRank": 849431
         },
         "Votetags": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 " looking for. Perhaps searching can help.",
@@ -23822,8 +23644,7 @@
         "Bayoushooter": {
             "tags": [
                 "forum",
-                "pk",
-                "us"
+                "pk"
             ],
             "engine": "XenForo",
             "alexaRank": 874364,
@@ -23852,7 +23673,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "alexaRank": 880322,
             "urlMain": "http://roboforum.ru",
@@ -23921,8 +23742,7 @@
         "Minecraft-statistic": {
             "tags": [
                 "ru",
-                "ua",
-                "us"
+                "ua"
             ],
             "checkType": "status_code",
             "alexaRank": 899627,
@@ -23948,8 +23768,7 @@
         "BitCoinForum": {
             "disabled": true,
             "tags": [
-                "forum",
-                "in"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -23978,7 +23797,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0447\u0442\u043e\u0431\u044b \u043f\u0435\u0440\u0435\u0439\u0442\u0438 \u043a \u043e\u0431\u0449\u0435\u043c\u0443 \u0441\u043f\u0438\u0441\u043a\u0443."
+                "чтобы перейти к общему списку."
             ],
             "alexaRank": 915930,
             "urlMain": "http://www.pgpru.com/",
@@ -24009,9 +23828,7 @@
             "alexaRank": 923486
         },
         "Kik": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "The page you requested was not found"
@@ -24029,7 +23846,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0417\u0430\u043f\u0440\u0430\u0448\u0438\u0432\u0430\u0435\u043c\u0430\u044f \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Запрашиваемая страница не существует"
             ],
             "alexaRank": 938357,
             "urlMain": "https://www.prizyvnik.info",
@@ -24079,7 +23896,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d"
+                "Пользователь не зарегистрирован"
             ],
             "alexaRank": 951805,
             "urlMain": "https://vezha.com/",
@@ -24132,7 +23949,7 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u0418\u043c\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Имя пользователя"
             ],
             "absenceStrs": [
                 "herdun"
@@ -24155,10 +23972,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "PulmonaryHypertensionNews": {
-            "tags": [
-                "in",
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "presenseStrs": [
                 "activity-personal-li"
@@ -24198,8 +24012,7 @@
         "Amirite": {
             "disabled": true,
             "tags": [
-                "gb",
-                "in"
+                "gb"
             ],
             "checkType": "status_code",
             "alexaRank": 976616,
@@ -24252,7 +24065,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "alexaRank": 984502,
             "urlMain": "https://seatracker.ru/",
@@ -24263,8 +24076,7 @@
         },
         "Nygunforum": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "alexaRank": 987225,
@@ -24317,7 +24129,7 @@
             "regexCheck": "^[^.]{1,}$",
             "checkType": "message",
             "absenceStrs": [
-                "\u042d\u0442\u043e\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442, \u0438\u043b\u0438 \u0437\u0430\u0431\u043b\u043e\u043a\u0438\u0440\u043e\u0432\u0430\u043d."
+                "Этот пользователь не существует, или заблокирован."
             ],
             "urlMain": "http://1001mem.ru",
             "url": "http://1001mem.ru/{username}",
@@ -24410,7 +24222,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                " \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e!"
+                " не найдено!"
             ],
             "urlMain": "https://apteka.ee",
             "url": "https://apteka.ee/user/id/{username}/",
@@ -24423,7 +24235,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d."
+                "Пользователь с таким именем не найден."
             ],
             "urlMain": "https://aback.com.ua",
             "url": "https://aback.com.ua/user/{username}",
@@ -24436,7 +24248,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "http://aboutcar.ru",
             "url": "http://aboutcar.ru/members/{username}.html",
@@ -24462,9 +24274,7 @@
         },
         "AllTheSoft": {
             "disabled": true,
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "http://www.allthesoft.com",
             "url": "http://www.allthesoft.com/member/{username}.html",
@@ -24489,7 +24299,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0442\u0430\u043a\u043e\u0433\u043e \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u0444\u043e\u0440\u0443\u043c\u0430 \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "такого участника форума не существует"
             ],
             "urlMain": "http://www.anapakurort.info",
             "url": "http://www.anapakurort.info/forum/profile.php?mode=viewprofile&u={username}",
@@ -24498,8 +24308,7 @@
         },
         "Anarcho-punk": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://www.anarcho-punk.net/",
@@ -24521,7 +24330,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u00dczg\u00fcn\u00fcz, b\u00f6yle bir kullan\u0131c\u0131 bulunmuyor"
+                "Üzgünüz, böyle bir kullanıcı bulunmuyor"
             ],
             "urlMain": "http://www.anime.web.tr/",
             "url": "http://www.anime.web.tr/yazar/{username}/",
@@ -24573,9 +24382,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Appearoo": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "response_url",
             "urlMain": "http://appearoo.com",
             "url": "http://appearoo.com/{username}",
@@ -24671,7 +24478,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "https://arhrock.info/",
             "url": "https://arhrock.info/forum/members/?username={username}",
@@ -24691,7 +24498,7 @@
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
-                "\u042d\u0442\u043e\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044c \u043b\u0438\u0431\u043e \u0431\u043e\u043b\u044c\u0448\u0435 \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442, \u043b\u0438\u0431\u043e \u0431\u043e\u043b\u044c\u0448\u0435 \u043d\u0435 \u0434\u043e\u0441\u0442\u0443\u043f\u0435\u043d."
+                "Этот профиль либо больше не существует, либо больше не доступен."
             ],
             "urlMain": "http://artpersona.org/",
             "url": "http://artpersona.org/cb/userprofile/{username}",
@@ -24719,7 +24526,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://www.astra-club.ru",
             "url": "http://www.astra-club.ru/forum/search.php?keywords=&terms=all&author={username}",
@@ -24733,7 +24540,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://www.astro-talks.ru",
             "url": "http://www.astro-talks.ru/forum/search.php?keywords=&terms=all&author={username}",
@@ -24755,7 +24562,7 @@
             "disabled": true,
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Пользователь не найден"
             ],
             "urlMain": "https://community.autolenta.ru",
             "url": "https://community.autolenta.ru/profile/{username}",
@@ -24771,7 +24578,7 @@
                 "Go to the homepage"
             ],
             "presenseStrs": [
-                "\u041f\u043e\u0441\u0442\u044b \u043e\u0442 "
+                "Посты от "
             ],
             "urlMain": "https://automania.ru",
             "url": "https://automania.ru/author/{username}/",
@@ -24808,7 +24615,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://forum.avtolyubiteli.com",
             "url": "https://forum.avtolyubiteli.com/search.php?keywords=&terms=all&author={username}",
@@ -24818,9 +24625,7 @@
         },
         "BackdoorSdslabs": {
             "disabled": true,
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
             "absenceStrs": [
@@ -24859,11 +24664,10 @@
             "tags": [
                 "forum",
                 "hacking",
-                "in",
                 "ru"
             ],
             "errors": {
-                "\u0412\u044b \u0434\u043e\u043b\u0436\u043d\u044b \u0431\u044b\u0442\u044c \u0430\u0432\u0442\u043e\u0440\u0438\u0437\u043e\u0432\u0430\u043d\u044b, \u0447\u0442\u043e\u0431\u044b \u0432\u044b\u043f\u043e\u043b\u043d\u0438\u0442\u044c \u044d\u0442\u043e \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0435 \u0438\u043b\u0438 \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0435\u0442\u044c \u044d\u0442\u0443 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443.": "Login required"
+                "Вы должны быть авторизованы, чтобы выполнить это действие или просмотреть эту страницу.": "Login required"
             },
             "engine": "XenForo",
             "urlMain": "https://xss.is",
@@ -24888,7 +24692,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442."
+                "Пользователя не существует."
             ],
             "urlMain": "https://bbshave.ru",
             "url": "https://bbshave.ru/profile/{username}",
@@ -24901,7 +24705,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://www.belmos.ru",
             "url": "https://www.belmos.ru/forum/search.php?keywords=&terms=all&author={username}",
@@ -24922,9 +24726,7 @@
         },
         "Bestfantasybooks": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "The specified member cannot be found"
@@ -24949,8 +24751,7 @@
         },
         "Bethepro": {
             "tags": [
-                "pk",
-                "us"
+                "pk"
             ],
             "disabled": true,
             "checkType": "status_code",
@@ -24972,7 +24773,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041e\u0448\u0438\u0431\u043a\u0430 / \u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Ошибка / Пользователя с таким именем не существует"
             ],
             "urlMain": "https://bgforum.ru",
             "url": "https://bgforum.ru/user/{username}/",
@@ -25022,9 +24823,7 @@
             "disabled": true
         },
         "BinarySearch": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "regexCheck": "^[a-zA-Z0-9-_]{1,15}$",
             "urlProbe": "https://binarysearch.com/api/users/{username}/profile",
             "checkType": "message",
@@ -25055,7 +24854,7 @@
                 "Niepoprawny adres."
             ],
             "presenseStrs": [
-                "Informacje og\u00f3lne"
+                "Informacje ogólne"
             ],
             "url": "https://www.blogi.pl/osoba,{username}.html",
             "usernameClaimed": "uehkon",
@@ -25081,7 +24880,7 @@
                 "- BongaCams</title>"
             ],
             "presenseStrs": [
-                "<title>Informa\u00e7\u00e3o e p\u00e1gina"
+                "<title>Informação e página"
             ],
             "checkType": "message",
             "urlMain": "https://sbongacams.com",
@@ -25092,8 +24891,7 @@
         },
         "Bookandreader": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://www.bookandreader.com",
@@ -25109,7 +24907,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f."
+                "Указанный пользователь не найден. Пожалуйста, введите другое имя."
             ],
             "urlMain": "https://boominfo.ru",
             "url": "https://boominfo.ru/members/?username={username}",
@@ -25133,7 +24931,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "http://boxing.ru/",
             "url": "http://boxing.ru/forum/member.php?username={username}",
@@ -25148,7 +24946,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "https://brute.su",
             "url": "https://brute.su/members/?username={username}",
@@ -25180,7 +24978,7 @@
         "Caringbridge": {
             "checkType": "message",
             "absenceStrs": [
-                "Sorry, we can\u2019t find that site"
+                "Sorry, we can’t find that site"
             ],
             "presenseStrs": [
                 "| CaringBridge"
@@ -25229,7 +25027,7 @@
         "CD-Action": {
             "checkType": "message",
             "absenceStrs": [
-                "Co\u015b si\u0119 popsu\u0142o..."
+                "Coś się popsuło..."
             ],
             "presenseStrs": [
                 "Lista gier:"
@@ -25241,7 +25039,7 @@
         "Cda.pl": {
             "checkType": "message",
             "absenceStrs": [
-                "Strona na kt\u00f3r\u0105 chcesz wej\u015b\u0107 nie istnieje"
+                "Strona na którą chcesz wejść nie istnieje"
             ],
             "presenseStrs": [
                 "Foldery"
@@ -25294,7 +25092,7 @@
                 "Page Not Found - Crowdin"
             ],
             "presenseStrs": [
-                ") \u2013 Crowdin"
+                ") – Crowdin"
             ],
             "url": "https://crowdin.com/profile/{username}",
             "usernameClaimed": "uehkon89",
@@ -25304,8 +25102,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "ma",
-                "us"
+                "ma"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -25380,7 +25177,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "urlMain": "http://www.chess-russia.ru",
             "url": "http://www.chess-russia.ru/profile.php?mode=viewprofile&u={username}",
@@ -25394,7 +25191,7 @@
             "disabled": true,
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "http://www.chevrolet-cruze-club.ru",
             "url": "http://www.chevrolet-cruze-club.ru/forum/member.php?username={username}",
@@ -25465,7 +25262,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "https://cyberclock.cc",
             "url": "https://cyberclock.cc/forum/member.php?username={username}",
@@ -25479,7 +25276,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "urlMain": "http://www.cydak.ru",
             "url": "http://www.cydak.ru/forum/profile.php?mode=viewprofile&u={username}",
@@ -25501,7 +25298,7 @@
         "d3.ru": {
             "checkType": "message",
             "absenceStrs": [
-                "d3.ru \u2014 \u041d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e!"
+                "d3.ru — Ничего не найдено!"
             ],
             "presenseStrs": [
                 "/user/"
@@ -25519,7 +25316,7 @@
         "Demotywatory": {
             "checkType": "message",
             "absenceStrs": [
-                "U\u017cytkownik o podanym pseudonimie nie istnieje."
+                "Użytkownik o podanym pseudonimie nie istnieje."
             ],
             "presenseStrs": [
                 "Z nami od:"
@@ -25540,11 +25337,11 @@
                 "ru"
             ],
             "errors": {
-                "\u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043f\u043e\u043f\u0440\u043e\u0431\u0443\u0439\u0442\u0435 \u0447\u0443\u0442\u044c \u043f\u043e\u0437\u0436\u0435.": "Rate limit"
+                "Пожалуйста, попробуйте чуть позже.": "Rate limit"
             },
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://www.dalnoboi.ru",
             "url": "https://www.dalnoboi.ru/phpBB3/search.php?keywords=&terms=all&author={username}",
@@ -25579,7 +25376,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0417\u0430\u043f\u0440\u0430\u0448\u0438\u0432\u0430\u0435\u043c\u0430\u044f \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430."
+                "Запрашиваемая страница не найдена."
             ],
             "urlMain": "https://derevnyaonline.ru",
             "url": "https://derevnyaonline.ru/user/{username}",
@@ -25645,7 +25442,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://dmyt.ru",
             "url": "https://dmyt.ru/forum/search.php?keywords=&terms=all&author={username}",
@@ -25664,9 +25461,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Droners": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "response_url",
             "urlMain": "https://droners.io",
             "url": "https://droners.io/accounts/{username}/",
@@ -25680,7 +25475,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d."
+                "Указанный пользователь не найден."
             ],
             "urlMain": "https://www.dublikat.shop",
             "url": "https://my.dublikat.pro/members/?username={username}",
@@ -25700,7 +25495,6 @@
         "Duno": {
             "disabled": true,
             "tags": [
-                "in",
                 "pk"
             ],
             "checkType": "message",
@@ -25763,7 +25557,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d"
+                "Пользователь не зарегистрирован"
             ],
             "urlMain": "https://enot-poloskun.ru/",
             "url": "https://enot-poloskun.ru/member.php?username={username}",
@@ -25772,8 +25566,7 @@
         },
         "Eporner": {
             "tags": [
-                "es",
-                "us"
+                "es"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -25808,7 +25601,7 @@
                 "<div class=\"blog-mainpage-item\">"
             ],
             "absenceStrs": [
-                "\u0411\u043b\u043e\u0433 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Блог не найден"
             ],
             "url": "http://esate.ru/blogs/{username}/",
             "usernameClaimed": "Flashhell",
@@ -25918,7 +25711,7 @@
         "Faktopedia": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie znaleziono u\u017cytkownika o podanym loginie."
+                "Nie znaleziono użytkownika o podanym loginie."
             ],
             "presenseStrs": [
                 "Zamieszcza fakty od:"
@@ -26100,7 +25893,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\ufeff\u042d\u0442\u043e\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044c \u043b\u0438\u0431\u043e \u0431\u043e\u043b\u044c\u0448\u0435 \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442 \u0438\u043b\u0438 \u043d\u0435 \u0434\u043e\u0441\u0442\u0443\u043f\u0435\u043d."
+                "﻿Этот профиль либо больше не существует или не доступен."
             ],
             "urlMain": "https://ficwriter.info",
             "url": "https://ficwriter.info/polzovateli/userprofile/{username}.html",
@@ -26121,9 +25914,7 @@
         "Filmwatch": {
             "tags": [
                 "ca",
-                "in",
-                "pk",
-                "us"
+                "pk"
             ],
             "checkType": "status_code",
             "urlMain": "https://filmwatch.com",
@@ -26142,7 +25933,6 @@
             "tags": [
                 "forum",
                 "ru",
-                "us",
                 "vn"
             ],
             "engine": "XenForo",
@@ -26152,7 +25942,6 @@
         },
         "Fireworktv": {
             "tags": [
-                "in",
                 "jp"
             ],
             "checkType": "message",
@@ -26185,7 +25974,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "<title>\u0418\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u044f</title>"
+                "<title>Информация</title>"
             ],
             "urlMain": "https://fm-forum.ru",
             "url": "https://fm-forum.ru/search.php?action=search&keywords=&author={username}",
@@ -26257,7 +26046,7 @@
             "urlMain": "https://forumsmotri.club",
             "url": "https://forumsmotri.club/user/{username}/",
             "presenseStrs": [
-                "\u0411\u044b\u043b \u0442\u0443\u0442"
+                "Был тут"
             ],
             "usernameClaimed": "red",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -26269,7 +26058,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "https://forumyuristov.ru/",
             "url": "https://forumyuristov.ru/members/?username={username}",
@@ -26284,7 +26073,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "По вашему запросу ничего не найдено."
             ],
             "urlMain": "https://forumreligions.ru",
             "url": "https://forumreligions.ru/search.php?action=search&keywords=&author={username}",
@@ -26340,7 +26129,7 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u0e2a\u0e21\u0e31\u0e04\u0e23\u0e2a\u0e21\u0e32\u0e0a\u0e34\u0e01\u0e40\u0e21\u0e37\u0e48\u0e2d"
+                "สมัครสมาชิกเมื่อ"
             ],
             "urlMain": "https://www.freelancebay.com",
             "url": "https://www.freelancebay.com/freelancer/{username}",
@@ -26364,7 +26153,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "title>\u0412\u044b\u0434\u0430\u044e\u0449\u0438\u0435\u0441\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u0438 | FullHub: \u0424\u043e\u0440\u0443\u043c \u043e \u043c\u043e\u0431\u0438\u043b\u044c\u043d\u044b\u0445"
+                "title>Выдающиеся пользователи | FullHub: Форум о мобильных"
             ],
             "urlMain": "https://fullhub.ru/",
             "url": "https://fullhub.ru/forum/members/?username={username}",
@@ -26378,7 +26167,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043f\u0440\u043e\u0431\u0443\u0439\u0442\u0435 \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c \u043f\u043e\u0438\u0441\u043a \u043f\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f\u043c"
+                "Попробуйте использовать поиск по пользователям"
             ],
             "urlMain": "https://furry-fandom.ru/",
             "url": "https://furry-fandom.ru/user?who={username}",
@@ -26400,12 +26189,11 @@
         "G-news": {
             "disabled": true,
             "tags": [
-                "in",
                 "ua"
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442."
+                "Пользователя не существует."
             ],
             "urlMain": "https://g-news.com.ua",
             "url": "https://g-news.com.ua/forum_smf/profile/{username}/",
@@ -26437,7 +26225,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://www.gps-forum.ru",
             "url": "http://www.gps-forum.ru/forum/search.php?keywords=&terms=all&author={username}",
@@ -26484,9 +26272,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "GaragePunk": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://www.garagepunk.com",
             "url": "https://www.garagepunk.com/profile/{username}",
@@ -26506,7 +26292,6 @@
         "Geekdoing": {
             "tags": [
                 "gr",
-                "in",
                 "ir"
             ],
             "checkType": "message",
@@ -26586,7 +26371,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0442\u0430\u043a\u043e\u0433\u043e \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u0444\u043e\u0440\u0443\u043c\u0430 \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "такого участника форума не существует"
             ],
             "urlMain": "http://gorodanapa.ru/",
             "url": "http://gorodanapa.ru/forum/profile.php?mode=viewprofile&u={username}",
@@ -26635,8 +26420,7 @@
         },
         "Gulfcoastgunforum": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://gulfcoastgunforum.com",
@@ -26646,9 +26430,7 @@
         "Gunandgame": {
             "disabled": true,
             "ignore403": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "The specified member cannot be found. Please enter a member's entire name."
@@ -26742,7 +26524,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0410\u043d\u043a\u0435\u0442\u0430 \u0443\u0434\u0430\u043b\u0435\u043d\u0430, \u0437\u0430\u0431\u043b\u043e\u043a\u0438\u0440\u043e\u0432\u0430\u043d\u0430"
+                "Анкета удалена, заблокирована"
             ],
             "urlMain": "https://www.holiday.ru",
             "url": "https://www.holiday.ru/ru/{username}",
@@ -26762,9 +26544,7 @@
         },
         "Houserepairtalk": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://www.houserepairtalk.com",
@@ -26809,9 +26589,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Ieoc": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://ieoc.com/",
             "url": "https://ieoc.com/profile/{username}",
@@ -26828,8 +26606,7 @@
         },
         "Ingunowners": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://www.ingunowners.com",
@@ -26880,7 +26657,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "https://itfy.org",
             "url": "https://itfy.org/members/?username={username}",
@@ -26890,10 +26667,10 @@
         "Jbzd": {
             "checkType": "message",
             "presenseStrs": [
-                "Dzidy u\u017cytkownika"
+                "Dzidy użytkownika"
             ],
             "absenceStrs": [
-                "B\u0142\u0105d 404"
+                "Błąd 404"
             ],
             "url": "https://jbzd.com.pl/uzytkownik/{username}",
             "usernameClaimed": "uehkon89",
@@ -26902,7 +26679,7 @@
         "Jeja.pl": {
             "checkType": "message",
             "presenseStrs": [
-                "Profil u\u017cytkownika"
+                "Profil użytkownika"
             ],
             "absenceStrs": [
                 "Niepoprawny login"
@@ -26931,7 +26708,7 @@
             "disabled": true,
             "checkType": "message",
             "absenceStrs": [
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430"
+                "Страница не найдена"
             ],
             "urlMain": "https://joby.su",
             "url": "https://joby.su/{username}/",
@@ -26941,10 +26718,10 @@
         "Joemonster": {
             "checkType": "message",
             "presenseStrs": [
-                "Aktywno\u015b\u0107 bojownicza"
+                "Aktywność bojownicza"
             ],
             "absenceStrs": [
-                "Nie wiem jak ci to powiedzie\u0107"
+                "Nie wiem jak ci to powiedzieć"
             ],
             "url": "https://joemonster.org/bojownik/{username}",
             "usernameClaimed": "uehkon89",
@@ -26971,8 +26748,7 @@
         "Juventuz": {
             "tags": [
                 "forum",
-                "sg",
-                "us"
+                "sg"
             ],
             "engine": "XenForo",
             "urlMain": "https://www.juventuz.com",
@@ -26982,10 +26758,10 @@
         "Karab.in": {
             "checkType": "message",
             "presenseStrs": [
-                "Do\u0142\u0105czy\u0142:"
+                "Dołączył:"
             ],
             "absenceStrs": [
-                "B\u0142\u0105d 404"
+                "Błąd 404"
             ],
             "url": "https://karab.in/u/{username}",
             "usernameClaimed": "uehkon89",
@@ -27051,7 +26827,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://forum.kladoiskatel.ru",
             "url": "http://forum.kladoiskatel.ru/search.php?keywords=&terms=all&author={username}",
@@ -27064,7 +26840,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "Belirtilen \u00fcye bulunamad\u0131. L\u00fctfen bir \u00fcyenin tam ad\u0131n\u0131 giriniz."
+                "Belirtilen üye bulunamadı. Lütfen bir üyenin tam adını giriniz."
             ],
             "urlMain": "https://www.kontrolkalemi.com",
             "url": "https://www.kontrolkalemi.com/forum/members/?username={username}",
@@ -27077,7 +26853,7 @@
                 "Zamieszcza kotburgery od:"
             ],
             "absenceStrs": [
-                "Nie znaleziono u\u017cytkownika o podanym loginie."
+                "Nie znaleziono użytkownika o podanym loginie."
             ],
             "url": "https://kotburger.pl/user/{username}",
             "usernameClaimed": "uehkon89",
@@ -27089,10 +26865,10 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "Kay\u0131t tarihi"
+                "Kayıt tarihi"
             ],
             "absenceStrs": [
-                "Kullan\u0131c\u0131 Detay\u0131 - Kriptom"
+                "Kullanıcı Detayı - Kriptom"
             ],
             "urlMain": "https://www.kriptom.com",
             "url": "https://www.kriptom.com/user/{username}/",
@@ -27122,7 +26898,6 @@
         },
         "Letsbeef": {
             "tags": [
-                "us",
                 "vi"
             ],
             "checkType": "message",
@@ -27136,9 +26911,7 @@
         },
         "Letschatlove": {
             "disabled": true,
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "The user whose profile you are trying to view does not exist."
@@ -27175,7 +26948,7 @@
                 "<table class=\"profil-tabl\">"
             ],
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d."
+                "Пользователь с таким именем не найден."
             ],
             "urlMain": "https://life-dom2.su",
             "url": "https://life-dom2.su/user/{username}",
@@ -27262,7 +27035,7 @@
                 "Zarejestrowany"
             ],
             "absenceStrs": [
-                "B\u0142\u0105d 404 - Podana strona nie istnieje"
+                "Błąd 404 - Podana strona nie istnieje"
             ],
             "url": "https://bazar.lowcygier.pl/user/{username}",
             "usernameClaimed": "janek",
@@ -27309,7 +27082,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://mag-portal.ru",
             "url": "https://mag-portal.ru/search.php?keywords=&terms=all&author={username}",
@@ -27334,7 +27107,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://magiimir.com",
             "url": "https://magiimir.com/forum/search.php?keywords=&terms=all&author={username}",
@@ -27390,10 +27163,10 @@
         "Marshmallow": {
             "checkType": "message",
             "absenceStrs": [
-                "\u3054\u6307\u5b9a\u306e\u30da\u30fc\u30b8\u306f\u898b\u3064\u304b\u308a\u307e\u305b\u3093\u3067\u3057\u305f"
+                "ご指定のページは見つかりませんでした"
             ],
             "presenseStrs": [
-                "\u3055\u3093\u306b\u30e1\u30c3\u30bb\u30fc\u30b8\u3092\u304a\u304f\u308b"
+                "さんにメッセージをおくる"
             ],
             "url": "https://marshmallow-qa.com/{username}",
             "usernameClaimed": "uehkon89",
@@ -27459,9 +27232,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Mcbans": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "response_url",
             "presenseStrs": [
                 "Issued Bans"
@@ -27537,7 +27308,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f."
+                "Указанный пользователь не найден. Пожалуйста, введите другое имя."
             ],
             "urlMain": "http://megane2.ru/",
             "url": "http://megane2.ru/forum/members/?username={username}",
@@ -27545,9 +27316,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "ProtonMail": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "presenseStrs": [
                 "Username already used"
@@ -27598,10 +27367,10 @@
         "Mistrzowie": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie znaleziono u\u017cytkownika o podanym loginie."
+                "Nie znaleziono użytkownika o podanym loginie."
             ],
             "presenseStrs": [
-                "Profil u\u017cytkownika"
+                "Profil użytkownika"
             ],
             "url": "https://mistrzowie.org/user/{username}",
             "usernameClaimed": "test",
@@ -27622,8 +27391,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "ru",
-                "us"
+                "ru"
             ],
             "engine": "vBulletin",
             "urlMain": "https://www.mobile-files.com/",
@@ -27645,7 +27413,6 @@
         },
         "Money-talk": {
             "tags": [
-                "in",
                 "ua"
             ],
             "errors": {
@@ -27666,7 +27433,6 @@
             "disabled": true,
             "tags": [
                 "es",
-                "in",
                 "ir"
             ],
             "checkType": "message",
@@ -27681,10 +27447,10 @@
         "Motokiller": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie znaleziono u\u017cytkownika o podanym loginie."
+                "Nie znaleziono użytkownika o podanym loginie."
             ],
             "presenseStrs": [
-                "Zamieszcza materia\u0142y od:"
+                "Zamieszcza materiały od:"
             ],
             "url": "https://mklr.pl/user/{username}",
             "usernameClaimed": "test",
@@ -27745,10 +27511,10 @@
         "Mym.fans": {
             "checkType": "message",
             "absenceStrs": [
-                "\u2022 MYM \u2022"
+                "• MYM •"
             ],
             "presenseStrs": [
-                "\u2022 MYM</title>"
+                "• MYM</title>"
             ],
             "url": "https://mym.fans/{username}",
             "usernameClaimed": "Djelizamay",
@@ -27805,8 +27571,7 @@
             "disabled": true,
             "tags": [
                 "ca",
-                "forum",
-                "us"
+                "forum"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -27823,7 +27588,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://naturalworld.guru",
             "url": "https://naturalworld.guru/forum/search.php?keywords=&terms=all&author={username}",
@@ -27842,7 +27607,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://no-jus.com",
             "url": "https://no-jus.com/search.php?keywords=&terms=all&author={username}",
@@ -27857,7 +27622,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://numizmat-forum.ru",
             "url": "https://numizmat-forum.ru/search.php?keywords=&terms=all&author={username}",
@@ -27890,10 +27655,10 @@
         "Oglaszamy24h": {
             "checkType": "message",
             "absenceStrs": [
-                "Nieprawid\u0142owy link, w bazie danych nie istnieje u\u017cytkownik o podanym loginie"
+                "Nieprawidłowy link, w bazie danych nie istnieje użytkownik o podanym loginie"
             ],
             "presenseStrs": [
-                "Profil u\u017cytkownika:"
+                "Profil użytkownika:"
             ],
             "url": "https://oglaszamy24h.pl/profil,{username}",
             "usernameClaimed": "janek",
@@ -27911,7 +27676,7 @@
         "Olx.pl": {
             "checkType": "message",
             "absenceStrs": [
-                "Przepraszamy, ale nie mo\u017cemy znale\u017a\u0107 takiej strony...",
+                "Przepraszamy, ale nie możemy znaleźć takiej strony...",
                 "Nie znaleziono"
             ],
             "presenseStrs": [
@@ -27927,7 +27692,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://onanistov.net",
             "url": "https://onanistov.net/search.php?keywords=&terms=all&author={username}",
@@ -27953,7 +27718,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://www.opelclub.ru",
             "url": "http://www.opelclub.ru/forum/search.html?keywords=&terms=all&author={username}",
@@ -27962,8 +27727,7 @@
         },
         "Otechie": {
             "tags": [
-                "finance",
-                "us"
+                "finance"
             ],
             "checkType": "message",
             "presenseStrs": [
@@ -28034,8 +27798,7 @@
         "Partyvibe": {
             "disabled": true,
             "tags": [
-                "pk",
-                "us"
+                "pk"
             ],
             "checkType": "status_code",
             "urlMain": "https://www.partyvibe.org",
@@ -28046,10 +27809,10 @@
         "Patronite": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie znale\u017ali\u015bmy strony kt\u00f3rej szukasz."
+                "Nie znaleźliśmy strony której szukasz."
             ],
             "presenseStrs": [
-                "Zosta\u0144 Patronem"
+                "Zostań Patronem"
             ],
             "url": "https://patronite.pl/{username}",
             "usernameClaimed": "radio357",
@@ -28058,7 +27821,7 @@
         "Pewex.pl": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie znaleziono u\u017cytkownika o podanym loginie."
+                "Nie znaleziono użytkownika o podanym loginie."
             ],
             "presenseStrs": [
                 "Zamieszcza eksponaty od:"
@@ -28070,7 +27833,7 @@
         "Piekielni": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie znaleziono u\u017cytkownika o podanym loginie."
+                "Nie znaleziono użytkownika o podanym loginie."
             ],
             "presenseStrs": [
                 "Zamieszcza historie od:"
@@ -28133,10 +27896,10 @@
         "Polczat.pl": {
             "checkType": "message",
             "absenceStrs": [
-                "Wybrany u\u017cytkownik nie istnieje."
+                "Wybrany użytkownik nie istnieje."
             ],
             "presenseStrs": [
-                "Historia wpis\u00f3w"
+                "Historia wpisów"
             ],
             "url": "https://polczat.pl/forum/profile/{username}/",
             "usernameClaimed": "test",
@@ -28250,7 +28013,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "http://www.prosvetlenie.org",
             "url": "http://www.prosvetlenie.org/forum/members/?username={username}",
@@ -28260,7 +28023,7 @@
         "Prv.pl": {
             "checkType": "message",
             "absenceStrs": [
-                "U\u017cytkownik nie istnieje."
+                "Użytkownik nie istnieje."
             ],
             "presenseStrs": [
                 "LOGIN"
@@ -28310,10 +28073,10 @@
             "regexCheck": "^[a-zA-Z0-9-]+$",
             "checkType": "message",
             "presenseStrs": [
-                "\u041f\u0440\u043e\u0444\u0438\u043b\u044c \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f"
+                "Профиль пользователя"
             ],
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435"
+                "Извините"
             ],
             "urlMain": "http://rcmir.com/",
             "url": "http://{username}.rcmir.com/",
@@ -28341,7 +28104,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://radio-uchebnik.ru",
             "url": "http://radio-uchebnik.ru/forum/search.php?keywords=&terms=all&author={username}",
@@ -28372,8 +28135,7 @@
             "disabled": true,
             "tags": [
                 "forum",
-                "music",
-                "us"
+                "music"
             ],
             "errors": {
                 "500 Error. Internal Server Error.": "Site error",
@@ -28423,8 +28185,7 @@
         },
         "Reincarnationforum": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "http://reincarnationforum.com",
@@ -28466,7 +28227,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "urlMain": "http://www.rngf.ru/",
             "url": "http://www.rngf.ru/profile.php?mode=viewprofile&u={username}",
@@ -28479,7 +28240,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://ro-ru.ru",
             "url": "https://ro-ru.ru/search.php?keywords=&terms=all&author={username}",
@@ -28501,10 +28262,8 @@
         "RoyalCams": {
             "tags": [
                 "gr",
-                "in",
                 "ng",
                 "ru",
-                "us",
                 "webcam"
             ],
             "headers": {
@@ -28522,7 +28281,7 @@
                 "- RoyalCams</title>"
             ],
             "presenseStrs": [
-                "<title>Informa\u00e7\u00e3o e p\u00e1gina"
+                "<title>Informação e página"
             ],
             "checkType": "message",
             "alexaRank": 134095,
@@ -28538,7 +28297,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "https://ru-sfera.org",
             "url": "https://ru-sfera.org/members/?username={username}",
@@ -28548,7 +28307,7 @@
         "Ruby.dating": {
             "checkType": "message",
             "absenceStrs": [
-                "We can\u2019t find that user"
+                "We can’t find that user"
             ],
             "presenseStrs": [
                 "Looks for:"
@@ -28612,7 +28371,7 @@
             "checkType": "message",
             "presenseStrs": [
                 "reputation_graf",
-                "\u0437\u0430\u0431\u043b\u043e\u043a\u0438\u0440\u043e\u0432\u0430\u043d"
+                "заблокирован"
             ],
             "absenceStrs": [
                 "afisha_list"
@@ -28739,7 +28498,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://sexforum.win",
             "url": "https://sexforum.win/search.php?keywords=&terms=all&author={username}",
@@ -28753,7 +28512,7 @@
                 "Brak aktywnego profilu na forum"
             ],
             "presenseStrs": [
-                "Tematy u\u017cytkownika"
+                "Tematy użytkownika"
             ],
             "url": "https://www.sfd.pl/profile/{username}",
             "usernameClaimed": "admin",
@@ -28772,9 +28531,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "ShitpostBot5000": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://www.shitpostbot.com/",
             "url": "https://www.shitpostbot.com/user/{username}",
@@ -28799,11 +28556,11 @@
                 "ru"
             ],
             "errors": {
-                "\u0412\u044b \u043d\u0435 \u043c\u043e\u0436\u0435\u0442\u0435 \u043f\u0440\u043e\u0438\u0437\u0432\u0435\u0441\u0442\u0438 \u043f\u043e\u0438\u0441\u043a \u0441\u0440\u0430\u0437\u0443 \u043f\u043e\u0441\u043b\u0435 \u043f\u0440\u0435\u0434\u044b\u0434\u0443\u0449\u0435\u0433\u043e": "Too many searhes per IP"
+                "Вы не можете произвести поиск сразу после предыдущего": "Too many searhes per IP"
             },
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://shoppingzone.ru",
             "url": "http://shoppingzone.ru/forum/search.php?keywords=&terms=all&author={username}",
@@ -28815,8 +28572,7 @@
             "disabled": true,
             "tags": [
                 "ca",
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://shotbow.net",
@@ -28825,8 +28581,7 @@
         },
         "Silver-collector": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://www.silver-collector.com",
@@ -28858,9 +28613,7 @@
         },
         "Skyrimforums": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://skyrimforums.org",
@@ -28882,8 +28635,7 @@
         "Smashrun": {
             "tags": [
                 "br",
-                "jp",
-                "us"
+                "jp"
             ],
             "checkType": "status_code",
             "urlMain": "https://smashrun.com/",
@@ -28924,7 +28676,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430"
+                "Страница не найдена"
             ],
             "urlMain": "http://www.soloby.ru",
             "url": "http://www.soloby.ru/user/{username}",
@@ -28973,9 +28725,7 @@
             "disabled": true
         },
         "Splits.io": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "status_code",
             "urlMain": "https://splits.io",
             "url": "https://splits.io/users/{username}",
@@ -28993,7 +28743,7 @@
                 "ru"
             ],
             "presenseStrs": [
-                " <b>\u0418\u043c\u044f: "
+                " <b>Имя: "
             ],
             "engine": "uCoz",
             "urlMain": "http://stalker-zone.info",
@@ -29076,9 +28826,7 @@
             ]
         },
         "Subeta": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "Invalid user"
@@ -29095,7 +28843,7 @@
                 "<title>404 | SUZURI</title>"
             ],
             "presenseStrs": [
-                "\u221e SUZURI\uff08\u30b9\u30ba\u30ea\uff09</title>"
+                "∞ SUZURI（スズリ）</title>"
             ],
             "url": "https://suzuri.jp/{username}",
             "usernameClaimed": "alex",
@@ -29126,7 +28874,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0422\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442."
+                "Такого пользователя не существует."
             ],
             "urlMain": "http://syktforum.ru",
             "url": "http://syktforum.ru/profile/{username}",
@@ -29138,7 +28886,7 @@
                 "ru"
             ],
             "errors": {
-                "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u0431\u0443\u0434\u0435\u0442 \u0434\u043e\u0441\u0442\u0443\u043f\u043d\u0430 \u0447\u0435\u0440\u0435\u0437 \u043d\u0435\u0441\u043a\u043e\u043b\u044c\u043a\u043e \u0441\u0435\u043a\u0443\u043d\u0434": "Verification redirect page"
+                "Страница будет доступна через несколько секунд": "Verification redirect page"
             },
             "checkType": "message",
             "absenceStrs": [
@@ -29157,7 +28905,7 @@
                 "Nie masz jeszcze konta?"
             ],
             "presenseStrs": [
-                "Profil u\u017cytkownika"
+                "Profil użytkownika"
             ],
             "url": "https://www.szerokikadr.pl/profil,{username}",
             "usernameClaimed": "janek",
@@ -29178,10 +28926,10 @@
         "Tanuki.pl": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie ma takiego u\u017cytkownika"
+                "Nie ma takiego użytkownika"
             ],
             "presenseStrs": [
-                "Do\u0142\u0105czy\u0142"
+                "Dołączył"
             ],
             "url": "https://tanuki.pl/profil/{username}",
             "usernameClaimed": "ania",
@@ -29193,7 +28941,7 @@
                 "<title>TaskRabbit: Same Day Handyman, Moving & Delivery Services</title>"
             ],
             "presenseStrs": [
-                "\u2019s Profile"
+                "’s Profile"
             ],
             "url": "https://www.taskrabbit.com/profile/{username}/about",
             "usernameClaimed": "john",
@@ -29282,7 +29030,7 @@
         "Thegatewaypundit": {
             "checkType": "message",
             "absenceStrs": [
-                "Oops! That page can\u2019t be found."
+                "Oops! That page can’t be found."
             ],
             "presenseStrs": [
                 "avatar avatar-50 photo"
@@ -29294,7 +29042,7 @@
         "Thetattooforum": {
             "checkType": "message",
             "absenceStrs": [
-                "We\u2019re sorry"
+                "We’re sorry"
             ],
             "presenseStrs": [
                 "Insert This Gallery"
@@ -29338,9 +29086,7 @@
         },
         "Thedaftclub": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "This user has not registered and therefore does not have a profile to view."
@@ -29366,9 +29112,7 @@
         },
         "TikTok Online Viewer": {
             "disabled": true,
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "errors": {
                 "Website unavailable": "Site error",
                 "is currently offline": "Site error"
@@ -29411,7 +29155,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "https://totalstavki.ru",
             "url": "https://totalstavki.ru/forum/members/?username={username}",
@@ -29453,9 +29197,7 @@
         },
         "Travis": {
             "tags": [
-                "forum",
-                "in",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://travis-ci.community",
@@ -29501,10 +29243,10 @@
         "Twpro.jp": {
             "checkType": "message",
             "absenceStrs": [
-                "\u3092\u3054\u78ba\u8a8d\u304f\u3060\u3055\u3044\u3002"
+                "をご確認ください。"
             ],
             "presenseStrs": [
-                "\u304a\u3068\u306a\u308a\u3055\u3093"
+                "おとなりさん"
             ],
             "url": "https://twpro.jp/{username}",
             "usernameClaimed": "wsise47",
@@ -29513,7 +29255,7 @@
         "ultrasdiary.pl": {
             "checkType": "message",
             "absenceStrs": [
-                "<title>UltrasDiary &#8211; Pami\u0119tnik Kibica</title>"
+                "<title>UltrasDiary &#8211; Pamiętnik Kibica</title>"
             ],
             "presenseStrs": [
                 "Mecze wyjazdowe:"
@@ -29586,7 +29328,7 @@
                 "Ostatnie komentarze"
             ],
             "presenseStrs": [
-                "Profil u\u017cytkownika"
+                "Profil użytkownika"
             ],
             "url": "https://vizjer.pl/uzytkownik/{username}",
             "usernameClaimed": "janek",
@@ -29726,9 +29468,7 @@
             "usernameUnclaimed": "noonewouldusethis7"
         },
         "Wittyprofiles": {
-            "tags": [
-                "in"
-            ],
+            "tags": [],
             "checkType": "message",
             "absenceStrs": [
                 "It looks like you are looking for something that isn't here."
@@ -29741,10 +29481,10 @@
         "WolniSlowianie": {
             "checkType": "message",
             "absenceStrs": [
-                "Nie znaleziono strony, kt\u00f3rej szukasz."
+                "Nie znaleziono strony, której szukasz."
             ],
             "presenseStrs": [
-                "O\u015b czasu"
+                "Oś czasu"
             ],
             "url": "https://wolnislowianie.pl/{username}",
             "usernameClaimed": "janek",
@@ -29781,7 +29521,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d"
+                "Пользователь не зарегистрирован"
             ],
             "urlMain": "https://forum.wotanks.com",
             "url": "https://forum.wotanks.com/member.php/?username={username}",
@@ -29808,7 +29548,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                "Указанный пользователь не найден"
             ],
             "urlMain": "http://wuz.by",
             "url": "http://wuz.by/forum/members/?username={username}",
@@ -29855,7 +29595,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://www.yalta-info.net",
             "url": "http://www.yalta-info.net/search.php?keywords=&terms=all&author={username}",
@@ -29899,7 +29639,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "http://zapravdu.ru/",
             "url": "http://zapravdu.ru/forum/search.php?author={username}",
@@ -29953,10 +29693,10 @@
         "Zmarsa.com": {
             "checkType": "message",
             "absenceStrs": [
-                "B\u0142\u0105d na stronie"
+                "Błąd na stronie"
             ],
             "presenseStrs": [
-                "Galeria u\u017cytkownika"
+                "Galeria użytkownika"
             ],
             "url": "https://zmarsa.com/uzytkownik/{username}/glowna/",
             "usernameClaimed": "test",
@@ -30193,7 +29933,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e \u0432\u0430\u0448\u0435\u043c\u0443 \u0437\u0430\u043f\u0440\u043e\u0441\u0443 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "По вашему запросу ничего не найдено."
             ],
             "urlMain": "https://forum-b.ru",
             "url": "https://forum-b.ru/search.php?action=search&keywords=&author={username}",
@@ -30227,7 +29967,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0442\u0430\u043a\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442"
+                "Извините, такого пользователя не существует"
             ],
             "urlMain": "http://forum.garminych.ru/",
             "url": "http://forum.garminych.ru/profile.php?mode=viewprofile&u={username}",
@@ -30341,7 +30081,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                "Подходящих тем или сообщений не найдено."
             ],
             "urlMain": "https://forum.lithotherapy.ru",
             "url": "https://forum.lithotherapy.ru/search.php?keywords=&terms=all&author={username}",
@@ -30387,7 +30127,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "https://forum.modnaya.org/",
             "url": "https://forum.modnaya.org/members/{username}.html",
@@ -30578,7 +30318,8 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum"
+                "forum",
+                "fr"
             ]
         },
         "relasko.ru": {
@@ -30611,7 +30352,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430."
+                "Пользователь не зарегистрирован и не имеет профиля для просмотра."
             ],
             "urlMain": "https://forum.ruboard.ru",
             "url": "https://forum.ruboard.ru/member.php/?username={username}",
@@ -30695,8 +30436,7 @@
         },
         "sourceruns": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "Discourse",
             "urlMain": "https://forums.sourceruns.org/",
@@ -30713,9 +30453,7 @@
             ]
         },
         "Orbys": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "checkType": "message",
             "presenseStrs": [
                 "profile_user_image"
@@ -30730,8 +30468,7 @@
         },
         "sportsjournalists.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "http://sportsjournalists.com/forum/",
@@ -30790,7 +30527,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c, \u0447\u0435\u0439 \u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0432\u044b \u043f\u044b\u0442\u0430\u0435\u0442\u0435\u0441\u044c \u043f\u043e\u0441\u043c\u043e\u0442\u0440\u0435\u0442\u044c, \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442."
+                "Пользователь, чей профиль вы пытаетесь посмотреть, не существует."
             ],
             "urlMain": "https://forum.theprodigy.ru/",
             "url": "https://forum.theprodigy.ru/index.php?board=13&action=viewprofile&user={username}",
@@ -30799,8 +30536,7 @@
         },
         "theturboforums.com": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://www.theturboforums.com/forums/",
@@ -32319,9 +32055,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "linuxpip.org": {
-            "tags": [
-                "us"
-            ],
+            "tags": [],
             "engine": "Wordpress/Author",
             "urlMain": "https://linuxpip.org",
             "usernameClaimed": "diehard",
@@ -32333,7 +32067,7 @@
                 "post_feed_title"
             ],
             "absenceStrs": [
-                "<h1>\u041e\u0448\u0438\u0431\u043a\u0430</h1>"
+                "<h1>Ошибка</h1>"
             ],
             "urlMain": "https://webonrails.ru",
             "url": "https://webonrails.ru/user/{username}/",
@@ -32356,8 +32090,7 @@
         },
         "universemc.us": {
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ],
             "engine": "XenForo",
             "urlMain": "https://universemc.us",
@@ -32421,7 +32154,7 @@
                 " name="
             ],
             "absenceStrs": [
-                "<html><head><title>404 \u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430</title></head><body><h2>404 \u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430</h2></body></html>"
+                "<html><head><title>404 Страница не найдена</title></head><body><h2>404 Страница не найдена</h2></body></html>"
             ],
             "urlMain": "https://wblitz.net",
             "url": "https://wblitz.net/stat/ru/{username}",
@@ -32475,7 +32208,7 @@
                 " usertotalposts"
             ],
             "absenceStrs": [
-                "<title>\u041e\u0448\u0438\u0431\u043a\u0430</title>"
+                "<title>Ошибка</title>"
             ],
             "urlMain": "https://pikabu.monster",
             "url": "https://pikabu.monster/user/{username}-summary",
@@ -32695,8 +32428,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
-                "forum",
-                "us"
+                "forum"
             ]
         },
         "egiki.ru": {
@@ -32839,9 +32571,7 @@
             "engine": "Flarum",
             "usernameClaimed": "admin",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "tags": [
-                "in"
-            ]
+            "tags": []
         },
         "forumbebas.com": {
             "urlMain": "https://forumbebas.com",
@@ -32981,7 +32711,7 @@
         "forum.rastrnet.ru": {
             "urlMain": "http://forum.rastrnet.ru",
             "errors": {
-                "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u043f\u0440\u043e\u0432\u043e\u0434\u044f\u0442\u0441\u044f \u0442\u0435\u0445\u043d\u0438\u0447\u0435\u0441\u043a\u0438\u0435 \u0440\u0430\u0431\u043e\u0442\u044b.": "Site error"
+                "Извините, проводятся технические работы.": "Site error"
             },
             "engine": "vBulletin",
             "usernameClaimed": "alex",
@@ -33035,7 +32765,7 @@
             "urlSubpath": "/forum",
             "urlMain": "https://mindmachine.ru/",
             "engine": "phpBB/Search",
-            "usernameClaimed": "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440_",
+            "usernameClaimed": "Александр_",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "tags": [
                 "forum"
@@ -33552,7 +33282,7 @@
                 "btn_label"
             ],
             "presenseStrs": [
-                "<title>\u0422\u0435\u043b\u0435\u0433\u0440\u0430\u043c \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c"
+                "<title>Телеграм пользователь"
             ],
             "url": "https://tg.rip/{username}",
             "urlMain": "https://tg.rip",
@@ -34373,8 +34103,7 @@
         },
         "uviu.com": {
             "tags": [
-                "porn",
-                "us"
+                "porn"
             ],
             "checkType": "message",
             "absenceStrs": [
@@ -35228,8 +34957,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "checkType": "message",
             "tags": [
-                "streaming",
-                "us"
+                "streaming"
             ]
         },
         "instaprofi.ru": {
@@ -35319,10 +35047,10 @@
             ],
             "checkType": "message",
             "presenseStrs": [
-                "\u00daltima conexi\u00f3n"
+                "Última conexión"
             ],
             "absenceStrs": [
-                "No se ha encontrado ning\u00fan usuario con ese nombre"
+                "No se ha encontrado ningún usuario con ese nombre"
             ],
             "url": "https://stats.universocraft.com/stats.php?player={username}",
             "usernameClaimed": "adam",
@@ -35673,7 +35401,7 @@
                 "h5 text-uppercase",
                 "<h2 class=",
                 "h5",
-                ">\u041f\u043e\u0441\u043c\u043e\u0442\u0440\u0438 \u0432\u0438\u0434\u0435\u043e\u0447\u0430\u0442 \u0434\u0440\u0443\u0433\u0438\u0445 \u043c\u043e\u0434\u0435\u043b\u0435\u0439.</div>",
+                ">Посмотри видеочат других моделей.</div>",
                 ">\t<h1 class="
             ],
             "url": "https://chaturbator.su/{username}?pagespeed=noscript",
@@ -36072,13 +35800,16 @@
             "usernameClaimed": "paulpfeister",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 6,
-            "requestMethod": "GET"
+            "requestMethod": "GET",
+            "tags": [
+                "social",
+                "professional"
+            ]
         },
         "PentesterLab": {
             "checkType": "status_code",
             "tags": [
-                "hacking",
-                "us"
+                "hacking"
             ],
             "url": "https://pentesterlab.com/profile/{username}",
             "urlMain": "https://pentesterlab.com/",
@@ -36091,8 +35822,7 @@
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
             },
             "tags": [
-                "hacking",
-                "us"
+                "hacking"
             ],
             "url": "https://ctftime.org/team/{username}",
             "urlMain": "https://ctftime.org/",
@@ -36108,13 +35838,13 @@
                 "absenceStrs": [
                     "The requested page could not be found.",
                     "The specified member cannot be found. Please enter a member",
-                    "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f.",
-                    "Le membre sp\u00e9cifi\u00e9 est introuvable. Veuillez saisir le nom complet d'un membre.",
-                    "Belirtilen \u00fcye bulunamad\u0131. L\u00fctfen bir \u00fcyenin tam ad\u0131n\u0131 giriniz."
+                    "Указанный пользователь не найден. Пожалуйста, введите другое имя.",
+                    "Le membre spécifié est introuvable. Veuillez saisir le nom complet d'un membre.",
+                    "Belirtilen üye bulunamadı. Lütfen bir üyenin tam adını giriniz."
                 ],
                 "presenseStrs": [
-                    "\u0412\u044b \u0434\u043e\u043b\u0436\u043d\u044b \u0431\u044b\u0442\u044c \u0430\u0432\u0442\u043e\u0440\u0438\u0437\u043e\u0432\u0430\u043d\u044b, \u0447\u0442\u043e\u0431\u044b \u0432\u044b\u043f\u043e\u043b\u043d\u0438\u0442\u044c \u044d\u0442\u043e \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0435 \u0438\u043b\u0438 \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0435\u0442\u044c \u044d\u0442\u0443 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443.",
-                    "\u0414\u043b\u044f \u0442\u043e\u0433\u043e, \u0447\u0442\u043e\u0431\u044b \u044d\u0442\u043e \u0441\u0434\u0435\u043b\u0430\u0442\u044c, \u043d\u0443\u0436\u043d\u043e \u0441\u043d\u0430\u0447\u0430\u043b\u0430 \u0432\u043e\u0439\u0442\u0438 \u043d\u0430 \u0444\u043e\u0440\u0443\u043c.",
+                    "Вы должны быть авторизованы, чтобы выполнить это действие или просмотреть эту страницу.",
+                    "Для того, чтобы это сделать, нужно сначала войти на форум.",
                     "You must be logged-in to do that.",
                     "You must be logged in to do that.",
                     "memberHeader-content",
@@ -36131,7 +35861,7 @@
             "name": "phpBB/Search",
             "site": {
                 "absenceStrs": [
-                    "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e."
+                    "Подходящих тем или сообщений не найдено."
                 ],
                 "presenseStrs": [
                     "postprofile",
@@ -36149,7 +35879,7 @@
             "site": {
                 "absenceStrs": [
                     "No members found for this search criterion.",
-                    "\u041d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e \u043d\u0438 \u043e\u0434\u043d\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f \u043f\u043e \u0437\u0430\u0434\u0430\u043d\u043d\u044b\u043c \u043a\u0440\u0438\u0442\u0435\u0440\u0438\u044f\u043c"
+                    "Не найдено ни одного пользователя по заданным критериям"
                 ],
                 "presenseStrs": [
                     "You must be logged in to do that.",
@@ -36166,7 +35896,7 @@
             "name": "phpBB2/Search",
             "site": {
                 "absenceStrs": [
-                    "\u041f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u0445 \u0442\u0435\u043c \u0438\u043b\u0438 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e"
+                    "Подходящих тем или сообщений не найдено"
                 ],
                 "presenseStrs": [
                     "\"postdetails"
@@ -36183,18 +35913,18 @@
             "site": {
                 "absenceStrs": [
                     "<title>HTTP 404",
-                    "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d"
+                    "Пользователь не найден"
                 ],
                 "presenseStrs": [
-                    "udtlb\">\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c:</div>",
-                    "\u0413\u043e\u0441\u0442\u044f\u043c \u0437\u0430\u043f\u0440\u0435\u0449\u0435\u043d\u043e \u043f\u0440\u043e\u0441\u043c\u0430\u0442\u0440\u0438\u0432\u0430\u0442\u044c \u0434\u0430\u043d\u043d\u0443\u044e \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443, \u043f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430 \u0432\u043e\u0439\u0434\u0438\u0442\u0435 \u043d\u0430 \u0441\u0430\u0439\u0442 \u043a\u0430\u043a \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c.",
-                    "<center><b>\u041b\u0438\u0447\u043d\u044b\u0435 \u0434\u0430\u043d\u043d\u044b\u0435</b>",
-                    "\u0413\u043e\u0441\u0442\u044f\u043c \u0437\u0430\u043f\u0440\u0435\u0449\u0435\u043d\u043e \u043f\u0440\u043e\u0441\u043c\u0430\u0442\u0440\u0438\u0432\u0430\u0442\u044c \u0434\u0430\u043d\u043d\u0443\u044e \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443, \u043f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u043e\u0439\u0434\u0438\u0442\u0435 \u043d\u0430 \u0441\u0430\u0439\u0442 \u043a\u0430\u043a \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c.",
+                    "udtlb\">Пользователь:</div>",
+                    "Гостям запрещено просматривать данную страницу, пожалуйста войдите на сайт как пользователь.",
+                    "<center><b>Личные данные</b>",
+                    "Гостям запрещено просматривать данную страницу, пожалуйста, войдите на сайт как пользователь.",
                     "<img alt=\"\" name=\"rankimg\" border=\"0\" src=\"/.s/rnk/",
-                    "\u0413\u043e\u0441\u0442\u044f\u043c \u0437\u0430\u043f\u0440\u0435\u0449\u0435\u043d\u043e \u043f\u0440\u043e\u0441\u043c\u0430\u0442\u0440\u0438\u0432\u0430\u0442\u044c \u043f\u0435\u0440\u0441\u043e\u043d\u0430\u043b\u044c\u043d\u044b\u0435 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u044b \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u0435\u0439.",
+                    "Гостям запрещено просматривать персональные страницы пользователей.",
                     "profile-section-name",
                     "webo4ka_dannii",
-                    "\u0414\u0430\u0442\u0430 \u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u0438"
+                    "Дата регистрации"
                 ],
                 "checkType": "message",
                 "regexCheck": "^[^\\.]+$",
@@ -36205,19 +35935,19 @@
             "name": "vBulletin",
             "site": {
                 "absenceStrs": [
-                    "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430.",
-                    "Bu \u00dcye kay\u0131tl\u0131 \u00dcyemiz de\u011fildir. Bu sebebten dolay\u0131 \u00dcyeye ait Profil g\u00f6sterilemiyor.",
+                    "Пользователь не зарегистрирован и не имеет профиля для просмотра.",
+                    "Bu Üye kayıtlı Üyemiz değildir. Bu sebebten dolayı Üyeye ait Profil gösterilemiyor.",
                     "This user has not registered and therefore does not have a profile to view.",
-                    "\u041a\u043e\u0440\u0438\u0441\u0442\u0443\u0432\u0430\u0447 \u043d\u0435 \u0437\u0430\u0440\u0435\u0454\u0441\u0442\u0440\u043e\u0432\u0430\u043d\u0438\u0439 \u0456 \u043d\u0435 \u043c\u0430\u0454 \u043f\u0440\u043e\u0444\u0456\u043b\u044e, \u044f\u043a\u0438\u0439 \u043c\u043e\u0436\u043d\u0430 \u043f\u0435\u0440\u0435\u0433\u043b\u044f\u043d\u0443\u0442\u0438.",
+                    "Користувач не зареєстрований і не має профілю, який можна переглянути.",
                     "Deze gebruiker is niet geregistreerd, zodat je zijn of haar profiel niet kunt bekijken.",
-                    "\u042d\u0442\u043e\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0435\u0449\u0451 \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d, \u043f\u043e\u044d\u0442\u043e\u043c\u0443 \u0435\u0433\u043e \u043f\u0440\u043e\u0444\u0438\u043b\u044c \u043d\u0435\u0434\u043e\u0441\u0442\u0443\u043f\u0435\u043d."
+                    "Этот пользователь ещё не зарегистрирован, поэтому его профиль недоступен."
                 ],
                 "checkType": "message",
                 "errors": {
-                    "\u041f\u0440\u043e\u0441\u0442\u0438\u0442\u0435, \u043d\u043e \u0432\u0430\u0448 IP \u0432 \u0441\u043f\u0438\u0441\u043a\u0435 \u0437\u0430\u043f\u0440\u0435\u0449\u0435\u043d\u043d\u044b\u0445 \u0430\u0434\u043c\u0438\u043d\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u0435\u0439 \u0444\u043e\u0440\u0443\u043c\u0430": "IP ban",
+                    "Простите, но ваш IP в списке запрещенных администрацией форума": "IP ban",
                     "You have been banned": "IP ban",
                     "The administrator has banned your IP address": "IP ban",
-                    "\u0418\u0437\u0432\u0438\u043d\u0438\u0442\u0435, \u0441\u0435\u0440\u0432\u0435\u0440 \u043f\u0435\u0440\u0435\u0433\u0440\u0443\u0436\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043f\u043e\u043f\u0440\u043e\u0431\u0443\u0439\u0442\u0435 \u0437\u0430\u0439\u0442\u0438 \u043f\u043e\u0437\u0436\u0435.": "Server is overloaded"
+                    "Извините, сервер перегружен. Пожалуйста, попробуйте зайти позже.": "Server is overloaded"
                 },
                 "url": "{urlMain}{urlSubpath}/member.php?username={username}"
             },
@@ -36232,7 +35962,7 @@
                     "<meta name=\"generator\" content=\"Discourse"
                 ],
                 "absenceStrs": [
-                    "Oops! That page doesn\u2019t exist or is private.",
+                    "Oops! That page doesn’t exist or is private.",
                     "wrap not-found-container"
                 ],
                 "checkType": "message",
@@ -36322,68 +36052,73 @@
         }
     },
     "tags": [
-        "gaming",
-        "coding",
-        "photo",
-        "music",
-        "blog",
-        "finance",
-        "freelance",
-        "dating",
-        "tech",
-        "forum",
-        "porn",
-        "erotic",
-        "webcam",
-        "video",
-        "movies",
-        "hacking",
-        "art",
-        "discussion",
-        "sharing",
-        "writing",
-        "wiki",
-        "business",
-        "shopping",
-        "sport",
-        "books",
-        "news",
-        "documents",
-        "travel",
-        "maps",
-        "hobby",
+        "3d",
+        "anime",
         "apps",
-        "classified",
-        "career",
-        "geosocial",
-        "streaming",
-        "education",
-        "networking",
-        "torrent",
-        "science",
-        "medicine",
-        "reading",
-        "stock",
-        "messaging",
-        "trading",
-        "links",
-        "fashion",
-        "tasks",
-        "military",
+        "archive",
+        "art",
         "auto",
-        "gambling",
-        "cybercriminal",
-        "review",
+        "blog",
         "bookmarks",
-        "design",
-        "tor",
-        "i2p",
-        "q&a",
+        "books",
+        "business",
+        "career",
+        "classified",
+        "coding",
         "crypto",
-        "ai",
-        "mastodon",
-        "writefreely",
+        "cybercriminal",
+        "dating",
+        "design",
+        "discussion",
+        "documents",
+        "education",
+        "erotic",
+        "fashion",
+        "finance",
+        "forum",
+        "freelance",
+        "gambling",
+        "gaming",
+        "geosocial",
+        "hacking",
+        "hobby",
+        "i2p",
         "lemmy",
-        "pixelfed"
+        "links",
+        "llm",
+        "maps",
+        "mastodon",
+        "medicine",
+        "messaging",
+        "military",
+        "movies",
+        "music",
+        "networking",
+        "news",
+        "nft",
+        "photo",
+        "porn",
+        "professional",
+        "q&a",
+        "reading",
+        "research",
+        "review",
+        "science",
+        "sharing",
+        "shopping",
+        "social",
+        "sport",
+        "stock",
+        "streaming",
+        "tasks",
+        "tech",
+        "tor",
+        "torrent",
+        "trading",
+        "travel",
+        "video",
+        "webcam",
+        "wiki",
+        "writing"
     ]
 }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,6 +4,30 @@ import pytest
 from maigret.utils import is_country_tag
 
 
+TOP_SITES_ALEXA_RANK_LIMIT = 50
+
+KNOWN_SOCIAL_DOMAINS = [
+    "facebook.com",
+    "instagram.com",
+    "twitter.com",
+    "tiktok.com",
+    "vk.com",
+    "reddit.com",
+    "pinterest.com",
+    "snapchat.com",
+    "linkedin.com",
+    "tumblr.com",
+    "threads.net",
+    "bsky.app",
+    "myspace.com",
+    "weibo.com",
+    "mastodon.social",
+    "gab.com",
+    "minds.com",
+    "clubhouse.com",
+]
+
+
 @pytest.mark.slow
 def test_tags_validity(default_db):
     unknown_tags = set()
@@ -19,3 +43,62 @@ def test_tags_validity(default_db):
     # if you see "unchecked" tag error, please, do
     # maigret --db `pwd`/maigret/resources/data.json --self-check --tag unchecked --use-disabled-sites
     assert unknown_tags == set()
+
+
+@pytest.mark.slow
+def test_top_sites_have_category_tag(default_db):
+    """Top sites by alexaRank must have at least one category tag (not just country codes)."""
+    sites_ranked = sorted(
+        [s for s in default_db.sites if s.alexa_rank],
+        key=lambda s: s.alexa_rank,
+    )[:TOP_SITES_ALEXA_RANK_LIMIT]
+
+    missing_category = []
+    for site in sites_ranked:
+        category_tags = [t for t in site.tags if not is_country_tag(t)]
+        if not category_tags:
+            missing_category.append(f"{site.name} (rank {site.alexa_rank})")
+
+    assert missing_category == [], (
+        f"{len(missing_category)} top-{TOP_SITES_ALEXA_RANK_LIMIT} sites have no category tag: "
+        + ", ".join(missing_category[:20])
+    )
+
+
+@pytest.mark.slow
+def test_no_unused_tags_in_registry(default_db):
+    """Every tag in the registry should be used by at least one site."""
+    all_used_tags = set()
+    for site in default_db.sites:
+        for tag in site.tags:
+            if not is_country_tag(tag):
+                all_used_tags.add(tag)
+
+    registered_tags = set(default_db._tags)
+    unused = registered_tags - all_used_tags
+
+    assert unused == set(), f"Tags registered but not used by any site: {unused}"
+
+
+@pytest.mark.slow
+def test_social_networks_have_social_tag(default_db):
+    """Known social network domains must have the 'social' tag."""
+    from urllib.parse import urlparse
+
+    missing_social = []
+    for site in default_db.sites:
+        url = site.url_main or ""
+        try:
+            hostname = urlparse(url).hostname or ""
+        except Exception:
+            continue
+        for domain in KNOWN_SOCIAL_DOMAINS:
+            if hostname == domain or hostname.endswith("." + domain):
+                if "social" not in site.tags:
+                    missing_social.append(f"{site.name} ({domain})")
+                break
+
+    assert missing_social == [], (
+        f"{len(missing_social)} known social networks missing 'social' tag: "
+        + ", ".join(missing_social)
+    )


### PR DESCRIPTION
- Added social tag to social networks (33 sites)
- Fixed wrong tags (8 sites)
- Filled empty tags for 213 sites in top-1000
- Country tag cleanup (~374 sites)
- Site naming normalization (75 sites)
- New tests (3)
- Documentation updates