### PR TITLE
Fix URLMatcher eating leading host characters (unescaped dots in www./m. prefix)

### DIFF
--- a/maigret/utils.py
+++ b/maigret/utils.py
@@ -48,7 +48,7 @@ def enrich_link_str(link: str) -> str:
 
 
 class URLMatcher:
-    _HTTP_URL_RE_STR = "^https?://(www.|m.)?(.+)$"
+    _HTTP_URL_RE_STR = r"^https?://(www\.|m\.)?(.+)$"
     HTTP_URL_RE = re.compile(_HTTP_URL_RE_STR)
     UNSAFE_SYMBOLS = ".?"
 

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -160,7 +160,7 @@ def test_site_url_detector():
 
     assert (
         db.sites[0].url_regexp.pattern
-        == r'^https?://(www.|m.)?forum\.amperka\.ru/members/\?username=(.+?)$'
+        == r'^https?://(www\.|m\.)?forum\.amperka\.ru/members/\?username=(.+?)$'
     )
     assert (
         db.sites[0].detect_username('http://forum.amperka.ru/members/?username=test')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -123,6 +123,17 @@ def test_url_extract_main_part():
         assert not url_regexp.match(url) is None
 
 
+def test_url_extract_main_part_keeps_host_starting_with_prefix_letters():
+    # The optional (www.|m.)? group must only strip the literal 'www.'/'m.'
+    # subdomain prefixes. With unescaped dots it instead ate the first
+    # character(s) of any host starting with 'm'/'www' (e.g. medium.com).
+    assert URLMatcher.extract_main_part('https://medium.com/alice') == 'medium.com/alice'
+    assert URLMatcher.extract_main_part('https://myspace.com/bob') == 'myspace.com/bob'
+    # genuine mobile/web subdomain prefixes are still stripped
+    assert URLMatcher.extract_main_part('https://m.wikipedia.org/wiki/Foo') == 'wikipedia.org/wiki/Foo'
+    assert URLMatcher.extract_main_part('https://www.flickr.com/photos/x') == 'flickr.com/photos/x'
+
+
 def test_url_make_profile_url_regexp():
     url_main_part = 'flickr.com/photos/{username}'
 
@@ -139,7 +150,7 @@ def test_url_make_profile_url_regexp():
         # ensure all combinations match pattern
         assert (
             URLMatcher.make_profile_url_regexp(url).pattern
-            == r'^https?://(www.|m.)?flickr\.com/photos/(.+?)$'
+            == r'^https?://(www\.|m\.)?flickr\.com/photos/(.+?)$'
         )
 
 


### PR DESCRIPTION
## Problem

`URLMatcher._HTTP_URL_RE_STR` is `"^https?://(www.|m.)?(.+)$"`. The dots in the optional `(www.|m.)?` subdomain-prefix group are **unescaped**, so each `.` matches *any* character. For a host that merely *starts with* `m` or `www` (not the literal `m.`/`www.` prefix), the optional group greedily eats the first character(s):

```python
>>> URLMatcher.extract_main_part('https://medium.com/alice')
'dium.com/alice'      # 'me' eaten
>>> URLMatcher.extract_main_part('https://myspace.com/bob')
'space.com/bob'       # 'my' eaten
```

`extract_main_part()` feeds `make_profile_url_regexp()` / `get_url_template()`, so the **generated site-detection regexp is corrupted too** (`medium.com` → `dium.com`), and the loose prefix would also match bogus hosts like `xmedium.com`. 170+ hosts in `resources/data.json` start with `m` (Medium, Myspace, Minecraft, market.yandex.ru, …).

## Fix

Escape the dots using a raw string:

```diff
-    _HTTP_URL_RE_STR = "^https?://(www.|m.)?(.+)$"
+    _HTTP_URL_RE_STR = r"^https?://(www\.|m\.)?(.+)$"
```

Genuine mobile/web prefixes are still stripped (`m.wikipedia.org` → `wikipedia.org`, `www.flickr.com` → `flickr.com`).

## Tests

Two existing tests pinned the *unescaped* pattern string (`test_utils.py::test_url_make_profile_url_regexp`, `test_sites.py::test_site_url_detector`) — updated to the corrected escaped form. Added `test_url_extract_main_part_keeps_host_starting_with_prefix_letters` as a regression test. `pytest tests/test_utils.py tests/test_sites.py tests/test_data.py` → 48 passed.