### PR TITLE
chore: clean up imports and replace list()[0] with next(iter())

### DIFF
--- a/maigret/activation.py
+++ b/maigret/activation.py
@@ -149,7 +149,7 @@ def import_aiohttp_cookies(cookiestxt_filename):
 
     cookies_list = []
     for domain in cookies_obj._cookies.values():  # type: ignore[attr-defined]
-        for key, cookie in list(domain.values())[0].items():
+        for key, cookie in next(iter(domain.values())).items():
             c: Morsel = Morsel()
             c.set(key, cookie.value, cookie.value)
             c["domain"] = cookie.domain

--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -8,8 +8,8 @@ import re
 import ssl
 import sys
 from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import Mock
 from urllib.parse import quote
-from maigret.error_detection import detect_error_page
 
 # Third party imports
 import aiodns
@@ -21,6 +21,18 @@ from aiohttp.client_exceptions import (
     ClientConnectorError,
     ServerDisconnectedError,
 )
+from python_socks import _errors as proxy_errors
+from socid_extractor import extract  # type: ignore[import-not-found]
+
+# Local imports
+from . import errors
+from .activation import ParsingActivator, import_aiohttp_cookies
+from .error_detection import detect_error_page
+from .errors import CheckError
+from .executors import AsyncioQueueGeneratorExecutor
+from .result import MaigretCheckResult, MaigretCheckStatus, KeywordMatchStatus, SiteResult
+from .sites import MaigretDatabase, MaigretSite
+from .utils import ascii_data_display, get_random_user_agent, is_plausible_username
 
 
 _DNS_ERROR_MARKERS = (
@@ -44,19 +56,6 @@ def _is_dns_error(exc: Exception) -> bool:
         return True
     text = str(exc).lower()
     return any(m in text for m in _DNS_ERROR_MARKERS)
-from python_socks import _errors as proxy_errors
-from socid_extractor import extract  # type: ignore[import-not-found]
-
-from unittest.mock import Mock
-
-# Local imports
-from . import errors
-from .activation import ParsingActivator, import_aiohttp_cookies
-from .errors import CheckError
-from .executors import AsyncioQueueGeneratorExecutor
-from .result import MaigretCheckResult, MaigretCheckStatus, KeywordMatchStatus, SiteResult
-from .sites import MaigretDatabase, MaigretSite
-from .utils import ascii_data_display, get_random_user_agent, is_plausible_username
 
 
 SUPPORTED_IDS = (


### PR DESCRIPTION
## Summary

Two safe, mechanical changes split out from #2810 (now closed).

### 1. Replace `list()[0]` with `next(iter())` (`maigret/activation.py`)

Avoid materializing the entire iterable just to grab the first dict in `import_aiohttp_cookies`:

```python
for key, cookie in next(iter(domain.values())).items():
```

### 2. Reorganize imports per PEP 8 (`maigret/checking.py`)

- `from unittest.mock import Mock` → stdlib section
- `python_socks`, `socid_extractor` → third-party section
- `from .error_detection import detect_error_page` and `from .` local imports → local section

## Notes

The original `next(iter())` commit also hoisted four lazy imports (`hashlib`, `secrets`, `time as _time`, `urlparse`) out of `ParsingActivator.onlyfans()`. Those are reverted here — the lazy imports were intentional (only loaded when an OnlyFans site is actually checked), and hoisting them added two stray blank lines inside `onlyfans()`.

No behavioral change. 314 tests pass, 3 skipped (network-dependent).