### PR TITLE
docs: fix typos

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -25,7 +25,7 @@ After start Maigret tries to load configuration from the following sources in ex
 
 Missing any of these files is not an error.
 If the next settings file contains already known option,
-this option will be rewrited. So it is possible to make
+this option will be rewritten. So it is possible to make
 custom configuration for different users and directories.
 
 .. _database-auto-update:

--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -689,7 +689,7 @@ def process_site_result(
         )
 
     site_name = site.pretty_name
-    # presense flags
+    # presence flags
     # True by default
     presense_flags = site.presense_strs
     is_presense_detected = False


### PR DESCRIPTION
## Summary
- Fix a small set of spelling mistakes in documentation/comments.
- Keep the change scoped to text-only cleanup.

## Validation
- git diff --check