### PR TITLE
Disable Google Scholar site check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -1329,6 +1329,11 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Google Scholar": {
+            "tags": [
+                "education",
+                "research"
+            ],
+            "disabled": true,
             "checkType": "message",
             "url": "https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q={username}&btnG=",
             "urlMain": "https://scholar.google.com/",
@@ -1347,10 +1352,6 @@
                 "/sorry/index": "Google rate-limit / captcha",
                 "unusual traffic from your computer network": "Google rate-limit / captcha"
             },
-            "tags": [
-                "education",
-                "research"
-            ],
             "similarSearch": true
         },
         "GoodReads": {


### PR DESCRIPTION
## Summary
Disable Google Scholar site check due to false positives.

## Problem
Google Scholar was reported as CLAIMED for random usernames by the Maigret bot.

## Cause
Google Scholar serves generic / anti-bot / fallback responses that can look valid even for nonexistent usernames, which causes false positives.

## Solution
Disable the Google Scholar site entry in `data.json` until reliable detection can be implemented.