### PR TITLE
Refresh stale Gravatar usernameClaimed sample (blue → automattic)

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -467,7 +467,7 @@
             ],
             "urlMain": "http://en.gravatar.com/",
             "url": "http://en.gravatar.com/{username}",
-            "usernameClaimed": "blue",
+            "usernameClaimed": "automattic",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Reddit": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-05-13T06:29:11Z",
+    "updated_at": "2026-05-13T10:39:40Z",
     "sites_count": 3154,
     "min_maigret_version": "0.6.0",
-    "data_sha256": "9c9c9c5c14e833daf32f537e283345c804ca396fba1cc8a57a2976ef8ecfd6a4",
+    "data_sha256": "f86d77a18bcd1d353933b64d99953634ce5e2966860f25bacd5e3de5659fb8a7",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }


### PR DESCRIPTION
## Summary

The bundled `usernameClaimed: "blue"` for Gravatar corresponds to a deleted account, so its `.json` probe returns 404 and maigret reports the supposedly-claimed sample as Not Found. The JSON endpoint itself is alive for real accounts — only the test fixture is stale.

## Reproducer (before)

```bash
$ maigret blue --site Gravatar --no-color --no-progressbar
[-] Gravatar: Not found!

$ curl -sL -o /dev/null -w '%{http_code}\n' http://en.gravatar.com/blue.json
404
$ curl -sL -o /dev/null -w '%{http_code}\n' http://en.gravatar.com/automattic.json
200
```

## After

```bash
$ maigret automattic --site Gravatar --no-color --no-progressbar
[+] Gravatar: http://en.gravatar.com/automattic
 ├─image: https://0.gravatar.com/avatar/9f3d4f181b9b6232bc277a445a462abc...
 ├─username: automattic
 ├─name: Automattic
 ├─gravatar_url: https://gravatar.com/9f3d4f181b9b6232bc277a445a462abc
 ├─gravatar_username: automattic
 └─gravatar_email_md5_hash: 9f3d4f181b9b6232bc277a445a462abc
```

## Change

`maigret/resources/data.json` — Gravatar entry: `usernameClaimed: "blue"` → `"automattic"`. Nothing else.

`automattic` is Automattic's own Gravatar account; Automattic operates Gravatar so it's a stable long-lived sample.

Regenerated `db_meta.json` via `utils/update_site_data.py`. Preserved `min_maigret_version` at `0.6.0`.
