### PR TITLE
Refresh stale Duolingo usernameClaimed sample (blue → duolingo)

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3137,7 +3137,7 @@
             "alexaRank": 1126,
             "urlMain": "https://duolingo.com/",
             "url": "https://www.duolingo.com/profile/{username}",
-            "usernameClaimed": "blue",
+            "usernameClaimed": "duolingo",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "kofi": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-05-11T17:38:18Z",
+    "updated_at": "2026-05-13T08:45:47Z",
     "sites_count": 3154,
     "min_maigret_version": "0.6.0",
-    "data_sha256": "1787a341c90d91a56507ae704c8471743709b56d85d6c3dfa8c56189dccbc6dd",
+    "data_sha256": "714e2f36a4d78821bca3bb59d4e8b0f4ba55a7f4a6a6703ffa2167dfbbaa4cc0",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -3158,7 +3158,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://app.airnfts.com) [AirNFTs (https://app.airnfts.com)](https://app.airnfts.com)*: top 100M, crypto, nft*
 1. ![](https://www.google.com/s2/favicons?domain=https://greasyfork.org) [GreasyFork (https://greasyfork.org)](https://greasyfork.org)*: top 100M, coding*
 
-The list was updated at (2026-05-11)
+The list was updated at (2026-05-13)
 ## Statistics
 
 Enabled/total sites: 2524/3154 = 80.03%


### PR DESCRIPTION
## Summary

`maigret SOMETHING --site Duolingo` regression: the bundled `usernameClaimed: "blue"` no longer corresponds to a real Duolingo account, so maigret's own self-check reports the supposedly-claimed sample as Not Found. The detector logic itself is correct — Duolingo's API just genuinely returns `{"users":[]}` for `blue`.

## Reproducer (before)

```bash
$ maigret blue --site Duolingo --no-color --no-progressbar
[-] Duolingo: Not found!     # but the absence is real — "blue" really doesn't exist
```

```bash
$ curl -s 'https://www.duolingo.com/2017-06-30/users?username=blue'
{"users":[]}
$ curl -s 'https://www.duolingo.com/2017-06-30/users?username=duolingo' | head -c 80
{"users":[{"id":1723277568,"acquisitionSurveyReason":"none",...
```

## After

```bash
$ maigret duolingo --site Duolingo --no-color --no-progressbar
[+] Duolingo: https://www.duolingo.com/profile/duolingo
```

## Change

`maigret/resources/data.json` — Duolingo entry: `usernameClaimed: "blue"` → `"duolingo"`. Nothing else.

`duolingo` is Duolingo's own official account (internal id 1723277568, visible in the API response). It's a safe long-lived claimed-username sample.

Regenerated `db_meta.json` and `sites.md` via `utils/update_site_data.py` per CONTRIBUTING. Preserved `min_maigret_version` at `0.6.0`.