### PR TITLE
fix: disable RomanticCollection check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -18539,7 +18539,8 @@
             "urlMain": "https://www.romanticcollection.ru",
             "url": "https://www.romanticcollection.ru/forum/search.php?keywords=&terms=all&author={username}",
             "usernameClaimed": "Prim@",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "disabled": true
         },
         "HSX": {
             "checkType": "message",

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-04-29T14:56:55Z",
+    "updated_at": "2026-05-02T12:32:02Z",
     "sites_count": 3157,
     "min_maigret_version": "0.6.0",
-    "data_sha256": "5dac8f1c045ea650d5872cf9dfd7f224410eaadba0f2b7eb60514cc51ba0097a",
+    "data_sha256": "6952bb4eddec6dc02c67a41581fc0a31bb49ea20ca36747ecc5f0ee5bbb9eb4c",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }


### PR DESCRIPTION
## Summary

Disables the RomanticCollection site check. The current probe uses the forum search endpoint, which now returns a successful HTTP response for rate-limit/anti-automation messages as well as normal search responses. When the expected absence text is not present, random usernames can be reported as claimed.

## Verification

- Reproduced the issue against `https://www.romanticcollection.ru/forum/search.php?...&author=noonewouldeverusethis7`
- Observed HTTP 200 with a forum message asking to wait before searching again
- Validated `maigret/resources/data.json` with `python3 -m json.tool`

Closes #2587