### PR TITLE
fix(report): keep failure reason in CSV and XMind exports (#2667)

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -29,6 +29,21 @@ UTILS
 """
 
 
+def get_failure_reason(result) -> str:
+    """Human-readable reason a check did not yield a claimed profile.
+
+    Returns the structured ``CheckError`` text when present (e.g.
+    "Captcha error: Cloudflare"), otherwise the free-form ``context``
+    string that the HTML and JSON reports already surface, or an empty
+    string when neither is available (e.g. a plain not-found result).
+    """
+    if getattr(result, "error", None) is not None:
+        return str(result.error)
+    if getattr(result, "context", None) is not None:
+        return str(result.context)
+    return ''
+
+
 def filter_supposed_data(data):
     allowed_fields = ["fullname", "gender", "location", "age"]
 
@@ -578,13 +593,15 @@ def generate_report_context(username_results: list):
 def generate_csv_report(username: str, results: dict, csvfile):
     writer = csv.writer(csvfile)
     writer.writerow(
-        ["username", "name", "url_main", "url_user", "exists", "http_status"]
+        ["username", "name", "url_main", "url_user", "exists", "http_status", "error_reason"]
     )
     for site in results:
-        # TODO: fix the reason
         status = 'Unknown'
-        if "status" in results[site]:
-            status = str(results[site]["status"].status)
+        reason = ''
+        result = results[site].get("status")
+        if result is not None:
+            status = str(result.status)
+            reason = get_failure_reason(result)
         writer.writerow(
             [
                 username,
@@ -593,6 +610,7 @@ def generate_csv_report(username: str, results: dict, csvfile):
                 results[site].get("url_user", ""),
                 status,
                 results[site].get("http_status", 0),
+                reason,
             ]
         )
 
@@ -677,8 +695,13 @@ def design_xmind_sheet(sheet, username, results):
     for website_name in results:
         dictionary = results[website_name]
         result_status = dictionary.get("status")
-        # TODO: fix the reason
         if not result_status or result_status.status != MaigretCheckStatus.CLAIMED:
+            # Surface the reason a check failed (e.g. captcha, blocked) under
+            # the "Undefined" branch instead of dropping the site silently.
+            reason = get_failure_reason(result_status) if result_status else ''
+            if reason:
+                errortopic = alltags["undefined"].addSubTopic()
+                errortopic.setTitle("%s: %s" % (website_name, reason))
             continue
 
         stripped_tags = list(map(lambda x: x.strip(), result_status.tags))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -31,6 +31,7 @@ from maigret.report import (
     generate_json_report,
     get_plaintext_report,
 )
+from maigret.errors import CheckError
 from maigret.result import MaigretCheckResult, MaigretCheckStatus
 from maigret.sites import MaigretSite
 
@@ -65,6 +66,28 @@ BROKEN_RESULTS = {
         'url_main': 'https://www.github.com/',
         'url_user': 'https://www.github.com/test',
         'http_status': 200,
+        'is_similar': False,
+        'rank': 78,
+        'site': MaigretSite('test', {}),
+    }
+}
+
+# A site that errored out (e.g. captcha) rather than returning a clean
+# claimed/available verdict. CSV and XMind reports must keep the reason.
+ERROR_RESULTS = {
+    'GitHub': {
+        'username': 'test',
+        'parsing_enabled': True,
+        'url_main': 'https://www.github.com/',
+        'url_user': 'https://www.github.com/test',
+        'status': MaigretCheckResult(
+            'test',
+            'GitHub',
+            'https://www.github.com/test',
+            MaigretCheckStatus.UNKNOWN,
+            error=CheckError('Captcha', 'Cloudflare'),
+        ),
+        'http_status': 403,
         'is_similar': False,
         'rank': 78,
         'site': MaigretSite('test', {}),
@@ -294,8 +317,8 @@ def test_generate_csv_report():
     data = csvfile.readlines()
 
     assert data == [
-        'username,name,url_main,url_user,exists,http_status\r\n',
-        'test,GitHub,https://www.github.com/,https://www.github.com/test,Claimed,200\r\n',
+        'username,name,url_main,url_user,exists,http_status,error_reason\r\n',
+        'test,GitHub,https://www.github.com/,https://www.github.com/test,Claimed,200,\r\n',
     ]
 
 
@@ -307,8 +330,22 @@ def test_generate_csv_report_broken():
     data = csvfile.readlines()
 
     assert data == [
-        'username,name,url_main,url_user,exists,http_status\r\n',
-        'test,GitHub,https://www.github.com/,https://www.github.com/test,Unknown,200\r\n',
+        'username,name,url_main,url_user,exists,http_status,error_reason\r\n',
+        'test,GitHub,https://www.github.com/,https://www.github.com/test,Unknown,200,\r\n',
+    ]
+
+
+def test_generate_csv_report_with_error_reason():
+    csvfile = StringIO()
+    generate_csv_report('test', ERROR_RESULTS, csvfile)
+
+    csvfile.seek(0)
+    data = csvfile.readlines()
+
+    assert data == [
+        'username,name,url_main,url_user,exists,http_status,error_reason\r\n',
+        'test,GitHub,https://www.github.com/,https://www.github.com/test,'
+        'Unknown,403,Captcha error: Cloudflare\r\n',
     ]
 
 
@@ -408,6 +445,19 @@ def test_save_xmind_report_broken():
     assert data['topic']['title'] == 'test'
     assert len(data['topic']['topics']) == 1
     assert data['topic']['topics'][0]['title'] == 'Undefined'
+
+
+def test_save_xmind_report_with_error_reason():
+    filename = 'report_test.xmind'
+    save_xmind_report(filename, 'test', ERROR_RESULTS)
+
+    workbook = xmind.load(filename)
+    sheet = workbook.getPrimarySheet()
+    data = sheet.getData()
+
+    undefined = data['topic']['topics'][0]
+    assert undefined['title'] == 'Undefined'
+    assert undefined['topics'][0]['title'] == 'GitHub: Captcha error: Cloudflare'
 
 
 def test_html_report():


### PR DESCRIPTION
## Problem

Closes #2667.

Both report generators dropped the per-site failure reason that the HTML/JSON reports keep:

- **CSV** (`generate_csv_report`): wrote a literal `Unknown` in the `exists` column and discarded any error context — you couldn't tell a captcha / blocked / timeout from a plain not-found.
- **XMind** (`design_xmind_sheet`): silently filtered out every non-`CLAIMED` site.

Both spots carried the `# TODO: fix the reason` marker.

## Fix

- Add an `error_reason` column to the CSV report, appended after `http_status` so existing column positions are unchanged.
- Surface non-`CLAIMED` sites that have a known error under the XMind **Undefined** branch as `"<site>: <reason>"`, instead of dropping them.
- Both read from a small `get_failure_reason()` helper: the structured `CheckError` text (e.g. `Captcha error: Cloudflare`), falling back to the free-form `context` string, else empty.

Sites with no error info (plain not-found, or a result with no `status` at all) keep the previous behaviour — empty reason, nothing added to the XMind tree — so the change only ever *adds* signal.

### CSV before / after (errored site)

```
# before
username,name,url_main,url_user,exists,http_status
test,GitHub,...,...,Unknown,403

# after
username,name,url_main,url_user,exists,http_status,error_reason
test,GitHub,...,...,Unknown,403,Captcha error: Cloudflare
```

## Tests

Added `test_generate_csv_report_with_error_reason` and `test_save_xmind_report_with_error_reason`, and updated the existing CSV header assertions. They fail against the unpatched code and pass with the fix.

```
$ pytest tests/test_report.py -q
38 passed, 1 skipped in 0.22s
```

Fails-before (new tests against unpatched `report.py`): 4 failed — header missing `error_reason` / XMind branch absent.

No new dependencies; the helper uses only core modules, so the `minimal-install` (no `[pdf]` extra) path is unaffected.