### PR TITLE
Add FaceIt site support

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -1,5 +1,15 @@
 {
     "sites": {
+            "FaceIt": {
+                "urlMain": "https://www.faceit.com/",
+                "url": "https://www.faceit.com/en/players/{username}",
+                "usernameClaimed": "Snotax",
+                "usernameUnclaimed": "noonewouldeverusethis7",
+                "tags": [
+                    "gaming"
+                ],
+                "checkType": "status_code"
+                },
         "Facebook": {
             "regexCheck": "^[a-zA-Z0-9_\\.]{3,49}(?<!\\.com|\\.org|\\.net)$",
             "checkType": "message",


### PR DESCRIPTION
## Summary

Adds FaceIt as a supported site in Maigret.

## Details

Added a new site definition for FaceIt using the profile URL pattern:

`https://www.faceit.com/en/players/{username}`

Included:

- main site URL
- claimed username
- unclaimed username
- gaming tag

## Testing

Tested with:

- claimed user: `Snotax`
- unclaimed user: `noonewouldeverusethis7`