### PR TITLE
fix(data): switch mineplex.com and forums.zooclub.ru to status_code detection

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -16183,7 +16183,8 @@
             "urlMain": "https://forums.zooclub.ru",
             "engine": "vBulletin",
             "usernameClaimed": "alex",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "checkType": "status_code"
         },
         "Lushstories": {
             "tags": [
@@ -23023,7 +23024,8 @@
             "tags": [
                 "forum"
             ],
-            "alexaRank": 772393
+            "alexaRank": 772393,
+            "checkType": "status_code"
         },
         "southbayriders.com": {
             "engine": "XenForo",


### PR DESCRIPTION
## Summary

Switch two sites from inherited engine `message` detection to `status_code` detection to fix false positives reported by the Maigret bot.

## Changes

- **mineplex.com** (gh-2823): XenForo forum, switch to status_code
- **forums.zooclub.ru** (gh-2822): vBulletin forum, switch to status_code

Both inherit generic error-page text patterns from their respective engines that do not match the actual HTML returned for non-existent usernames, causing random usernames to be incorrectly reported as CLAIMED. Using HTTP status code comparison avoids this.

## Verification

Both sites use a status_code check that compares the HTTP response codes for a claimed vs. unclaimed username probe.

Closes gh-2823
Closes gh-2822