### PR TITLE
Fix get_dict_ascii_tree ignoring new_line=False

### DIFF
--- a/maigret/utils.py
+++ b/maigret/utils.py
@@ -84,14 +84,14 @@ def ascii_data_display(data: str) -> Any:
 
 def get_dict_ascii_tree(items, prepend="", new_line=True):
     new_result = b'\xe2\x94\x9c'.decode()
-    new_line = b'\xe2\x94\x80'.decode()
+    h_line = b'\xe2\x94\x80'.decode()
     last_result = b'\xe2\x94\x94'.decode()
     skip_result = b'\xe2\x94\x82'.decode()
 
     text = ""
     for num, item in enumerate(items):
         box_symbol = (
-            new_result + new_line if num != len(items) - 1 else last_result + new_line
+            new_result + h_line if num != len(items) - 1 else last_result + h_line
         )
 
         if isinstance(item, tuple):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -233,3 +233,16 @@ def test_is_plausible_username_rejects_non_strings():
     assert not is_plausible_username(None)
     assert not is_plausible_username(42)
     assert not is_plausible_username(["alice"])
+
+
+def test_get_dict_ascii_tree_new_line_false_strips_leading_newline():
+    # new_line=False must drop the leading newline. It used to be a no-op
+    # because the parameter was shadowed by the horizontal box-drawing glyph.
+    items = [('a', '1'), ('b', '2')]
+    with_nl = get_dict_ascii_tree(items)
+    without_nl = get_dict_ascii_tree(items, new_line=False)
+
+    assert with_nl.startswith('\n')
+    assert not without_nl.startswith('\n')
+    # Only the leading newline differs; the tree content is identical.
+    assert with_nl[1:] == without_nl


### PR DESCRIPTION
## Summary

`get_dict_ascii_tree(items, prepend="", new_line=True)` reassigns `new_line` on its first line:

```python
def get_dict_ascii_tree(items, prepend="", new_line=True):
    new_result = b'\xe2\x94\x9c'.decode()
    new_line = b'\xe2\x94\x80'.decode()   # ← shadows the boolean parameter with "─"
    ...
    if not new_line:        # always False now: "─" is a non-empty (truthy) string
        text = text[1:]
    return text
```

The horizontal box glyph `─` overwrites the `new_line` flag, so the
`if not new_line: text = text[1:]` that should strip the leading newline never
runs. Callers passing `new_line=False` still get a leading newline — e.g.
`maigret.py`:

```python
print(get_dict_ascii_tree(info.items(), new_line=False), ' ')
```

which prints a stray blank line before the tree.

## Fix

Rename the glyph local to `h_line` so the `new_line` parameter survives and its
strip takes effect. The drawn tree is unchanged.

## Testing

```text
$ pytest tests/test_utils.py -q
22 passed
```

Adds `test_get_dict_ascii_tree_new_line_false_strips_leading_newline` — it
**fails before the fix** (the leading newline isn't stripped) and passes after;
the existing `test_get_dict_ascii_tree` (default `new_line=True`) still passes.