### PR TITLE
fix: preserve report error reasons

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -578,13 +578,22 @@ def generate_report_context(username_results: list):
 def generate_csv_report(username: str, results: dict, csvfile):
     writer = csv.writer(csvfile)
     writer.writerow(
-        ["username", "name", "url_main", "url_user", "exists", "http_status"]
+        [
+            "username",
+            "name",
+            "url_main",
+            "url_user",
+            "exists",
+            "http_status",
+            "error_reason",
+        ]
     )
     for site in results:
-        # TODO: fix the reason
         status = 'Unknown'
-        if "status" in results[site]:
-            status = str(results[site]["status"].status)
+        result_status = results[site].get("status")
+        error_reason = _get_result_error_reason(result_status)
+        if result_status:
+            status = str(result_status.status)
         writer.writerow(
             [
                 username,
@@ -593,8 +602,28 @@ def generate_csv_report(username: str, results: dict, csvfile):
                 results[site].get("url_user", ""),
                 status,
                 results[site].get("http_status", 0),
+                error_reason,
             ]
         )
+
+
+def _get_result_error_reason(result_status):
+    if not result_status:
+        return 'Unknown'
+
+    if result_status.error:
+        context = getattr(result_status.error, 'context', None)
+        if context:
+            return str(context)
+        return str(result_status.error)
+
+    if result_status.context:
+        return str(result_status.context)
+
+    if result_status.status == MaigretCheckStatus.UNKNOWN:
+        return 'Unknown'
+
+    return ''
 
 
 def generate_txt_report(username: str, results: dict, file):
@@ -673,12 +702,24 @@ def design_xmind_sheet(sheet, username, results):
     undefinedsection = root_topic1.addSubTopic()
     undefinedsection.setTitle("Undefined")
     alltags["undefined"] = undefinedsection
+    error_section = None
 
     for website_name in results:
         dictionary = results[website_name]
         result_status = dictionary.get("status")
-        # TODO: fix the reason
         if not result_status or result_status.status != MaigretCheckStatus.CLAIMED:
+            error_reason = _get_result_error_reason(result_status)
+            if not error_reason:
+                continue
+
+            if error_section is None:
+                error_section = root_topic1.addSubTopic()
+                error_section.setTitle("Errors")
+
+            userlink = error_section.addSubTopic()
+            userlink.setTitle(f"{website_name}: {error_reason}")
+            if dictionary.get("url_user"):
+                userlink.addLabel(dictionary["url_user"])
             continue
 
         stripped_tags = list(map(lambda x: x.strip(), result_status.tags))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -31,6 +31,7 @@ from maigret.report import (
     generate_json_report,
     get_plaintext_report,
 )
+from maigret.errors import CheckError
 from maigret.result import MaigretCheckResult, MaigretCheckStatus
 from maigret.sites import MaigretSite
 
@@ -65,6 +66,26 @@ BROKEN_RESULTS = {
         'url_main': 'https://www.github.com/',
         'url_user': 'https://www.github.com/test',
         'http_status': 200,
+        'is_similar': False,
+        'rank': 78,
+        'site': MaigretSite('test', {}),
+    }
+}
+
+ERROR_RESULTS = {
+    'GitHub': {
+        'username': 'test',
+        'parsing_enabled': True,
+        'url_main': 'https://www.github.com/',
+        'url_user': 'https://www.github.com/test',
+        'status': MaigretCheckResult(
+            'test',
+            'GitHub',
+            'https://www.github.com/test',
+            MaigretCheckStatus.UNKNOWN,
+            error=CheckError('Request timeout', 'slow server'),
+        ),
+        'http_status': 0,
         'is_similar': False,
         'rank': 78,
         'site': MaigretSite('test', {}),
@@ -294,8 +315,8 @@ def test_generate_csv_report():
     data = csvfile.readlines()
 
     assert data == [
-        'username,name,url_main,url_user,exists,http_status\r\n',
-        'test,GitHub,https://www.github.com/,https://www.github.com/test,Claimed,200\r\n',
+        'username,name,url_main,url_user,exists,http_status,error_reason\r\n',
+        'test,GitHub,https://www.github.com/,https://www.github.com/test,Claimed,200,\r\n',
     ]
 
 
@@ -307,8 +328,21 @@ def test_generate_csv_report_broken():
     data = csvfile.readlines()
 
     assert data == [
-        'username,name,url_main,url_user,exists,http_status\r\n',
-        'test,GitHub,https://www.github.com/,https://www.github.com/test,Unknown,200\r\n',
+        'username,name,url_main,url_user,exists,http_status,error_reason\r\n',
+        'test,GitHub,https://www.github.com/,https://www.github.com/test,Unknown,200,Unknown\r\n',
+    ]
+
+
+def test_generate_csv_report_error_reason():
+    csvfile = StringIO()
+    generate_csv_report('test', ERROR_RESULTS, csvfile)
+
+    csvfile.seek(0)
+    data = csvfile.readlines()
+
+    assert data == [
+        'username,name,url_main,url_user,exists,http_status,error_reason\r\n',
+        'test,GitHub,https://www.github.com/,https://www.github.com/test,Unknown,0,Request timeout error: slow server\r\n',
     ]
 
 
@@ -406,8 +440,33 @@ def test_save_xmind_report_broken():
 
     assert data['title'] == 'test Analysis'
     assert data['topic']['title'] == 'test'
-    assert len(data['topic']['topics']) == 1
+    assert len(data['topic']['topics']) == 2
     assert data['topic']['topics'][0]['title'] == 'Undefined'
+    assert data['topic']['topics'][1]['title'] == 'Errors'
+    assert data['topic']['topics'][1]['topics'][0]['title'] == 'GitHub: Unknown'
+
+
+def test_save_xmind_report_error_reason():
+    filename = 'report_test.xmind'
+    save_xmind_report(filename, 'test', ERROR_RESULTS)
+
+    workbook = xmind.load(filename)
+    sheet = workbook.getPrimarySheet()
+    data = sheet.getData()
+
+    assert data['title'] == 'test Analysis'
+    assert data['topic']['title'] == 'test'
+    assert len(data['topic']['topics']) == 2
+    assert data['topic']['topics'][0]['title'] == 'Undefined'
+    assert data['topic']['topics'][1]['title'] == 'Errors'
+    assert (
+        data['topic']['topics'][1]['topics'][0]['title']
+        == 'GitHub: Request timeout error: slow server'
+    )
+    assert (
+        data['topic']['topics'][1]['topics'][0]['label']
+        == 'https://www.github.com/test'
+    )
 
 
 def test_html_report():


### PR DESCRIPTION
## Summary
- add an `error_reason` column to CSV reports so failed checks keep their reason
- include missing/error statuses in XMind under an `Errors` section instead of dropping them silently
- centralize report error reason formatting for CheckError, context, and missing-status cases
- add regression tests for CSV and XMind error reason output

## Verification
- python -m pytest tests/test_report.py

Closes #2667
