### PR TITLE
Compare raw error percentage against threshold (don't round before the check)

### DIFF
--- a/maigret/errors.py
+++ b/maigret/errors.py
@@ -167,11 +167,13 @@ def extract_and_group(search_res: Dict[str, SiteResult]) -> List[Dict[str, Any]]
             {
                 'err': err,
                 'count': count,
-                # Scale to a percentage first, THEN round. Rounding the raw
-                # fraction (round(x, 2)) only keeps whole-percent granularity,
-                # so e.g. 1/40 = 2.5% became 0.03 * 100 = 3.0% and tripped the
-                # 3% "important" threshold for an error rate that is below it.
-                'perc': round(count / len(search_res) * 100, 2),
+                # Keep the RAW percentage. is_important() compares this value
+                # against the threshold, so rounding it here can push a
+                # sub-threshold rate up to the cutoff: e.g. 8/267 = 2.996%,
+                # but round(2.996, 2) == 3.0, which would trip the 3%
+                # "important" threshold for a rate that is below it. Rounding
+                # is display-only (see notify_about_errors).
+                'perc': count / len(search_res) * 100,
             }
         )
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -90,6 +90,30 @@ def test_below_threshold_non_integer_percent_stays_silent():
     assert all('Captcha' not in n[0] for n in notifications), notifications
 
 
+def test_below_threshold_rate_rounding_up_stays_silent():
+    # 8 Captcha errors out of 267 sites = 2.99625%, strictly below the 3%
+    # threshold. The percentage must be compared raw: rounding it to 2 decimals
+    # before the threshold check turns 2.996% into 3.0% and fires a spurious
+    # "Too many errors" warning for a sub-threshold rate.
+    results = {}
+    for i in range(8):
+        results[f'cap{i}'] = {
+            'status': MaigretCheckResult(
+                '', '', '', MaigretCheckStatus.UNKNOWN, error=CheckError('Captcha')
+            )
+        }
+    for i in range(259):
+        results[f'ok{i}'] = {
+            'status': MaigretCheckResult(
+                '', '', '', MaigretCheckStatus.CLAIMED, error=None
+            )
+        }
+
+    notifications = notify_about_errors(results, query_notify=None)
+
+    assert all('Captcha' not in (n[0] if n else '') for n in notifications), notifications
+
+
 # Tests for the DNS-vs-generic split of "Connecting failure" introduced for
 # https://github.com/soxoj/maigret/issues/2688 — when the user's machine
 # cannot reach a DNS server, the result was previously reported as plain


### PR DESCRIPTION
## Problem

`extract_and_group` stores each error type's percentage already **rounded to 2 decimals**, and `is_important()` compares that stored value against the threshold. Rounding *before* the comparison can push a rate that is strictly below the threshold up to it:

```
8 Captcha errors / 267 sites = 2.99625%
round(2.99625, 2) == 3.0  ->  is_important() True
->  spurious  'Too many errors of type "Captcha" (3.0%)'
```

This is the residual of the same class fixed in #2788 (scale-then-round): scaling to a percentage first stopped `2.5%` from becoming `3.0%`, but rounding the *percentage* still feeds the threshold check.

## Fix

Store the **raw** percentage; the comparison in `is_important()` is then exact. The display sites already round (`round(e["perc"], 2)` in `notify_about_errors`), so the values shown to the user are unchanged.

```diff
-                'perc': round(count / len(search_res) * 100, 2),
+                'perc': count / len(search_res) * 100,
```

Genuine at-or-above-threshold rates still fire (`3/100 = 3.0%`, DNS at `10%`); only the sub-threshold rounding-up case is silenced.

## Tests

Added `test_below_threshold_rate_rounding_up_stays_silent` (8/267 = 2.996%). `pytest tests/test_errors.py` → 22 passed.