### PR TITLE
Make include-tag site filter case-insensitive (match the exclude filter)

### DIFF
--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -395,7 +395,9 @@ class MaigretDatabase:
         is_engine_ok = (
             lambda x: isinstance(x.engine, str) and x.engine.lower() in normalized_tags
         )
-        is_tags_ok = lambda x: set(x.tags).intersection(set(normalized_tags))
+        is_tags_ok = lambda x: set(map(str.lower, x.tags)).intersection(
+            set(normalized_tags)
+        )
         is_protocol_in_tags = lambda x: x.protocol and x.protocol in normalized_tags
         is_disabled_needed = lambda x: not x.disabled or (
             "disabled" in tags or disabled

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -271,6 +271,19 @@ def test_ranked_sites_dict_excluded_tags():
     assert list(db.ranked_sites_dict(excluded_tags=['forum', 'ucoz']).keys()) == []
 
 
+def test_ranked_sites_dict_tag_filter_is_case_insensitive():
+    # The include (whitelist) tag filter must be case-insensitive, like the
+    # exclude (blacklist) filter and every sibling lambda (name/source/engine),
+    # all of which lowercase the site-side value. A site tagged 'US' must be
+    # found by tags=['us'] just as it is excluded by excluded_tags=['us'].
+    db = MaigretDatabase()
+    db.update_site(MaigretSite('1', {'alexaRank': 2, 'tags': ['US']}))
+
+    assert list(db.ranked_sites_dict(tags=['us']).keys()) == ['1']
+    # the blacklist already treats the same tag case-insensitively
+    assert list(db.ranked_sites_dict(excluded_tags=['us']).keys()) == []
+
+
 def test_ranked_sites_dict_excluded_tags_with_top():
     """Excluded tags should also prevent mirrors from being included."""
     db = MaigretDatabase()


### PR DESCRIPTION
## Problem

In `MaigretDatabase.ranked_sites_dict`, the **include** (whitelist) tag filter compares the site's raw tags against the lowercased query tags:

```python
is_tags_ok = lambda x: set(x.tags).intersection(set(normalized_tags))
```

while the **exclude** (blacklist) filter — and every sibling lambda (`name`/`source`/`engine`) — lowercases the site-side value:

```python
is_excluded_by_tag = lambda x: set(map(str.lower, x.tags)).intersection(
    set(normalized_excluded_tags)
)
```

(`normalized_tags`/`normalized_excluded_tags` are both lowercased up front.)

So a site stored with an upper/mixed-case tag — e.g. a custom or submitted site tagged `US` — is correctly excluded by `--exclude-tags us`, but is **not** found by `--tags us`. The two filters disagree on the same tag/site pair.

## Fix

Lowercase the site tags in the include filter too, matching the exclude filter and the rest of the method:

```diff
-        is_tags_ok = lambda x: set(x.tags).intersection(set(normalized_tags))
+        is_tags_ok = lambda x: set(map(str.lower, x.tags)).intersection(
+            set(normalized_tags)
+        )
```

## Tests

Added `test_ranked_sites_dict_tag_filter_is_case_insensitive` (a site tagged `US` is found by `tags=['us']`, mirroring the existing blacklist behavior). `pytest tests/test_sites.py` → 23 passed.