### PR TITLE
Apply --proxy to CurlCffiChecker (tls_fingerprint sites)

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -273,6 +273,7 @@ class CurlCffiChecker(CheckerBase):
     def __init__(self, *args, **kwargs):
         self.logger = kwargs.get('logger', Mock())
         self.browser_emulate = kwargs.get('browser_emulate', 'chrome')
+        self.proxy = kwargs.get('proxy')
         self.url = None
         self.headers = None
         self.allow_redirects = True
@@ -294,7 +295,10 @@ class CurlCffiChecker(CheckerBase):
 
     async def check(self) -> Tuple[Optional[str], int, Optional[CheckError]]:
         try:
-            async with CurlCffiAsyncSession() as session:
+            session_kwargs = {}
+            if self.proxy:
+                session_kwargs['proxies'] = {'http': self.proxy, 'https': self.proxy}
+            async with CurlCffiAsyncSession(**session_kwargs) as session:
                 # Strip the User-Agent so curl_cffi can use the impersonated browser's
                 # matching UA. Mixing a random UA with a Chrome TLS fingerprint trips
                 # composite bot scoring (e.g. Cloudflare returns a JS challenge for
@@ -828,7 +832,11 @@ def make_site_result(
             f"(protection: {list(site.protection)})"
         )
     elif needs_impersonation and CURL_CFFI_AVAILABLE:
-        checker = CurlCffiChecker(logger=logger, browser_emulate='chrome')
+        checker = CurlCffiChecker(
+            logger=logger,
+            browser_emulate='chrome',
+            proxy=options.get('proxy'),
+        )
     elif needs_impersonation and not CURL_CFFI_AVAILABLE:
         logger.warning(
             f"Site {site.name} requires TLS impersonation (curl_cffi) but it's not installed. "
@@ -1139,6 +1147,7 @@ async def maigret(
     options["id_type"] = id_type
     options["forced"] = forced
     options["cloudflare_bypass"] = cloudflare_bypass
+    options["proxy"] = proxy
 
     # results from analysis of all sites
     all_results: Dict[str, QueryResultWrapper] = {}


### PR DESCRIPTION
## Summary

`CurlCffiChecker` silently ignores the `--proxy` (and `settings.json` `proxy_url`) setting, so any site with `tls_fingerprint` in its `protection` list — Instagram, Reddit, Threads, SoundCloud, Kickstarter, Codepen, Fiverr, PyPi, NPM-Package, DeviantART, Genius, Artstation, Letterboxd, Taplink, OpenSea, VSCO, etc. — is checked over a **direct connection** even when a proxy is configured.

Both `SimpleAiohttpChecker` and `ProxiedAiohttpChecker` already read `proxy` from their kwargs and forward it. The curl_cffi-based checker was missing the same wiring.

## Empirical reproducer

Before this patch:
```bash
$ maigret testuser --site Instagram --proxy http://127.0.0.1:1 \
    --timeout 8 --print-errors --no-color --no-progressbar
[+] Instagram: https://www.instagram.com/testuser/      # proxy was ignored, went direct
```

After this patch:
```bash
$ maigret testuser --site Instagram --proxy http://127.0.0.1:1 \
    --timeout 8 --print-errors --no-color --no-progressbar
[?] Instagram: Unexpected error: Failed to perform, curl: (7)
    Failed to connect to 127.0.0.1 port 1 ...                # proxy honored
```

The error format (`curl: (7) ...`) confirms the request now routes through `curl_cffi` with proxy applied, rather than bypassing it.

## What the change does

1. `CurlCffiChecker.__init__`: capture `proxy` from kwargs (parity with `SimpleAiohttpChecker.__init__`).
2. `CurlCffiChecker.check`: pass `proxies={'http': self.proxy, 'https': self.proxy}` to `CurlCffiAsyncSession` — `curl_cffi`'s standard proxy-config kwarg.
3. `make_site_result`: forward `options.get('proxy')` when constructing the checker, same way it's wired for `SimpleAiohttpChecker` via `options['checkers']`.
4. `maigret()` (top-level): add `proxy` to the `options` dict alongside the existing checker setup, so the per-site constructor can pick it up.

No behavior change when `--proxy` isn't set (the conditional `if self.proxy` keeps the existing direct-connection path intact).

## Why this matters

The README and CLI help both describe `--proxy` as a global routing setting. Users running through `--tor-proxy` or a corporate egress proxy would expect (and need) high-traffic sites like Instagram and Reddit to also transit the configured proxy. This patch makes the actual behavior match the documented promise.

## Suggested test

A simple pytest case that constructs `CurlCffiChecker(proxy="http://127.0.0.1:1")` and asserts the underlying `CurlCffiAsyncSession` is instantiated with the matching `proxies` dict (via monkeypatching or `unittest.mock.patch`).