### PR TITLE
fix(security): harden /reports path containment via send_from_directory

### DIFF
--- a/maigret/web/app.py
+++ b/maigret/web/app.py
@@ -2,12 +2,13 @@ from flask import (
     Flask,
     render_template,
     request,
-    send_file,
+    send_from_directory,
     Response,
     flash,
     redirect,
     url_for,
 )
+from werkzeug.exceptions import NotFound
 import logging
 import os
 import asyncio
@@ -325,14 +326,12 @@ def results(session_id):
 
 @app.route('/reports/<path:filename>')
 def download_report(filename):
+    reports_root = app.config["REPORTS_FOLDER"]
+    os.makedirs(reports_root, exist_ok=True)
     try:
-        os.makedirs(app.config["REPORTS_FOLDER"], exist_ok=True)
-        file_path = os.path.normpath(
-            os.path.join(app.config["REPORTS_FOLDER"], filename)
-        )
-        if not file_path.startswith(app.config["REPORTS_FOLDER"]):
-            raise Exception("Invalid file path")
-        return send_file(file_path)
+        return send_from_directory(reports_root, filename)
+    except NotFound:
+        return "File not found", 404
     except Exception as e:
         logging.error(f"Error serving file {filename}: {str(e)}")
         return "File not found", 404

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -140,6 +140,55 @@ def test_failed_task_redirects_to_index(client, web_app, monkeypatch):
     assert status_resp.location.endswith('/')
 
 
+def test_download_report_serves_file_inside_reports_folder(client, web_app, tmp_path):
+    """Happy path: a real file inside REPORTS_FOLDER is served back."""
+    target = tmp_path / 'session1'
+    target.mkdir()
+    (target / 'report.json').write_text('{"ok": true}')
+
+    resp = client.get('/reports/session1/report.json')
+
+    assert resp.status_code == 200
+    assert resp.get_data() == b'{"ok": true}'
+
+
+def test_download_report_blocks_dotdot_traversal(client, web_app, tmp_path):
+    """A literal ../ in the path must not escape REPORTS_FOLDER."""
+    secret = tmp_path.parent / 'outside_secret.txt'
+    secret.write_text('SECRET')
+
+    resp = client.get('/reports/..%2Foutside_secret.txt')
+
+    assert resp.status_code == 404
+    assert b'SECRET' not in resp.get_data()
+
+
+def test_download_report_blocks_sibling_prefix_bypass(client, web_app, tmp_path):
+    """Regression: the previous startswith() check let `<reports_root>2/secret`
+    bypass containment because '/tmp/maigret_reports2'.startswith('/tmp/maigret_reports')
+    is True. send_from_directory enforces a real boundary."""
+    sibling = tmp_path.parent / (tmp_path.name + '_sibling')
+    sibling.mkdir()
+    (sibling / 'leak.txt').write_text('LEAK')
+
+    encoded = '..%2F' + sibling.name + '%2Fleak.txt'
+    resp = client.get('/reports/' + encoded)
+
+    assert resp.status_code == 404
+    assert b'LEAK' not in resp.get_data()
+
+
+def test_download_report_blocks_absolute_path(client, web_app, tmp_path):
+    """An absolute filename must not escape REPORTS_FOLDER."""
+    secret = tmp_path.parent / 'abs_secret.txt'
+    secret.write_text('ABSOLUTE')
+
+    resp = client.get('/reports/' + str(secret).lstrip('/'))
+
+    assert resp.status_code == 404
+    assert b'ABSOLUTE' not in resp.get_data()
+
+
 def test_real_report_generation_does_not_crash(client, web_app, monkeypatch):
     """End-to-end with mocked maigret.search but REAL report generation.
 


### PR DESCRIPTION
## Summary

The `/reports/<path:filename>` handler in `maigret/web/app.py` validates path containment with a `startswith(REPORTS_FOLDER)` prefix check after `os.path.normpath` collapses `..`. Plain `../` traversal is correctly blocked, but the prefix check has a sibling-directory bypass: a request whose resolved path lives in a directory whose name starts with the configured reports folder name (e.g. `/tmp/maigret_reports` vs. `/tmp/maigret_reports2`) passes the `startswith` check and the file is served back.

This PR replaces the manual `normpath + startswith` check with Flask's `send_from_directory`, which delegates to `werkzeug.security.safe_join`. `safe_join` enforces a real boundary against the resolved directory, rejects absolute paths, and refuses `..` segments that escape the root.

## Impact

- The web UI binds to `FLASK_HOST=127.0.0.1` by default; the `web` Docker target sets `FLASK_HOST=0.0.0.0`, exposing the UI on whatever network the container is published on.
- An attacker who can place a file under any sibling of `REPORTS_FOLDER` whose name starts with the reports-folder name (e.g. `/tmp/maigret_reports2/leak.txt` when `REPORTS_FOLDER=/tmp/maigret_reports`) can read it through `/reports/`. This is most relevant on multi-user or shared-tmp deployments, and on any setup where `/tmp` is writable by the wider machine.
- No authentication is required to reach `/reports/`.

Severity: **low** (bounded by who can place files in the sibling-prefix path).

## Location

`maigret/web/app.py:327-339` (the `download_report` handler).

## Fix

- Drop the manual `os.path.normpath` + `startswith` check.
- Use `send_from_directory(reports_root, filename)`, which uses `werkzeug.security.safe_join` for containment.
- Catch `werkzeug.exceptions.NotFound` separately and return the same `"File not found", 404` body the previous handler returned, so behaviour for legitimate 404s is unchanged.
- The `os.makedirs(reports_root, exist_ok=True)` call moves out of the `try` block; it never raised the kinds of errors the previous broad `except` was catching, and pulling it out makes the control flow easier to read.

## Verification

`pytest tests/test_web.py` — 12/12 pass (8 baseline + 4 new path-containment tests).

`pytest tests/ --ignore=tests/test_cli.py` — 188 passed, 3 skipped (matches the baseline; the only environment-driven skips are unaffected by this change).

The new `test_download_report_blocks_sibling_prefix_bypass` is a regression test: it fails against the pre-fix `startswith` check (returns 200 with the leaked content) and passes against `send_from_directory`.

## Detected by

Aeon + manual review of `maigret.web.app` after running semgrep / trufflehog / osv-scanner on the tree at `264bae3`.

- CWE: [CWE-22](https://cwe.mitre.org/data/definitions/22.html) — Improper Limitation of a Pathname to a Restricted Directory
- Severity: low

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Happy to adjust scope or split into smaller pieces if you'd prefer.
