### PR TITLE
Disable broken LeetCode site check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -6240,6 +6240,7 @@
             "urlMain": "https://leetcode.com/",
             "checkType": "message",
             "requestMethod": "POST",
+            "disabled": true,
             "requestPayload": {
                 "query": "{{ matchedUser(username: \"{username}\") {{ username }} }}"
             },


### PR DESCRIPTION
## Summary
Disable the LeetCode site check because the current detection is no longer reliable.

## Problem
LeetCode no longer works with the current profile detection approach and now relies on GraphQL-based checks.

## Fix
Mark the LeetCode site entry as disabled in `data.json` until proper GraphQL support is implemented.

## Result
This prevents unreliable LeetCode matches and avoids false positives from the current broken check.