### PR TITLE
Fix context field using class instead of instance in error handling

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -452,7 +452,7 @@ def process_site_result(
             MaigretCheckStatus.UNKNOWN,
             query_time=response_time,
             error=check_error,
-            context=str(CheckError),
+            context=str(check_error),
             tags=fulltags,
         )
     elif check_type == "message":


### PR DESCRIPTION
## Summary
- Fixed a bug in `process_site_result()` where the context field was set to `str(CheckError)` (the class itself) instead of `str(check_error)` (the error instance)

## Problem
When a check error occurred, the context field would contain the string representation of the class itself rather than the actual error message. This made error messages unhelpful for debugging.

**Before fix:** `context = "<class 'maigret.errors.CheckError'>"`
**After fix:** `context = "Request timeout error: slow server"`

## Solution
Changed `str(CheckError)` to `str(check_error)` on line 455 of `maigret/checking.py`.

## Testing
- All existing unit tests pass (25/25 relevant tests)
- Verified the fix produces correct error messages