### PR TITLE
refactor: drop dead 'if not dictionary' guards across report paths

### DIFF
--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -97,10 +97,6 @@ def extract_ids_from_results(results: Dict[str, SiteResult], db: MaigretDatabase
     ids_results = {}
     for website_name in results:
         dictionary = results[website_name]
-        # TODO: fix no site data issue
-        if not dictionary:
-            continue
-
         new_usernames = dictionary.get('ids_usernames')
         if new_usernames:
             for u, utype in new_usernames.items():

--- a/maigret/report.py
+++ b/maigret/report.py
@@ -148,7 +148,7 @@ def save_graph_report(filename: str, username_results: list, db: MaigretDatabase
         username_node_name = graph.add_node(id_type, norm_username)
 
         for website_name, dictionary in results.items():
-            if not dictionary or dictionary.get("is_similar"):
+            if dictionary.get("is_similar"):
                 continue
 
             status = dictionary.get("status")
@@ -463,10 +463,6 @@ def generate_report_context(username_results: list):
 
         for website_name in results:
             dictionary = results[website_name]
-            # TODO: fix no site data issue
-            if not dictionary:
-                continue
-
             if dictionary.get("is_similar"):
                 continue
 
@@ -605,9 +601,6 @@ def generate_txt_report(username: str, results: dict, file):
     exists_counter = 0
     for website_name in results:
         dictionary = results[website_name]
-        # TODO: fix no site data issue
-        if not dictionary:
-            continue
         if (
             dictionary.get("status")
             and dictionary["status"].status == MaigretCheckStatus.CLAIMED
@@ -623,8 +616,7 @@ def generate_json_report(username: str, results: dict, file, report_type):
 
     for sitename in results:
         site_result = results[sitename]
-        # TODO: fix no site data issue
-        if not site_result or not site_result.get("status"):
+        if not site_result.get("status"):
             continue
 
         if site_result["status"].status != MaigretCheckStatus.CLAIMED:
@@ -684,8 +676,6 @@ def design_xmind_sheet(sheet, username, results):
 
     for website_name in results:
         dictionary = results[website_name]
-        if not dictionary:
-            continue
         result_status = dictionary.get("status")
         # TODO: fix the reason
         if not result_status or result_status.status != MaigretCheckStatus.CLAIMED:


### PR DESCRIPTION
Closes #2665.

## Summary

The four `if not dictionary: continue` guards across the report paths (all tagged `# TODO: fix no site data issue`) are dead code — the falsy entries they guard against cannot occur. This removes them.

## Why they're dead

Every site results entry flows through **`make_site_result`** (`maigret/checking.py:788`):

- initializes `results_site = {}`
- then unconditionally populates it: `site` / `username` / `keywords` / `parsing_enabled` / `url_main` / `cookies` up front, `checker` at the end
- every branch sets `status` (disabled / wrong id_type / bad username) **or** `url_user` + `future` (normal path)
- **no return path yields an empty dict**

`check_site_for_username` wraps that result and likewise never returns a falsy entry. `maigret.py` does not construct site-result dicts by hand (its `results[v] = k` / `results[username] = 'username'` are the username→id_type map in a different function).

So the downstream guards were defending against an input that the writers cannot produce.

## Changes

Removed the dead guard + `# TODO: fix no site data issue` at:

- `maigret/maigret.py:101` — `extract_ids_from_results`
- `maigret/report.py:467` — extended-report builder
- `maigret/report.py:609` — `generate_txt_report`
- `maigret/report.py:687` — `generate_json_report`

**Trimmed** (kept the real logic, dropped only the dead `not dictionary` / `not site_result` part):

- `maigret/report.py:151` — `if not dictionary or dictionary.get("is_similar")` → `if dictionary.get("is_similar")`
- `maigret/report.py:627` — `if not site_result or not site_result.get("status")` → `if not site_result.get("status")`

## Safety

No behavior change for well-formed inputs. Downstream `.get()` calls are safe because entries are always populated dicts. "If no: drop all four guards" is the resolution branch #2665 itself prescribes for this case.

## Verification

```
$ poetry run pytest tests -q -m "not slow"
292 passed, 1 skipped, 24 deselected

$ poetry run flake8 --count --select=E9,F63,F7,F82 maigret/maigret.py maigret/report.py
0
```

(Follow-up to #2795, same audit-the-TODOs theme.)