### PR TITLE
fix: pass value v not key k to is_country_tag in generate_report_context

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -509,7 +509,7 @@ def generate_report_context(username_results: list):
                     # suppose country
                     if k in ["country", "locale"]:
                         try:
-                            if is_country_tag(k):
+                            if is_country_tag(v):
                                 country = pycountry.countries.get(alpha_2=v)
                                 tag = country.alpha_2.lower()  # type: ignore[union-attr]
                             else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,22 @@ def test_is_country_tag():
     assert is_country_tag('global') is True
 
 
+def test_is_country_tag_field_names_are_not_country_codes():
+    """The field names 'country' and 'locale' must not be mistaken for ISO codes.
+
+    generate_report_context iterates ids_data and for keys 'country'/'locale'
+    decides whether to use direct alpha_2 lookup (is_country_tag(v)) or fuzzy
+    search. A previous bug passed the key name k instead of the value v, so
+    is_country_tag('country') was always False and the direct lookup path was
+    dead code.
+    """
+    assert is_country_tag('country') is False
+    assert is_country_tag('locale') is False
+    # Values that should trigger the direct lookup
+    assert is_country_tag('US') is True
+    assert is_country_tag('ru') is True
+
+
 def test_enrich_link_str():
     assert enrich_link_str('test') == 'test'
     assert (


### PR DESCRIPTION
## Summary

Fixes #2752

`is_country_tag` was called with the field name `k` (`"country"` / `"locale"`) instead of the field value `v`. Since `is_country_tag` matches 2-letter alpha codes and these field names are 6-7 characters long, the condition was always `False` — making the fast `alpha_2` lookup branch dead code and forcing all country lookups through the slower `search_fuzzy` path.

## Change

`maigret/report.py` — one character:

```python
# before
if is_country_tag(k):

# after
if is_country_tag(v):
```

Now 2-letter ISO codes (`"US"`, `"RU"`, etc.) use `pycountry.countries.get(alpha_2=v)` (fast, exact), and full country names continue to use `search_fuzzy` (as intended).

## Test

Added `test_is_country_tag_field_names_are_not_country_codes` to `tests/test_utils.py`, asserting:
- `is_country_tag("country")` and `is_country_tag("locale")` are `False` (keys are never country codes)
- `is_country_tag("US")` and `is_country_tag("ru")` are `True` (values may be country codes)

## Test plan

- [ ] `pytest tests/test_utils.py` — all tests pass including new one
- [ ] `pytest` — full suite green
- [ ] `make lint` — no lint errors