### PR TITLE
fix(data): update InterPals absence string to match current site response

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -13655,7 +13655,7 @@
             ],
             "checkType": "message",
             "absenceStrs": [
-                "The requested user does not exist or is inactive"
+                "User not found"
             ],
             "alexaRank": 46998,
             "urlMain": "https://www.interpals.net/",
@@ -29285,6 +29285,7 @@
             "usernameClaimed": "alex",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
+
         "izmailonline.com": {
             "tags": [
                 "ua"


### PR DESCRIPTION
## Problem

InterPals was reporting false positives — claiming users exist when they do not (issue #2433).

The site returns HTTP 200 for both existing and non-existing users, so detection relies entirely on page content matching.

## Root Cause

The previous absence string `The requested user does not exist or is inactive` no longer matches what interpals.net returns for non-existent profiles.

## Fix

Updated `absenceStrs` to match the current site response:

```diff
- "The requested user does not exist or is inactive"
+ "User not found"
```

## Testing

Manually verified against live site:
- `interpals.net/noneownsthisusername` → returns "User not found" ✓ (correctly detected as absent)
- `interpals.net/blue` → returns user profile ✓ (correctly detected as claimed)

Fixes #2433