### PR TITLE
Improve startup error message for missing dependencies

### DIFF
--- a/maigret/__init__.py
+++ b/maigret/__init__.py
@@ -7,7 +7,16 @@ __author_email__ = 'soxoj@protonmail.com'
 
 
 from .__version__ import __version__
-from .checking import maigret as search
+try:
+    from .checking import maigret as search
+except ImportError as e:
+    raise ImportError(
+        "Missing required dependency while starting Maigret.\n\n"
+        "Install dependencies first:\n"
+        "    python -m pip install -e .\n\n"
+        "Then run Maigret as:\n"
+        "    python -m maigret <username>"
+    ) from e
 from .maigret import main as cli
 from .sites import MaigretEngine, MaigretSite, MaigretDatabase
 from .notify import QueryNotifyPrint as Notifier

--- a/maigret/__init__.py
+++ b/maigret/__init__.py
@@ -12,8 +12,10 @@ try:
 except ImportError as e:
     raise ImportError(
         "Missing required dependency while starting Maigret.\n\n"
-        "Install dependencies first:\n"
-        "    python -m pip install -e .\n\n"
+        "If installed from PyPI:\n"
+        "    pip install -U maigret\n\n"
+        "If running from a cloned repository:\n"
+        "    pip install -e .\n\n"
         "Then run Maigret as:\n"
         "    python -m maigret <username>"
     ) from e

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -13,7 +13,17 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from typing import List, Tuple
 import os.path as path
 
-from socid_extractor import extract, parse  # type: ignore[import-not-found]
+try:
+    from socid_extractor import extract, parse
+except ImportError as e:
+    raise ImportError(
+        "Missing dependency: socid_extractor\n\n"
+        "Install dependencies first:\n"
+        "    python -m pip install -e .\n\n"
+        "Then run Maigret as:\n"
+        "    python -m maigret <username>"
+    ) from e
+
 
 from .__version__ import __version__
 from .checking import (

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -18,8 +18,10 @@ try:
 except ImportError as e:
     raise ImportError(
         "Missing dependency: socid_extractor\n\n"
-        "Install dependencies first:\n"
-        "    python -m pip install -e .\n\n"
+        "If installed from PyPI:\n"
+        "    pip install -U maigret\n\n"
+        "If running from a cloned repository:\n"
+        "    pip install -e .\n\n"
         "Then run Maigret as:\n"
         "    python -m maigret <username>"
     ) from e


### PR DESCRIPTION
## Summary

Improves startup error handling when required dependencies are missing.

## Problem

Running Maigret without all dependencies installed produced raw tracebacks such as:

- `ModuleNotFoundError: No module named 'socid_extractor'`
- `ModuleNotFoundError: No module named 'aiodns'`

This made installation issues difficult to understand for users.

## Solution

Wraps the early startup import path with a clearer error message explaining:

- dependencies are missing
- how to install them correctly
- how to run Maigret properly

This provides a cleaner and more helpful startup failure path.