### PR TITLE
Warn on engine dict merge conflicts

### DIFF
--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -1,11 +1,15 @@
 # ****************************** -*-
 """Maigret Sites Information"""
+
 import copy
 import json
+import logging
 import sys
 from typing import Optional, List, Dict, Any, Tuple
 
 from .utils import CaseConverter, URLMatcher, is_country_tag
+
+logger = logging.getLogger(__name__)
 
 
 class MaigretEngine:
@@ -175,7 +179,9 @@ class MaigretSite:
                         self.__dict__[CaseConverter.camel_to_snake(group)],
                     )
 
-            self.url_regexp = URLMatcher.make_profile_url_regexp(url, self.regex_check or "")
+            self.url_regexp = URLMatcher.make_profile_url_regexp(
+                url, self.regex_check or ""
+            )
 
     def detect_username(self, url: str) -> Optional[str]:
         if self.url_regexp:
@@ -269,9 +275,18 @@ class MaigretSite:
         for k, v in engine_data.items():
             field = CaseConverter.camel_to_snake(k)
             if isinstance(v, dict):
-                # TODO: assertion of intersecting keys
                 # update dicts like errors
-                self.__dict__.get(field, {}).update(v)
+                target = self.__dict__.get(field, {})
+                for item_key, item_value in v.items():
+                    if item_key in target and target[item_key] != item_value:
+                        logger.warning(
+                            "Engine %s overrides %s.%s for site %s",
+                            engine.name,
+                            field,
+                            item_key,
+                            self.name,
+                        )
+                target.update(v)
             elif isinstance(v, list):
                 self.__dict__[field] = self.__dict__.get(field, []) + v
             else:
@@ -387,12 +402,11 @@ class MaigretDatabase:
         )
         is_id_type_ok = lambda x: x.type == id_type
 
-        is_excluded_by_tag = lambda x: set(
-            map(str.lower, x.tags)
-        ).intersection(set(normalized_excluded_tags))
+        is_excluded_by_tag = lambda x: set(map(str.lower, x.tags)).intersection(
+            set(normalized_excluded_tags)
+        )
         is_excluded_by_engine = lambda x: (
-            isinstance(x.engine, str)
-            and x.engine.lower() in normalized_excluded_tags
+            isinstance(x.engine, str) and x.engine.lower() in normalized_excluded_tags
         )
         is_excluded_by_protocol = lambda x: (
             x.protocol and x.protocol in normalized_excluded_tags
@@ -633,9 +647,7 @@ class MaigretDatabase:
             if site.engine:
                 engine_total[site.engine] = engine_total.get(site.engine, 0) + 1
                 if not site.disabled:
-                    engine_enabled[site.engine] = (
-                        engine_enabled.get(site.engine, 0) + 1
-                    )
+                    engine_enabled[site.engine] = engine_enabled.get(site.engine, 0) + 1
 
             # Count tags
             if not site.tags:

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,10 +1,11 @@
 """Maigret Database test functions"""
 
+import logging
 import re
 
 from typing import Any, Dict
 
-from maigret.sites import MaigretDatabase, MaigretSite
+from maigret.sites import MaigretDatabase, MaigretEngine, MaigretSite
 
 EXAMPLE_DB: Dict[str, Any] = {
     'engines': {
@@ -114,6 +115,45 @@ def test_saving_site_error():
     assert amperka.strip_engine_data().json['errors'] == {'error1': 'text1'}
 
 
+def test_update_from_engine_warns_on_conflicting_dict_entries(caplog):
+    site = MaigretSite(
+        'Example',
+        {
+            'urlMain': 'https://example.com',
+            'url': 'https://example.com/{username}',
+            'errors': {
+                'Shared marker': 'site value',
+                'Same marker': 'same value',
+            },
+        },
+    )
+    engine = MaigretEngine(
+        'ExampleEngine',
+        {
+            'site': {
+                'errors': {
+                    'Shared marker': 'engine value',
+                    'Same marker': 'same value',
+                    'Engine marker': 'engine-only value',
+                },
+            },
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        site.update_from_engine(engine)
+
+    assert site.errors == {
+        'Shared marker': 'engine value',
+        'Same marker': 'same value',
+        'Engine marker': 'engine-only value',
+    }
+    assert 'Example' in caplog.text
+    assert 'errors' in caplog.text
+    assert 'Shared marker' in caplog.text
+    assert 'Same marker' not in caplog.text
+
+
 def test_site_url_detector():
     db = MaigretDatabase()
     db.load_from_json(EXAMPLE_DB)
@@ -216,10 +256,16 @@ def test_ranked_sites_dict_excluded_tags():
     assert list(db.ranked_sites_dict(excluded_tags=['ucoz']).keys()) == ['1', '2']
 
     # combining include and exclude tags
-    assert list(db.ranked_sites_dict(tags=['forum'], excluded_tags=['ru']).keys()) == ['1']
+    assert list(db.ranked_sites_dict(tags=['forum'], excluded_tags=['ru']).keys()) == [
+        '1'
+    ]
 
     # excluding non-existent tag has no effect
-    assert list(db.ranked_sites_dict(excluded_tags=['nonexistent']).keys()) == ['1', '2', '3']
+    assert list(db.ranked_sites_dict(excluded_tags=['nonexistent']).keys()) == [
+        '1',
+        '2',
+        '3',
+    ]
 
     # exclude all
     assert list(db.ranked_sites_dict(excluded_tags=['forum', 'ucoz']).keys()) == []
@@ -232,7 +278,15 @@ def test_ranked_sites_dict_excluded_tags_with_top():
         MaigretSite('Parent', {'alexaRank': 1, 'tags': ['forum'], 'type': 'username'})
     )
     db.update_site(
-        MaigretSite('Mirror', {'alexaRank': 999999, 'source': 'Parent', 'tags': ['forum'], 'type': 'username'})
+        MaigretSite(
+            'Mirror',
+            {
+                'alexaRank': 999999,
+                'source': 'Parent',
+                'tags': ['forum'],
+                'type': 'username',
+            },
+        )
     )
     db.update_site(
         MaigretSite('Other', {'alexaRank': 2, 'tags': ['coding'], 'type': 'username'})


### PR DESCRIPTION
## Summary
- log a warning when engine-provided dict entries overwrite site-specific entries with different values
- keep the current merge result intact so existing engine defaults still win
- add regression coverage for conflicting, equal, and engine-only dict entries

Closes #2672

## Tests
- `.venv/bin/python -m pytest tests/test_sites.py::test_update_from_engine_warns_on_conflicting_dict_entries -q`
- `.venv/bin/python -m pytest tests/test_sites.py -q`
- `.venv/bin/python -m black --check --skip-string-normalization maigret/sites.py tests/test_sites.py`
- `.venv/bin/python -m flake8 --count --select=E9,F63,F7,F82 --show-source --statistics maigret/sites.py tests/test_sites.py`
- `.venv/bin/python -m mypy --check-untyped-defs maigret/sites.py tests/test_sites.py`
- `git diff --check`

I also ran `.venv/bin/python -m pytest tests -q`; it reached 284 passed / 3 skipped and failed only in the unrelated local timing/order-sensitive `tests/test_executors.py::test_asyncio_progressbar_queue_executor`.

I used AI assistance while preparing this change and reviewed/tested the result locally.