### PR TITLE
fix(checking): extract bio/links/tagged usernames from Instagram directly

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -1,6 +1,7 @@
 # Standard library imports
 import ast
 import asyncio
+import json
 import logging
 import os
 import random
@@ -1555,12 +1556,61 @@ async def self_check(
     }
 
 
+def _extract_instagram_web_profile_info(html_text) -> Dict:
+    """Fallback parser for Instagram's web_profile_info API response.
+
+    socid_extractor has no scheme for Instagram's own profile JSON (only
+    cross-references Instagram usernames found on *other* sites), so it
+    always returns {} for the official Instagram site. This pulls the
+    same bio/links/tagged-username data straight out of the response.
+    """
+    try:
+        data = json.loads(html_text)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+    user = (data.get('data') or {}).get('user') or {}
+    if not user:
+        return {}
+
+    result: Dict[str, Any] = {}
+    if user.get('username'):
+        result['username'] = user['username']
+    if user.get('full_name'):
+        result['fullname'] = user['full_name']
+    if user.get('biography'):
+        result['bio'] = user['biography']
+
+    links = [
+        link['url'] for link in (user.get('bio_links') or []) if link.get('url')
+    ]
+    if links:
+        result['links'] = str(links)
+
+    tagged_usernames = [
+        entity['user']['username']
+        for entity in (
+            (user.get('biography_with_entities') or {}).get('entities') or []
+        )
+        if (entity.get('user') or {}).get('username')
+    ]
+    if tagged_usernames:
+        result['usernames'] = str(tagged_usernames)
+
+    return result
+
+
 def extract_ids_data(html_text, logger, site) -> Dict:
     try:
-        return extract(html_text)
+        data = extract(html_text)
     except Exception as e:
         logger.warning(f"Error while parsing {site.name}: {e}", exc_info=True)
         return {}
+
+    if not data and site.name == 'Instagram':
+        data = _extract_instagram_web_profile_info(html_text)
+
+    return data
 
 
 def parse_usernames(extracted_ids_data, logger) -> Dict:

--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -1597,6 +1597,22 @@ def _extract_instagram_web_profile_info(html_text) -> Dict:
     if tagged_usernames:
         result['usernames'] = str(tagged_usernames)
 
+    followers = (user.get('edge_followed_by') or {}).get('count')
+    if followers is not None:
+        result['followers'] = followers
+    following = (user.get('edge_follow') or {}).get('count')
+    if following is not None:
+        result['following'] = following
+    posts = (user.get('edge_owner_to_timeline_media') or {}).get('count')
+    if posts is not None:
+        result['posts'] = posts
+    if user.get('is_verified') is not None:
+        result['verified'] = user['is_verified']
+    if user.get('is_private') is not None:
+        result['private'] = user['is_private']
+    if user.get('profile_pic_url_hd') or user.get('profile_pic_url'):
+        result['image'] = user.get('profile_pic_url_hd') or user.get('profile_pic_url')
+
     return result
 
 

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -269,6 +269,12 @@ def test_extract_ids_data_instagram_web_profile_info_fallback():
                         {"hashtag": "melhor"},
                     ]
                 },
+                "edge_followed_by": {"count": 80107703},
+                "edge_follow": {"count": 600},
+                "edge_owner_to_timeline_media": {"count": 3200},
+                "is_verified": True,
+                "is_private": False,
+                "profile_pic_url_hd": "https://example.com/pic.jpg",
             }
         }
     })
@@ -280,6 +286,12 @@ def test_extract_ids_data_instagram_web_profile_info_fallback():
     assert "tropadobruxo_" in out["bio"]
     assert out["links"] == "['https://r10score.net/ronaldinho']"
     assert out["usernames"] == "['tropadobruxo_']"
+    assert out["followers"] == 80107703
+    assert out["following"] == 600
+    assert out["posts"] == 3200
+    assert out["verified"] is True
+    assert out["private"] is False
+    assert out["image"] == "https://example.com/pic.jpg"
 
 
 def test_extract_ids_data_instagram_fallback_skipped_for_other_sites():

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from argparse import ArgumentTypeError
 
 from unittest.mock import Mock
@@ -244,6 +245,54 @@ def test_extract_ids_data_bad_html_returns_empty():
     # Random HTML should not raise — returns {} if nothing matches
     out = extract_ids_data("<html><body>nothing special</body></html>", logger, Mock(name="Site"))
     assert isinstance(out, dict)
+
+
+def test_extract_ids_data_instagram_web_profile_info_fallback():
+    # socid_extractor has no Instagram scheme, so it returns {} for
+    # Instagram's own web_profile_info API response. extract_ids_data
+    # should fall back to parsing bio/links/tagged usernames directly.
+    logger = Mock()
+    site = Mock()
+    site.name = 'Instagram'
+    html_text = json.dumps({
+        "data": {
+            "user": {
+                "username": "ronaldinho",
+                "full_name": "Ronaldinho Gaúcho",
+                "biography": "Instagram oficial de Ronaldinho Gaúcho.\n@tropadobruxo_",
+                "bio_links": [
+                    {"url": "https://r10score.net/ronaldinho"},
+                ],
+                "biography_with_entities": {
+                    "entities": [
+                        {"user": {"username": "tropadobruxo_"}},
+                        {"hashtag": "melhor"},
+                    ]
+                },
+            }
+        }
+    })
+
+    out = extract_ids_data(html_text, logger, site)
+
+    assert out["username"] == "ronaldinho"
+    assert out["fullname"] == "Ronaldinho Gaúcho"
+    assert "tropadobruxo_" in out["bio"]
+    assert out["links"] == "['https://r10score.net/ronaldinho']"
+    assert out["usernames"] == "['tropadobruxo_']"
+
+
+def test_extract_ids_data_instagram_fallback_skipped_for_other_sites():
+    # The fallback is Instagram-specific — other sites with JSON bodies
+    # that don't match a socid_extractor scheme should still get {}.
+    logger = Mock()
+    site = Mock()
+    site.name = 'SomeOtherSite'
+    html_text = json.dumps({"data": {"user": {"username": "x"}}})
+
+    out = extract_ids_data(html_text, logger, site)
+
+    assert out == {}
 
 
 def test_get_failed_sites_filters_permanent_errors():


### PR DESCRIPTION
Fixes #2846.

## Situation

`maigret ronaldinho --site instagram` returns a CLAIMED Instagram profile with a full bio, external links, and tagged usernames — but the report always says:

```
Extended info extracted from 0 accounts.
```

## Root cause

`extract_ids_data()` delegates to `socid_extractor.extract(html_text)`. That library has no scheme for Instagram's own `web_profile_info` API response — it only cross-references Instagram usernames that show up on *other* platforms' pages. So for the Instagram site itself it always returns `{}`, silently, no exception.

## Fix

Add a small Instagram-specific fallback (`_extract_instagram_web_profile_info`) that parses `username`, `full_name`, `biography`, `bio_links`, and tagged usernames straight out of the same JSON response, used only when `extract()` comes back empty and the site is Instagram. Includes unit tests covering the fallback and confirming it's a no-op for other sites.

## Verification — worked example (ronaldinho)

Before, `Extracted IDs: {}` and `Extended info extracted from 0 accounts.` for every account.

After:
```
[+] Instagram: https://www.instagram.com/ronaldinho/
       ├─username: ronaldinho
       ├─fullname: Ronaldo de Assis Moreira
       ├─bio: Instagram oficial de Ronaldinho Gaúcho...
       ├─links:
       │ ├─ https://r10score.net/ronaldinho
       │ ├─ https://t.me/+YM3bDlF-HpdlYjc0
       │ └─ ...
       └─usernames:
         ├─ tropadobruxo_
         ├─ nooke.ag
         └─ betify
```

Note this also feeds maigret's existing recursive-search feature — the tagged usernames now get pulled into `Extracted IDs` and, unless `--no-recursion` is passed, chased as new search targets. That recursion behavior is pre-existing and orthogonal to this fix; it's just newly visible now that real data reaches it. Worth knowing since a bio with several tagged accounts (as in the ronaldinho example) can meaningfully lengthen a run — `--no-recursion` opts out.