### PR TITLE
fix: remove malformed type attribute from html tag in PDF template

### DIFF
--- a/maigret/resources/simple_report_pdf.tpl
+++ b/maigret/resources/simple_report_pdf.tpl
@@ -1,4 +1,4 @@
-<html>type="text/css"
+<html>
 <head>
     <meta charset="utf-8" />
 </head>


### PR DESCRIPTION
## Summary
Fix the malformed `<html>` tag on line 1 of `simple_report_pdf.tpl`.

**Before:** `<html>type="text/css"` (broken — missing `>` before stray attribute)
**After:** `<html>` (valid HTML5)

The `type="text/css"` attribute is valid for `<style>` elements, not `<html>`. Removing it produces valid HTML in generated PDF reports.

## Changes
- `maigret/resources/simple_report_pdf.tpl`: Remove broken `type="text/css"` attribute from opening `<html>` tag

This is a standalone fix addressing only the HTML validation issue. No other files changed.