### PR TITLE
Update PDF dependency for web variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV FLASK_HOST=0.0.0.0
 
 # Web UI variant: auto-launches the web interface on $PORT
 FROM base AS web
+RUN pip install --no-cache-dir '.[pdf]'
 ENV PORT=5000
 EXPOSE 5000
 ENTRYPOINT ["sh", "-c", "exec maigret --web \"$PORT\""]


### PR DESCRIPTION
Adding PDF dependency by default for web variant as a search will result in an error without installing this. In case it is not installed it maigret web will return to the landing page and will present an error in the logs.