### PR TITLE
Disable Jigidi site check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -17533,6 +17533,7 @@
             "tags": [
                 "hobby"
             ],
+            "disabled": true,
             "checkType": "status_code",
             "alexaRank": 199456,
             "urlMain": "https://www.jigidi.com/",


### PR DESCRIPTION
## Summary
Disable the Jigidi site check because it currently produces false positives.

## What changed
- Marked `Jigidi` as disabled in `maigret/resources/data.json`

## Why
Jigidi is behind Cloudflare protection and returns HTTP 200 for both existing and non-existing usernames.

Since the site uses `status_code` detection, this causes Maigret to incorrectly report unclaimed usernames as claimed.

Disabling the check prevents false positives until the site can be reworked with a reliable detection method.

Closes #2580