### PR TITLE
Fix ID extraction crash when regex groups are optional

### DIFF
--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -214,7 +214,6 @@ class MaigretSite:
         )
         if _id is None:
             return None
-        _id = match_groups.groups()[-1].rstrip("/")
         _type = self.type
 
         return _id, _type

--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -181,7 +181,15 @@ class MaigretSite:
         if self.url_regexp:
             match_groups = self.url_regexp.match(url)
             if match_groups:
-                return match_groups.groups()[-1].rstrip("/")
+                username = next(
+                    (
+                        group.rstrip("/")
+                        for group in reversed(match_groups.groups())
+                        if isinstance(group, str) and group
+                    ),
+                    None,
+                )
+                return username
 
         return None
 
@@ -196,7 +204,16 @@ class MaigretSite:
         match_groups = self.url_regexp.match(url)
         if not match_groups:
             return None
-
+        _id = next(
+            (
+                group.rstrip("/")
+                for group in reversed(match_groups.groups())
+                if isinstance(group, str) and group
+            ),
+            None,
+        )
+        if _id is None:
+            return None
         _id = match_groups.groups()[-1].rstrip("/")
         _type = self.type
 

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,5 +1,7 @@
 """Maigret Database test functions"""
 
+import re
+
 from typing import Any, Dict
 
 from maigret.sites import MaigretDatabase, MaigretSite
@@ -123,6 +125,22 @@ def test_site_url_detector():
     assert (
         db.sites[0].detect_username('http://forum.amperka.ru/members/?username=test')
         == 'test'
+    )
+
+
+def test_extract_id_from_url_skips_none_groups():
+    site = MaigretSite(
+        "Example",
+        {
+            "urlMain": "https://example.com",
+            "url": "https://example.com/{username}",
+        },
+    )
+    site.url_regexp = re.compile(r"^https://example\.com/([^/?#]+)(?:/(.*))?$")
+
+    assert site.extract_id_from_url("https://example.com/username") == (
+        "username",
+        "username",
     )
 
 


### PR DESCRIPTION
Fix crash that occurred during ID extraction when regex groups were optional.