### PR TITLE
Disable Icheckmovies site check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -15797,6 +15797,7 @@
             "tags": [
                 "movies"
             ],
+            "disabled": true,
             "checkType": "status_code",
             "alexaRank": 92240,
             "urlMain": "https://www.icheckmovies.com/",


### PR DESCRIPTION
## Summary
Disable the Icheckmovies site check because it currently produces false positives.

## What changed
- Marked `Icheckmovies` as disabled in `maigret/resources/data.json`

## Why
The site is currently being reported as falsely claimed by the Maigret bot for random usernames, which indicates unreliable detection.

Disabling the check prevents false positives until the site can be reworked with a reliable detection method.

Closes #2571