### PR TITLE
fix: make include-tag filter case-insensitive

### DIFF
--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -395,7 +395,7 @@ class MaigretDatabase:
         is_engine_ok = (
             lambda x: isinstance(x.engine, str) and x.engine.lower() in normalized_tags
         )
-        is_tags_ok = lambda x: set(x.tags).intersection(set(normalized_tags))
+        is_tags_ok = lambda x: set(map(str.lower, x.tags)).intersection(set(normalized_tags))
         is_protocol_in_tags = lambda x: x.protocol and x.protocol in normalized_tags
         is_disabled_needed = lambda x: not x.disabled or (
             "disabled" in tags or disabled


### PR DESCRIPTION
## Summary
Make the `--tags` filter case-insensitive by using `.lower()` on site tags before comparison, matching the exclude-tag behavior.

## Changes
In `maigret/sites.py`, the `is_tags_ok` lambda now uses `set(map(str.lower, x.tags)).intersection(...)` instead of `set(x.tags).intersection(...)`.

## Example
Before: `--tags SOCIAL` would NOT match sites tagged `social`.
After: `--tags SOCIAL` correctly matches sites tagged `social`.

Fixes: #2811