### PR TITLE
Add archive.org and archive.is links to profile URL blocks

### DIFF
--- a/maigret/resources/simple_report.tpl
+++ b/maigret/resources/simple_report.tpl
@@ -78,6 +78,7 @@
                     {% endif %}
                     <p class="card-text">
                         <a href="{{ v.url_user }}" target="_blank">{{ v.url_user }}</a>
+                        <span class="text-muted small">(<a href="https://web.archive.org/web/*/{{ v.url_user }}" target="_blank">web.archive.org</a>, <a href="https://archive.is/newest/{{ v.url_user }}" target="_blank">archive.is</a>)</span>
                     </p>
                     {% if v.ids_data %}
                     <table class="table table-striped">

--- a/maigret/resources/simple_report_pdf.tpl
+++ b/maigret/resources/simple_report_pdf.tpl
@@ -76,6 +76,7 @@
                                         {% endif %}
                                         <p class="card-text">
                                             <a href="{{ v.url_user }}" target="_blank">{{ v.url_user }}</a>
+                                            <span class="text-muted small">(<a href="https://web.archive.org/web/*/{{ v.url_user }}" target="_blank">web.archive.org</a>, <a href="https://archive.is/newest/{{ v.url_user }}" target="_blank">archive.is</a>)</span>
                                         </p>
                                     </div>
                                     {% if v.ids_data %}


### PR DESCRIPTION
## Summary

Adds quick-access archive links (web.archive.org and archive.is) alongside the profile URL in generated HTML reports.

When a profile URL is displayed in the report, users can now click the archive links next to it to view a cached version if the original page is no longer available.

**Change:**
```html
<p class="card-text">
    <a href="{{ v.url_user }}" target="_blank">{{ v.url_user }}</a>
    <span class="text-muted small">(<a href="https://web.archive.org/web/*/{{ v.url_user }}" target="_blank">web.archive.org</a>, <a href="https://archive.is/newest/{{ v.url_user }}" target="_blank">archive.is</a>)</span>
</p>
```

Modified files:
- `maigret/resources/simple_report.tpl`
- `maigret/resources/simple_report_pdf.tpl`

Closes #247