### PR TITLE
Fix HackerNews and Rajce.net false positives

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3003,6 +3003,9 @@
                 "news"
             ],
             "checkType": "message",
+            "presenseStrs": [
+                "karma:"
+            ],
             "absenceStrs": [
                 "No such user"
             ],
@@ -5601,7 +5604,13 @@
                 "cz"
             ],
             "regexCheck": "^[^\\.]+$",
-            "checkType": "status_code",
+            "checkType": "message",
+            "presenseStrs": [
+                "\"user\":{\"username\":\""
+            ],
+            "absenceStrs": [
+                "Uživatel neexistuje"
+            ],
             "urlMain": "https://www.rajce.idnes.cz/",
             "url": "https://{username}.rajce.idnes.cz/",
             "usernameClaimed": "blue",

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-06-14T19:47:07Z",
+    "updated_at": "2026-06-18T12:23:06Z",
     "sites_count": 3161,
     "min_maigret_version": "0.6.1",
-    "data_sha256": "d1e339a7d7839b6e4fe2ff0440138f5ce8a5d1da8ff0a4be9b936368756315c0",
+    "data_sha256": "0da1607d2d82e27a875daec64ec13fed37e47e29b7c236b64e423778d66674d1",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -3165,16 +3165,16 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://faceit.com/) [Faceit (https://faceit.com/)](https://faceit.com/)*: top 100M, gaming*
 1. ![](https://www.google.com/s2/favicons?domain=https://hey.xyz/) [Hey (https://hey.xyz/)](https://hey.xyz/)*: top 100M, nft, social*
 
-The list was updated at (2026-06-10)
+The list was updated at (2026-06-18)
 ## Statistics
 
 Enabled/total sites: 2517/3161 = 79.63%
 
-Incomplete message checks: 308/2517 = 12.24% (false positive risks)
+Incomplete message checks: 307/2517 = 12.2% (false positive risks)
 
-Status code checks: 629/2517 = 24.99% (false positive risks)
+Status code checks: 628/2517 = 24.95% (false positive risks)
 
-False positive risk (total): 37.23%
+False positive risk (total): 37.15%
 
 Sites with probing: 500px, Armchairgm, BinarySearch (disabled), BleachFandom, Bluesky, BongaCams, Boosty, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, Discord, Diskusjon.no, Disqus, Docker Hub, Duolingo, Faceit, FandomCommunityCentral, GitHub, GitLab, Google Plus (archived), Gravatar, HackTheBox, Hackerrank, Hashnode, Hey, Holopin, Imgur, Instagram, Issuu, Keybase, Kick, Kvinneguiden, LeetCode, Lesswrong, Livejasmin, LocalCryptos (disabled), Matrix, Medium, MicrosoftLearn, MixCloud, Monkeytype, NPM, Niftygateway, Omg.lol, OnlyFans, Paragraph, Picsart, Plurk, Polarsteps, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), YouNow, en.brickimedia.org, forums.grandstream.com, nightbot, notabug.org, qiwi.me (disabled)
 

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -374,6 +374,58 @@ def test_process_site_result_message_available_by_absence():
     assert out["status"].status == MaigretCheckStatus.AVAILABLE
 
 
+def _process_default_site(site, body, status_code=200, username="random"):
+    info = {
+        "username": username,
+        "parsing_enabled": False,
+        "url_user": site.url.replace("{username}", username),
+    }
+    return process_site_result((body, status_code, None), Mock(), Mock(), info, site)
+
+
+def test_hackernews_requires_profile_marker(default_db):
+    site = default_db.sites_dict["HackerNews"]
+
+    claimed = _process_default_site(
+        site,
+        "<tr><td>user:</td><td>blue</td></tr>"
+        "<tr><td>created:</td><td>January 1, 2020</td></tr>"
+        "<tr><td>karma:</td><td>1</td></tr>",
+        username="blue",
+    )
+    missing = _process_default_site(site, "No such user.", username="random-hn-user")
+    generic = _process_default_site(site, "Sorry.", username="random-hn-user")
+
+    assert claimed["status"].status == MaigretCheckStatus.CLAIMED
+    assert missing["status"].status == MaigretCheckStatus.AVAILABLE
+    assert generic["status"].status == MaigretCheckStatus.AVAILABLE
+
+
+def test_rajce_requires_profile_marker(default_db):
+    site = default_db.sites_dict["Rajce.net"]
+
+    claimed = _process_default_site(
+        site,
+        '<script>var settings = {"user":{"username":"blue"}}</script>',
+        username="blue",
+    )
+    missing = _process_default_site(
+        site,
+        "<title>Uživatel neexistuje</title>",
+        status_code=410,
+        username="random-rajce-user",
+    )
+    generic = _process_default_site(
+        site,
+        "<html><title>Rajce.net</title></html>",
+        username="random-rajce-user",
+    )
+
+    assert claimed["status"].status == MaigretCheckStatus.CLAIMED
+    assert missing["status"].status == MaigretCheckStatus.AVAILABLE
+    assert generic["status"].status == MaigretCheckStatus.AVAILABLE
+
+
 def test_process_site_result_with_error_is_unknown():
     site = _make_site({"checkType": "status_code"})
     info = {"username": "a", "parsing_enabled": False, "url_user": "https://x/a"}


### PR DESCRIPTION
## What changed

- Tightened the HackerNews probe by requiring the profile-specific `karma:` marker, preventing generic pages from being treated as claimed profiles.
- Changed Rajce.net from a status-code-only check to a message-based check requiring the real profile marker (`"user":{"username":"`) and recognizing the missing-user page (`Uživatel neexistuje`).

## Tests added

### HackerNews

- claimed profile marker detection
- missing user response
- generic `Sorry.` response

### Rajce.net

- claimed profile marker detection
- missing-user page
- generic landing page

## Verification

```text
python -m pytest tests\test_checking.py -q
47 passed in 7.27s

python -m pip check
No broken requirements found.
```