### PR TITLE
Disable GaiaOnline site check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -8191,6 +8191,7 @@
                 "social",
                 "us"
             ],
+            "disabled": true,
             "checkType": "message",
             "absenceStrs": [
                 "No user ID specified or user does not exist!"


### PR DESCRIPTION
## Summary
Disable the GaiaOnline site check because it currently produces false positives.

## What changed
- Marked `GaiaOnline` as disabled in `maigret/resources/data.json`

## Why
The site is currently being reported as falsely claimed by the Maigret bot for random usernames, which indicates unreliable detection.

Disabling the check prevents false positives until the site can be reworked with a reliable detection method.

Closes #2570