### PR TITLE
fix: update_site() now replaces list element instead of local variable

### DIFF
--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -476,9 +476,9 @@ class MaigretDatabase:
         return {engine.name: engine for engine in self._engines}
 
     def update_site(self, site: MaigretSite) -> "MaigretDatabase":
-        for s in self._sites:
+        for i, s in enumerate(self._sites):
             if s.name == site.name:
-                s = site
+                self._sites[i] = site
                 return self
 
         self._sites.append(site)

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -370,6 +370,30 @@ def test_get_url_template():
     assert site.get_url_template() == "SUBDOMAIN"
 
 
+def test_update_site_replaces_existing_entry():
+    """update_site() must replace the list element, not just rebind a loop variable."""
+    db = MaigretDatabase()
+    db.update_site(MaigretSite('Example', {'urlMain': 'https://example.com', 'disabled': False}))
+
+    updated = MaigretSite('Example', {'urlMain': 'https://example.com', 'disabled': True})
+    db.update_site(updated)
+
+    # The database must contain exactly one entry and it must be the updated one
+    assert len(db.sites) == 1
+    assert db.sites_dict['Example'].disabled is True
+
+
+def test_update_site_appends_when_name_not_found():
+    """update_site() must append when no site with that name exists."""
+    db = MaigretDatabase()
+    db.update_site(MaigretSite('Alpha', {'urlMain': 'https://alpha.com'}))
+    db.update_site(MaigretSite('Beta', {'urlMain': 'https://beta.com'}))
+
+    assert len(db.sites) == 2
+    assert 'Alpha' in db.sites_dict
+    assert 'Beta' in db.sites_dict
+
+
 def test_has_site_url_or_name(default_db):
     # by the same url or partial match
     assert default_db.has_site("https://aback.com.ua/user/") == True


### PR DESCRIPTION
## Summary

Fixes #2750

`MaigretDatabase.update_site()` was a silent no-op when the site already existed. `s = site` inside a `for s in self._sites` loop only rebinds the local loop variable — the list element at that index is untouched. The method returned `self` looking like success while the database remained unchanged.

This silently broke `--auto-disable`: after `checking.py` sets `site.disabled = True` and calls `db.update_site(site)`, the database save wrote the original enabled copy because the list element was never replaced.

## Change

`maigret/sites.py` — `update_site()`:

```python
# before
for s in self._sites:
    if s.name == site.name:
        s = site        # only rebinds local variable
        return self

# after
for i, s in enumerate(self._sites):
    if s.name == site.name:
        self._sites[i] = site   # replaces the actual list element
        return self
```

## Tests

Added two regression tests to `tests/test_sites.py`:
- `test_update_site_replaces_existing_entry` — verifies that updating a site with `disabled=True` is reflected in `db.sites_dict`
- `test_update_site_appends_when_name_not_found` — verifies that a new site is still appended correctly (no regression)

## Test plan

- [ ] `pytest tests/test_sites.py` — all tests pass including new ones
- [ ] `pytest` — full suite green
- [ ] `make lint` — no lint errors
- [ ] `maigret user --self-check --auto-disable` — disabled sites are now persisted correctly