### PR TITLE
Disable Garden site check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -11425,6 +11425,7 @@
             "tags": [
                 "us"
             ],
+            "disabled": true,
             "checkType": "message",
             "presenseStrs": [
                 "'s profile - Garden.org</title>"


### PR DESCRIPTION
## Summary
Disable Garden site check due to false positives.

## Problem
Garden was reported as CLAIMED for random usernames by the Maigret bot.

## Cause
The site returns generic responses for invalid usernames, causing false positives.

## Solution
Disable the Garden site entry in `data.json` until reliable detection can be implemented.