### PR TITLE
refactor: update instagram entry structure

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -50,11 +50,17 @@
                 "social"
             ],
             "checkType": "message",
+            "urlProbe": "https://www.instagram.com/api/v1/users/web_profile_info/?username={username}",
+            "headers": {
+                "x-ig-app-id": "936619743392459",
+                "referer": "https://www.instagram.com/"
+            },
             "presenseStrs": [
-                "\"routePath\":\"\\/{username}"
+                "\"biography\""
             ],
             "absenceStrs": [
-                "\"routePath\":null"
+                "Sorry, this page isn&#39;t available.",
+                "dialog-404"
             ],
             "errors": {
                 "Login • Instagram": "Login required",


### PR DESCRIPTION
- Added,
```bash
            "urlProbe": "https://www.instagram.com/api/v1/users/web_profile_info/?username={username}",
            "headers": {
                "x-ig-app-id": "936619743392459",
                "referer": "https://www.instagram.com/"
            },
```
- Now maigret will be able to check availability of usernames without status code `403` or `429`.
- After merge of the latest PR in `socid-extractor`, Output:

```bash
[+] Instagram: https://www.instagram.com/cristiano/
       ├─username: cristiano
       ├─fullname: Cristiano Ronaldo
       ├─id: 173560420
       ├─image: https://instagram.fdbd3-1.fna.fbcdn.net/v/t51.2885-19/472007201_1142000150877579_994350541752907763_n.jpg?stp=dst-jpg_s320x320_tt6&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLmRqYW5nby4xMDgwLmMyIn0&_nc_ht=instagram.fdbd3-1.fna.fbcdn.net&_nc_cat=1&_nc_oc=Q6cZ2gGp2ERusckEx5X5t6WT-fFZAZnXv4lXjHNHAVYlw3kpfNzHXALVqSobC5zoONTACis&_nc_ohc=kx09owrydRYQ7kNvwEcoP2Q&_nc_gid=1iNJfsFvss1s9NYNDBDl2g&edm=AOQ1c0wBAAAA&ccb=7-5&oh=00_Af9FrQDNCGf5wXcB0rNaV1Sn1ChE5Hug2cnU_ROXJzCMwQ&oe=6A25961E&_nc_sid=8b3546
       ├─external_url: https://hrbl.me/CR7Pro2col
       ├─facebook_uid: 17841401692602711
       ├─is_business: False
       ├─is_joined_recently: False
       ├─is_private: False
       ├─is_verified: True
       ├─follower_count: 665326752
       ├─following_count: 633
       └─_extractor: Instagram GraphQL

```