### PR TITLE
test: cover #2666 TODO-test paths (cookie_jar, extract_ids_from_results)

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -244,7 +244,6 @@ class SimpleAiohttpChecker(CheckerBase):
         async with ClientSession(
             connector=connector,
             trust_env=True,
-            # TODO: tests
             cookie_jar=self.cookie_jar if self.cookie_jar else None,
         ) as session:
             html_text, status_code, error = await self._make_request(

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -943,7 +943,6 @@ async def main():
 
         general_results.append((username, id_type, results))
 
-        # TODO: tests
         if recursive_search_enabled:
             extracted_ids = extract_ids_from_results(results, db)
             query_notify.warning(f'Extracted IDs: {extracted_ids}')

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -902,3 +902,90 @@ async def test_dns_resolver_async_omits_resolver_kwarg(monkeypatch):
         "Default dns_resolver='async' must not pass a resolver kwarg — let "
         "aiohttp pick DefaultResolver"
     )
+
+
+# -----------------------------------------------------------------------------
+# cookie_jar forwarding (issue #2666). SimpleAiohttpChecker.check() builds the
+# ClientSession with `cookie_jar=self.cookie_jar if self.cookie_jar else None`,
+# but the path was flagged `# TODO: tests` because nothing asserted the jar
+# passed to the checker actually reached the outgoing ClientSession.
+# -----------------------------------------------------------------------------
+
+
+def _capture_clientsession(monkeypatch):
+    """Replace aiohttp.ClientSession with a constructor-recorder so we can
+    assert on the kwargs it received (cookie_jar in particular) without
+    opening any sockets. Mirrors the _capture_tcpconnector pattern above."""
+    from maigret import checking
+    captured = []
+
+    class _DummySession:
+        def __init__(self, *args, **kwargs):
+            captured.append(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(checking, 'ClientSession', _DummySession)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_cookie_jar_forwarded_to_clientsession(monkeypatch):
+    """Issue #2666: the cookie_jar passed to SimpleAiohttpChecker must reach
+    ClientSession(cookie_jar=...) on the outgoing request. Reuses the
+    constructor-capture pattern from the DNS-resolver tests above.
+
+    A sentinel object stands in for the real aiohttp.CookieJar: check() only
+    does `self.cookie_jar if self.cookie_jar else None`, so any truthy object
+    proves the forwarding. Avoiding CookieJar() also sidesteps its event-loop
+    requirement under pytest-asyncio, keeping this a pure unit test."""
+    from maigret.checking import SimpleAiohttpChecker
+
+    captured = _capture_clientsession(monkeypatch)
+    _capture_tcpconnector(monkeypatch)  # keep check() from opening a socket
+
+    sentinel_jar = object()  # any truthy stand-in for the CookieJar
+    checker = SimpleAiohttpChecker(logger=Mock(), cookie_jar=sentinel_jar)
+    checker.prepare(url='https://example.com/u/test')
+    try:
+        await checker.check()
+    except Exception:
+        pass
+
+    assert captured, "ClientSession was never constructed — check() bailed out earlier"
+    init_kwargs = captured[0]
+    assert init_kwargs.get('cookie_jar') is sentinel_jar, (
+        "cookie_jar passed to SimpleAiohttpChecker was not forwarded to ClientSession"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_cookie_jar_passes_none_to_clientsession(monkeypatch):
+    """Counterpart to the above: with no cookie_jar configured, ClientSession
+    must receive `cookie_jar=None` (the `else None` branch), not the default
+    aiohttp CookieJar — maigret manages cookie persistence explicitly via
+    import_aiohttp_cookies and must not let aiohttp silently persist cookies."""
+    from maigret.checking import SimpleAiohttpChecker
+
+    captured = _capture_clientsession(monkeypatch)
+    _capture_tcpconnector(monkeypatch)
+
+    checker = SimpleAiohttpChecker(logger=Mock())  # no cookie_jar
+    checker.prepare(url='https://example.com/u/test')
+    try:
+        await checker.check()
+    except Exception:
+        pass
+
+    assert captured, "ClientSession was never constructed — check() bailed out earlier"
+    init_kwargs = captured[0]
+    assert init_kwargs.get('cookie_jar') is None, (
+        "No cookie_jar configured, but ClientSession received a non-None cookie_jar"
+    )

--- a/tests/test_maigret.py
+++ b/tests/test_maigret.py
@@ -192,15 +192,56 @@ def test_extract_ids_from_page(test_db):
     }
 
 
-def test_extract_ids_from_results(test_db):
+def test_extract_ids_from_results_aggregates_usernames_and_links(default_db):
+    """Covers the recursive ID-extraction path flagged at maigret.py:946
+    (`# TODO: tests`, `if recursive_search_enabled: extract_ids_from_results(...)`).
+
+    The previous incarnation of this test was a bare expression
+    (`extract_ids_from_results(...) == {...}`) with no `assert`, so it silently
+    passed regardless of the return value. It also pinned the result against
+    `test_db` (tests/db.json), whose site set never matched the Reddit URL and
+    thus returned `{'test1': ...}` — silently dropping `test2`. Restored here as
+    a real assertion against `default_db`, which carries the Reddit URL pattern.
+    """
     TEST_EXAMPLE: dict = copy.deepcopy(RESULTS_EXAMPLE)
     TEST_EXAMPLE['Reddit']['ids_usernames'] = {'test1': 'yandex_public_id'}
     TEST_EXAMPLE['Reddit']['ids_links'] = ['https://www.reddit.com/user/test2']
 
-    extract_ids_from_results(TEST_EXAMPLE, test_db) == {
+    assert extract_ids_from_results(TEST_EXAMPLE, default_db) == {
         'test1': 'yandex_public_id',
         'test2': 'username',
     }
+
+
+def test_extract_ids_from_results_merges_ids_usernames_across_sites(default_db):
+    """ids_usernames from every site must be merged into the result dict,
+    keyed by username with the per-site id type as the value."""
+    example = {
+        'SiteA': {'ids_usernames': {'alice': 'username', 'bob': 'telegram'}},
+        'SiteB': {'ids_usernames': {'carol': 'username'}},
+    }
+    assert extract_ids_from_results(example, default_db) == {
+        'alice': 'username',
+        'bob': 'telegram',
+        'carol': 'username',
+    }
+
+
+def test_extract_ids_from_results_skips_empty_site_entry(default_db):
+    """A site whose result dict is empty (`{}`) must be skipped via
+    `if not dictionary: continue` rather than raising on the subsequent
+    `.get('ids_usernames')` / `.get('ids_links')` calls."""
+    example = {
+        'EmptySite': {},
+        'SiteA': {'ids_usernames': {'alice': 'username'}},
+    }
+    assert extract_ids_from_results(example, default_db) == {'alice': 'username'}
+
+
+def test_extract_ids_from_results_empty_input_returns_empty(default_db):
+    """No sites searched → no extracted ids. Guards against accidental
+    KeyError / iteration over None."""
+    assert extract_ids_from_results({}, default_db) == {}
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2666.

## Summary

Issue #2666 tracks four code paths the original author flagged `# TODO: tests`. I cloned current `main` and checked each — two of the four no longer exist:

| issue line | current state | this PR |
|---|---|---|
| `checking.py:204` cookie_jar | alive, now `checking.py:247` | ✅ covered |
| `executors.py:113` increment_progress | removed by #2789 refactor | n/a |
| `executors.py:123` stop_progress | removed by #2789 refactor | n/a |
| `maigret.py:857` recursive ID | alive, now `maigret.py:946` | ✅ covered |

`executors.py` is 76 lines now; `increment_progress` / `stop_progress` are gone (grep returns nothing):
```
$ grep -n 'def increment_progress\|def stop_progress' maigret/executors.py
(no matches)
```

## What this adds

**1. `maigret/checking.py:247` — ClientSession cookie_jar forwarding**

`SimpleAiohttpChecker.check()` builds `ClientSession(..., cookie_jar=self.cookie_jar if self.cookie_jar else None)`, but nothing asserted the jar handed to the checker actually reached the outgoing session. Two tests in `tests/test_checking.py`, using the existing constructor-capture pattern (`_capture_clientsession`, mirroring `_capture_tcpconnector`):
- a configured jar is forwarded verbatim to `ClientSession(cookie_jar=...)`
- with no jar configured, `None` is passed (the `else` branch)

**2. `maigret/maigret.py:946` — `extract_ids_from_results`**

The pre-existing `test_extract_ids_from_results` had **two** problems:
- it was a bare expression — `extract_ids_from_results(...) == {...}` with no `assert`, so it silently passed regardless of return value
- it pinned its expectation against `test_db` (`tests/db.json`), whose site set never matched the Reddit URL, so `ids_links` resolution silently returned `{}` and dropped `test2` — the expected dict was wrong

Fixed: real `assert` against `default_db` (which carries the Reddit URL pattern), plus three branch tests: cross-site username merge, empty-site skip (`if not dictionary: continue`), and empty input.

## Design notes

- **No new dependencies.** The issue suggested `aioresponses`, but it's not a project dependency. The existing monkeypatch constructor-capture pattern (`_capture_tcpconnector` / `_capture_clientsession`) already in `tests/test_checking.py` fits the codebase better and adds zero deps.
- **No business-logic changes.** Pure test additions + removing the two now-fulfilled `# TODO: tests` comments.

## Verification

```
$ poetry run pytest tests/test_checking.py tests/test_maigret.py -q -m "not slow"
52 passed, 10 deselected

$ poetry run flake8 --count --select=E9,F63,F7,F82 tests/test_checking.py tests/test_maigret.py maigret/checking.py maigret/maigret.py
0
```

`checking.py:247` no longer appears in the uncovered-lines list. `maigret.py:946` is in a large function-level uncovered block (the `search()` main flow); this PR covers the `extract_ids_from_results` function it calls, which is the unit the issue said to pair it with (`should be paired with the extract_ids_from_results work`).

The two `test_web.py` / `test_submit.py` failures on my local run are pre-existing network-dependent tests (time out reaching `play.google.com`) unrelated to these changes.