### PR TITLE
Fix error-percentage rounding tripping thresholds at whole-percent granularity

### DIFF
--- a/maigret/errors.py
+++ b/maigret/errors.py
@@ -168,7 +168,11 @@ def extract_and_group(search_res: QueryResultWrapper) -> List[Dict[str, Any]]:
             {
                 'err': err,
                 'count': count,
-                'perc': round(count / len(search_res), 2) * 100,
+                # Scale to a percentage first, THEN round. Rounding the raw
+                # fraction (round(x, 2)) only keeps whole-percent granularity,
+                # so e.g. 1/40 = 2.5% became 0.03 * 100 = 3.0% and tripped the
+                # 3% "important" threshold for an error rate that is below it.
+                'perc': round(count / len(search_res) * 100, 2),
             }
         )
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -68,6 +68,29 @@ def test_notify_about_errors():
     assert notifications == expected_output
 
 
+def test_below_threshold_non_integer_percent_stays_silent():
+    # 1 Captcha error out of 40 sites = 2.5%, below the 3% threshold. The raw
+    # fraction must be scaled to a percentage before rounding; rounding the
+    # fraction first turned 2.5% into 3.0% and fired a spurious warning.
+    results = {
+        'cap': {
+            'status': MaigretCheckResult(
+                '', '', '', MaigretCheckStatus.UNKNOWN, error=CheckError('Captcha')
+            )
+        }
+    }
+    for i in range(39):
+        results[f'ok{i}'] = {
+            'status': MaigretCheckResult(
+                '', '', '', MaigretCheckStatus.CLAIMED, error=None
+            )
+        }
+
+    notifications = notify_about_errors(results, query_notify=None)
+
+    assert all('Captcha' not in n[0] for n in notifications), notifications
+
+
 # Tests for the DNS-vs-generic split of "Connecting failure" introduced for
 # https://github.com/soxoj/maigret/issues/2688 — when the user's machine
 # cannot reach a DNS server, the result was previously reported as plain


### PR DESCRIPTION
## Summary

`extract_and_group` (`maigret/errors.py`) computes each error type's
percentage by rounding the **fraction** before scaling, so the value only ever
has whole-percent granularity and is mis-rounded across the "important"
threshold — producing spurious error warnings.

```python
'perc': round(count / len(search_res), 2) * 100,
```

`round(0.025, 2)` is `0.03`, so `* 100` gives `3.0`. A genuine **2.5%** error
rate (1 error out of 40 sites) is reported as **3.0%** and trips the 3%
threshold in `is_important()` → a spurious *"Too many errors of type Captcha
(3.0%)"* warning fires for a rate that should stay silent. Likewise a **9.5%**
DNS error rate rounds to **10.0%** and crosses the `Connecting failure (DNS)`
override.

`perc` feeds both `is_important()`'s threshold test and the displayed text, so
this is a behavioral (mis)classification, not just a cosmetic rounding nit.

## Fix

Scale to a percentage **before** rounding:

```python
'perc': round(count / len(search_res) * 100, 2),
```

| errors / sites | before | after | threshold |
|---|---|---|---|
| 1 / 40 (Captcha) | 3.0% → **fires** | 2.5% → silent | 3% |
| 95 / 1000 (DNS) | 10.0% → **fires** | 9.5% → silent | 10% |
| 4 / 40 (Captcha) | 10.0% → fires | 10.0% → fires | 3% |

## Testing

```text
$ pytest tests/test_errors.py -q
21 passed
```

The existing tests use integer-landing ratios (25/100, 5/100, 3/100) that are
identical under both formulas, so none change. Adds a regression test for a
sub-threshold non-integer rate (2.5%) staying silent.
