### PR TITLE
fix(data): tag Pixwox with cf_firewall so --cloudflare-bypass triggers

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -22772,7 +22772,8 @@
                 "photo"
             ],
             "protection": [
-                "ip_reputation"
+                "ip_reputation",
+                "cf_firewall"
             ]
         },
         "crown6.org": {


### PR DESCRIPTION
Fixes #2845.

## Situation

Running `maigret ronaldinho --site pixwox --cloudflare-bypass` still failed with:

```
[?] Pixwox [Instagram]: Just a moment: bot redirect challenge error: Cloudflare
```

...even with `--cloudflare-bypass` passed and a working FlareSolverr instance reachable at `localhost:8191`. Calling FlareSolverr directly against the same URL confirmed it solves the challenge fine (200, real profile HTML) — so the solver itself wasn't the problem.

## Root cause

`build_cloudflare_bypass_config()` only activates the bypass module for sites whose `protection` tag matches `trigger_protection` (default `["cf_js_challenge", "cf_firewall", "webgate"]`). Pixwox's `data.json` entry tags it `"protection": ["ip_reputation"]` only — so the bypass path was silently skipped regardless of the CLI flag or `settings.json`.

## Fix

Add `cf_firewall` to Pixwox's `protection` list (kept `ip_reputation` alongside it, since both symptoms have been observed). This is a one-line data fix, no code changes.

## Verification

Before:
```
[?] Pixwox [Instagram]: Just a moment: bot redirect challenge error: Cloudflare
```

After (with this fix + `--cloudflare-bypass`):
```
[+] Pixwox [Instagram]: https://www.pixwox.com/profile/ronaldinho/
```