### PR TITLE
fix: explicit SKIPPED status for Tor/I2P/DNS sites when no proxy is configured

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -851,8 +851,17 @@ def make_site_result(
     else:
         checker = make_protocol_checker(options, site.protocol)
 
+    if isinstance(checker, CheckerMock):
+        protocol = site.protocol or "protocol"
+        results_site["status"] = MaigretCheckResult(
+            username,
+            site.name,
+            url,
+            MaigretCheckStatus.ILLEGAL,
+            error=CheckError("Skipped", f"no {protocol} gateway configured"),
+        )
     # site check is disabled
-    if site.disabled and not options['forced']:
+    elif site.disabled and not options['forced']:
         logger.debug(f"Site {site.name} is disabled, skipping...")
         results_site["status"] = MaigretCheckResult(
             username,
@@ -962,6 +971,10 @@ async def check_site_for_username(
     default_result = make_site_result(
         site, username, options, logger, retry=kwargs.get('retry'), keywords=keywords
     )
+    if default_result.get("status"):
+        query_notify.update(default_result["status"], site.similar_search)
+        return site.name, default_result
+
     # future = default_result.get("future")
     # if not future:
     # return site.name, default_result

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -15,6 +15,7 @@ from maigret.checking import (
     debug_response_logging,
     process_site_result,
     check_site_for_username,
+    CheckerMock,
 )
 from maigret.error_detection import detect_error_page
 from maigret.errors import CheckError
@@ -434,6 +435,88 @@ def test_process_site_result_error_context_uses_instance():
     out = process_site_result(("body", 0, err), Mock(), Mock(), info, site)
     assert out["status"].context == "Request timeout error: slow server"
     assert "class" not in out["status"].context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("protocol", ["tor", "i2p", "dns"])
+async def test_check_site_for_username_skips_mock_protocol_checkers(protocol):
+    site = _make_site({"protocol": protocol})
+
+    class TrackingChecker(CheckerMock):
+        checked = False
+
+        async def check(self):
+            self.checked = True
+            return await super().check()
+
+    checker = TrackingChecker()
+    options = {
+        "parsing": False,
+        "cookie_jar": None,
+        "forced": True,
+        "id_type": "username",
+        "timeout": 3,
+        "proxy": None,
+        "checkers": {protocol: checker},
+    }
+    query_notify = Mock()
+
+    _, result = await check_site_for_username(
+        site,
+        "a",
+        options,
+        Mock(),
+        query_notify,
+    )
+
+    status = result["status"]
+    assert status.status == MaigretCheckStatus.ILLEGAL
+    assert status.error.type == "Skipped"
+    assert status.error.desc == f"no {protocol} gateway configured"
+    assert "Connection lost" not in str(status.error)
+    assert checker.checked is False
+    query_notify.update.assert_called_once_with(status, site.similar_search)
+
+
+@pytest.mark.asyncio
+async def test_check_site_for_username_preserves_clearweb_connection_lost():
+    site = _make_site()
+
+    class FailingChecker:
+        prepared = False
+        checked = False
+
+        def prepare(self, *args, **kwargs):
+            self.prepared = True
+            return None
+
+        async def check(self):
+            self.checked = True
+            return "", 0, CheckError("Connection lost")
+
+    checker = FailingChecker()
+    options = {
+        "parsing": False,
+        "cookie_jar": None,
+        "forced": True,
+        "id_type": "username",
+        "timeout": 3,
+        "proxy": None,
+        "checkers": {"": checker},
+    }
+
+    _, result = await check_site_for_username(
+        site,
+        "a",
+        options,
+        Mock(),
+        Mock(),
+    )
+
+    assert checker.prepared is True
+    assert checker.checked is True
+    assert result["status"].status == MaigretCheckStatus.UNKNOWN
+    assert result["status"].error.type == "Connection lost"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
In the dispatch path (maigret/checking.py around line 852, right after `checker = make_protocol_checker(options, site.protocol)`), detect when the resolved checker is the no-op mock via `isinstance(checker, CheckerMock)` and short-circuit before the request is attempted. Instead of dispatching to the mock, build a `MaigretCheckResult` with `MaigretCheckStatus.ILLEGAL` plus an explanatory `CheckError("Skipped", "no <protocol> gateway configured")`, mirroring the existing disabled-site branch (checking.py ~860) that already renders cleanly in CLI and JSON. Reusing `ILLEGAL` keeps the change to a single file and avoids touching the report/rendering layer (no new enum value to plumb through `maigret/report.py`), while still satisfying the acceptance criteria: no "Connection lost" entries for `.onion`/`.i2p`/domain sites and a one-line skip explanation in the report.

## Why this matters
When the user does not pass `--tor-proxy` / `--i2p-proxy` / `--with-domains`, the corresponding protocol checker is resolved to a `CheckerMock` (maigret/checking.py:599) whose `check()` returns `('', 0, None)`. A `status_code` of `0` is later interpreted as `CheckError("Connection lost")`, so every `.onion` / `.i2p` / domain entry reports a fake "Connection lost" error instead of being honestly skipped. This pollutes `--print-errors`, masks real connection-lost errors on clearweb sites, and is misleading because the site was never actually contacted. The issue was filed by the maintainer (soxoj) with detailed code refs and acceptance criteria; a contributor noted the exact symptom string has drifted, but the underlying `CheckerMock` mechanism is unchanged on current `main` (verified at checking.py:599-610 and the proxy-absent fallbacks at checking.py:1121-1138).

See https://github.com/soxoj/maigret/issues/2664.

## Testing
- Happy path: clearweb site with a real checker still reaches the normal request path and reports CLAIMED/AVAILABLE unchanged. - Edge case: `.onion` site dispatched with no `--tor-proxy` yields a skipped result with an explanatory message, and `--print-errors` shows no "Connection lost" entry for it. - Edge case: `.i2p` and domain (DNS) sites behave identically when their proxy/option is absent. - Error path: a genuine clearweb connection failure still surfaces as a real `CheckError("Connection lost")` and is not swallowed by the new skip branch.

Fixes #2664
