### PR TITLE
Fix linktr.ee detector (status_code, not stale message check)

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -863,14 +863,7 @@
             "tags": [
                 "links"
             ],
-            "checkType": "message",
-            "absenceStrs": [
-                "The page you’re looking for doesn’t exist.",
-                "Want this to be your username?"
-            ],
-            "presenseStrs": [
-                "@container/profile-container"
-            ],
+            "checkType": "status_code",
             "urlMain": "https://linktr.ee",
             "url": "https://linktr.ee/{username}",
             "usernameUnclaimed": "noonewouldeverusethis7",

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-05-11T17:38:18Z",
+    "updated_at": "2026-05-13T06:29:11Z",
     "sites_count": 3154,
     "min_maigret_version": "0.6.0",
-    "data_sha256": "1787a341c90d91a56507ae704c8471743709b56d85d6c3dfa8c56189dccbc6dd",
+    "data_sha256": "9c9c9c5c14e833daf32f537e283345c804ca396fba1cc8a57a2976ef8ecfd6a4",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -3158,16 +3158,16 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://app.airnfts.com) [AirNFTs (https://app.airnfts.com)](https://app.airnfts.com)*: top 100M, crypto, nft*
 1. ![](https://www.google.com/s2/favicons?domain=https://greasyfork.org) [GreasyFork (https://greasyfork.org)](https://greasyfork.org)*: top 100M, coding*
 
-The list was updated at (2026-05-11)
+The list was updated at (2026-05-13)
 ## Statistics
 
 Enabled/total sites: 2524/3154 = 80.03%
 
 Incomplete message checks: 311/2524 = 12.32% (false positive risks)
 
-Status code checks: 636/2524 = 25.2% (false positive risks)
+Status code checks: 637/2524 = 25.24% (false positive risks)
 
-False positive risk (total): 37.52%
+False positive risk (total): 37.56%
 
 Sites with probing: 500px, Armchairgm, BinarySearch (disabled), BleachFandom, Bluesky, BongaCams, Boosty, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, Discord, Diskusjon.no, Disqus, Docker Hub, Duolingo, FandomCommunityCentral, GitHub, GitLab, Google Plus (archived), Gravatar, HackTheBox, Hackerrank, Hashnode, Holopin, Imgur, Issuu, Keybase, Kick, Kvinneguiden, LeetCode, Lesswrong, Livejasmin, LocalCryptos (disabled), Medium, MicrosoftLearn, MixCloud, Monkeytype, NPM, Niftygateway, Omg.lol, OnlyFans, Paragraph, Picsart, Plurk, Polarsteps, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), YouNow, en.brickimedia.org, forums.grandstream.com, nightbot, notabug.org, qiwi.me (disabled)
 


### PR DESCRIPTION
## Summary

The current `linktr.ee` detector uses `checkType: message` with the presence string `"@container/profile-container"`. linktr.ee removed that Tailwind class in a site refresh, so **every** check now returns Not found — including maigret's own `usernameClaimed` sample `Blisscartoos`.

## Reproducer (before this patch)

```bash
$ maigret Blisscartoos --site linktr.ee --print-not-found --no-color --no-progressbar
[-] linktr.ee: Not found!     # but the profile exists and is reachable at https://linktr.ee/Blisscartoos
```

linktr.ee actually answers cleanly at the HTTP level:

```bash
$ curl -sI https://linktr.ee/Blisscartoos                 -w "%{http_code}\n" -o /dev/null
200
$ curl -sI https://linktr.ee/noonewouldeverusethis7       -w "%{http_code}\n" -o /dev/null
404
```

After this patch:

```bash
$ maigret Blisscartoos --site linktr.ee --no-color --no-progressbar
[+] linktr.ee: https://linktr.ee/Blisscartoos             # found correctly
$ maigret noonewouldeverusethis7 --site linktr.ee --print-not-found --no-color --no-progressbar
[-] linktr.ee: Not found!                                  # correctly absent
```

## Change

`maigret/resources/data.json` — switch `linktr.ee`:

- `checkType`: `message` → `status_code`
- Drop the now-obsolete `presenseStrs` and `absenceStrs` arrays (neither string appears in the current claimed or unclaimed page bodies).
- All other fields (`tags`, URLs, sample usernames, `alexaRank`) preserved.

Regenerated `db_meta.json` and `sites.md` via `utils/update_site_data.py` per CONTRIBUTING. The status-code-check count goes from 636 → 637 as expected. (Preserved `min_maigret_version` at `0.6.0`; the regenerator defaulted it to `0.5.0` which would have regressed the constraint.)

## Verification

Tested against both maigret's own `usernameClaimed`/`usernameUnclaimed` samples and other real profiles. Status-code detection is well-precedented across the DB (status_code is the second most common `checkType`).