### PR TITLE
Fix network graph height to be viewport-responsive instead of fixed 750px

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -245,7 +245,7 @@ def save_graph_report(filename: str, username_results: list, db: MaigretDatabase
     # Generate interactive visualization
     from pyvis.network import Network  # type: ignore[import-untyped]
 
-    nt = Network(notebook=True, height="750px", width="100%")
+    nt = Network(notebook=True, height="100vh", width="100%")
     nt.from_nx(G)
     nt.show(filename)
 


### PR DESCRIPTION
## Summary

This fixes the network graph height in the web UI by replacing the fixed `750px` height with a viewport-based height (`100vh`).

## Problem

The network graph in the web UI used a hardcoded height of `750px`, which caused:

- overflow on smaller screens
- wasted vertical space on larger screens

## Solution

Updated the graph height in `maigret/report.py` from:

```python
height="750px"