### PR TITLE
Add Neo4j Cypher export (--neo4j)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ maigret user --json ndjson   # newline-delimited JSON (also: --json simple)
 maigret user --csv
 maigret user --txt
 maigret user --graph         # interactive D3 graph (HTML)
+maigret user --neo4j         # Neo4j Cypher script (graph database)
 
 # search on sites marked with tags photo & dating
 maigret user --tags photo,dating

--- a/docs/source/command-line-options.rst
+++ b/docs/source/command-line-options.rst
@@ -203,6 +203,11 @@ ndjson (one report per username). E.g. ``--json ndjson``
 ``-M``, ``--md`` - Generate a Markdown report (general report on all
 usernames). See :ref:`markdown-report` below.
 
+``--neo4j`` - Generate a Neo4j Cypher report: a ``.cypher`` script that
+recreates the maigret graph (the same one produced by ``--graph``) in a
+Neo4j database, importable with ``cypher-shell`` or the Neo4j Browser
+(general report on all usernames).
+
 ``--ai`` - Run an AI-powered analysis of the search results using an
 OpenAI-compatible chat completion API. The internal Markdown report is
 sent to the model, which returns a short investigation summary that is

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -50,6 +50,7 @@ from .report import (
     get_plaintext_report,
     sort_report_by_data_points,
     save_graph_report,
+    save_neo4j_report,
     save_markdown_report,
 )
 from .sites import MaigretDatabase
@@ -515,6 +516,13 @@ def setup_arguments_parser(settings: Settings):
         dest="graph",
         default=settings.graph_report,
         help="Generate a graph report (general report on all usernames).",
+    )
+    report_group.add_argument(
+        "--neo4j",
+        action="store_true",
+        dest="neo4j",
+        default=settings.neo4j_report,
+        help="Generate a Neo4j Cypher report (general report on all usernames).",
     )
     report_group.add_argument(
         "-J",
@@ -1042,6 +1050,14 @@ async def main():
             )
             save_graph_report(filename, general_results, db)
             query_notify.warning(f'Graph report on all usernames saved in {filename}')
+
+        if args.neo4j:
+            username = username.replace('/', '_')
+            filename = report_filepath_tpl.format(
+                username=username, postfix='_neo4j.cypher'
+            )
+            save_neo4j_report(filename, general_results, db)
+            query_notify.warning(f'Neo4j report on all usernames saved in {filename}')
 
         if not args.ai:
             text_report = get_plaintext_report(report_context)

--- a/maigret/report.py
+++ b/maigret/report.py
@@ -132,7 +132,7 @@ class MaigretGraph:
         self.G.add_edge(node1_name, node2_name, weight=2)
 
 
-def save_graph_report(filename: str, username_results: list, db: MaigretDatabase):
+def _build_maigret_graph(username_results: list, db: MaigretDatabase):
     import networkx as nx
 
     G: Any = nx.Graph()
@@ -252,12 +252,70 @@ def save_graph_report(filename: str, username_results: list, db: MaigretDatabase
     ]
     G.remove_nodes_from(single_degree_sites)
 
+    return G
+
+
+def save_graph_report(filename: str, username_results: list, db: MaigretDatabase):
+    G = _build_maigret_graph(username_results, db)
+
     # Generate interactive visualization
     from pyvis.network import Network  # type: ignore[import-untyped]
 
     nt = Network(notebook=True, height="100vh", width="100%")
     nt.from_nx(G)
     nt.show(filename)
+
+
+def _graph_to_cypher(G) -> str:
+    """Serialize a maigret networkx graph as an idempotent Cypher script.
+
+    Nodes are MERGEd on their unique ``name`` so re-importing the same report
+    does not create duplicate nodes; edges become ``[:LINKED_TO]`` relationships.
+    """
+
+    def cstr(value) -> str:
+        # Cypher single-quoted string literal, with escaping.
+        s = (
+            str(value)
+            .replace('\\', '\\\\')
+            .replace("'", "\\'")
+            .replace('\n', '\\n')
+            .replace('\r', '\\r')
+            .replace('\t', '\\t')
+        )
+        return "'" + s + "'"
+
+    lines = [
+        "// maigret Neo4j export. Import: cypher-shell -u neo4j -p <password> < <file>.cypher",
+        "CREATE CONSTRAINT maigret_node_name IF NOT EXISTS",
+        "FOR (n:MaigretNode) REQUIRE n.name IS UNIQUE;",
+        "",
+    ]
+    for node in G.nodes():
+        node_type, _, label = str(node).partition(':')
+        lines.append(
+            "MERGE (n:MaigretNode {name: %s}) SET n.type = %s, n.label = %s;"
+            % (cstr(node), cstr(node_type.strip()), cstr(label.strip()))
+        )
+    lines.append("")
+    for node1, node2 in G.edges():
+        lines.append(
+            "MATCH (a:MaigretNode {name: %s}), (b:MaigretNode {name: %s}) "
+            "MERGE (a)-[:LINKED_TO]->(b);" % (cstr(node1), cstr(node2))
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def save_neo4j_report(filename: str, username_results: list, db: MaigretDatabase):
+    """Save a Neo4j Cypher report of the maigret graph (see ``_graph_to_cypher``).
+
+    Load the resulting file with ``cypher-shell -u neo4j -p <password> < file``
+    or paste it into the Neo4j Browser.
+    """
+    G = _build_maigret_graph(username_results, db)
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(_graph_to_cypher(G))
 
 
 def get_plaintext_report(context: dict) -> str:

--- a/maigret/resources/settings.json
+++ b/maigret/resources/settings.json
@@ -52,6 +52,7 @@
     "csv_report": false,
     "xmind_report": false,
     "graph_report": false,
+    "neo4j_report": false,
     "pdf_report": false,
     "html_report": false,
     "md_report": false,

--- a/maigret/settings.py
+++ b/maigret/settings.py
@@ -42,6 +42,7 @@ class Settings:
     pdf_report: bool
     html_report: bool
     graph_report: bool
+    neo4j_report: bool
     md_report: bool
     web_interface_port: int
     no_autoupdate: bool

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ DEFAULT_ARGS: Dict[str, Any] = {
     'folderoutput': 'reports',
     'html': False,
     'graph': False,
+    'neo4j': False,
     'id_type': 'username',
     'ignore_ids_list': [],
     'info': False,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -29,6 +29,7 @@ from maigret.report import (
     generate_report_context,
     generate_json_report,
     get_plaintext_report,
+    _graph_to_cypher,
 )
 from maigret.result import MaigretCheckResult, MaigretCheckStatus
 from maigret.sites import MaigretSite
@@ -309,6 +310,29 @@ def test_generate_csv_report_broken():
         'username,name,url_main,url_user,exists,http_status\r\n',
         'test,GitHub,https://www.github.com/,https://www.github.com/test,Unknown,200\r\n',
     ]
+
+
+def test_generate_neo4j_report():
+    import networkx as nx
+
+    G = nx.Graph()
+    G.add_node("username: alice")
+    G.add_node("account: https://github.com/alice")
+    G.add_node("bio: o'brien\nbreak")  # tricky value: single quote + newline
+    G.add_edge("username: alice", "account: https://github.com/alice")
+
+    cypher = _graph_to_cypher(G)
+
+    assert "CREATE CONSTRAINT maigret_node_name IF NOT EXISTS" in cypher
+    assert cypher.count("MERGE (n:MaigretNode {name: ") == 3
+    assert cypher.count("-[:LINKED_TO]->") == 1
+    assert "SET n.type = 'username', n.label = 'alice'" in cypher
+
+    # the value with a quote and a newline stays on one terminated line, escaped
+    bio_lines = [ln for ln in cypher.splitlines() if "bio:" in ln]
+    assert len(bio_lines) == 1
+    assert bio_lines[0].endswith(";")
+    assert "o\\'brien\\nbreak" in bio_lines[0]
 
 
 def test_generate_txt_report():


### PR DESCRIPTION
### Summary

Adds a `--neo4j` export that serializes the maigret graph (the same one `--graph` builds) into a Cypher script importable into Neo4j, per #2630 and your go-ahead there.

Closes #2630

### What it does

`maigret <username> --neo4j` writes a `*_neo4j.cypher` file. It reuses the existing `MaigretGraph` (the structure behind `--graph`), so it captures the same username / account / site / data nodes and relationships, and serializes them as idempotent Cypher:
- each node is `MERGE`d on a unique `name` (re-imports do not create duplicates),
- edges become `[:LINKED_TO]` relationships,
- with a `CREATE CONSTRAINT ... IF NOT EXISTS` on the node name.

No new runtime dependency (`networkx` is already used). Import with `cypher-shell -u neo4j -p <pw> < <file>.cypher`, or paste into the Neo4j Browser.

### Refactor

I extracted the graph-building out of `save_graph_report` into a shared `_build_maigret_graph()` helper so both `--graph` and `--neo4j` use it; `save_graph_report` behavior is unchanged.

### Testing

- Full pytest suite passes. Added `tests/test_report.py::test_generate_neo4j_report` (covers the Cypher structure plus escaping of quotes and newlines) and updated `tests/test_cli.py`'s arg baseline for the new flag. No regressions; `--graph` still works.
- Live import: generated the Cypher from a real scan and imported it into Neo4j 5 with zero errors (25 nodes / 26 relationships; idempotent on re-import).
- Docs: added `--neo4j` to the README usage block and `docs/source/command-line-options.rst`.

Note: the `CREATE CONSTRAINT ... IF NOT EXISTS FOR ... REQUIRE` line uses Neo4j 4.4+ syntax; the `MERGE` statements keep the import idempotent on any version.
