### PR TITLE
fix: don't let the SUPPORTED_IDS branch re-add a rejected 'username' value

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -1808,7 +1808,7 @@ def parse_usernames(extracted_ids_data, logger) -> Dict:
                             )
             except Exception as e:
                 logger.warning(e)
-        if k in SUPPORTED_IDS:
+        elif k in SUPPORTED_IDS:
             new_usernames[v] = k
     return new_usernames
 

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -240,12 +240,26 @@ def test_parse_usernames_filters_urls_inside_list():
 
 def test_parse_usernames_supported_id():
     logger = Mock()
-    # "telegram" is in SUPPORTED_IDS per socid_extractor
     from maigret.checking import SUPPORTED_IDS
     if SUPPORTED_IDS:
         key = next(iter(SUPPORTED_IDS))
         result = parse_usernames({key: "some_value"}, logger)
         assert result.get("some_value") == key
+
+
+def test_parse_usernames_rejects_implausible_bare_username():
+    """Regression for #1403: the bare 'username' key is itself in SUPPORTED_IDS,
+    so a URL/email/path value under it must still be dropped. Previously the
+    unconditional 'if k in SUPPORTED_IDS' branch re-added the value that the
+    plausibility check had just rejected, reopening the false-error cascade."""
+    logger = Mock()
+    from maigret.checking import SUPPORTED_IDS
+    assert "username" in SUPPORTED_IDS  # guards the premise of this test
+    assert parse_usernames({"username": "https://instagram.com/zuck"}, logger) == {}
+    assert parse_usernames({"username": "alice@example.com"}, logger) == {}
+    assert parse_usernames({"username": "user/alice"}, logger) == {}
+    # a plausible bare username still survives
+    assert parse_usernames({"username": "alice"}, logger) == {"alice": "username"}
 
 
 def test_update_results_info_links():


### PR DESCRIPTION
`parse_usernames()` validates the `*_username` extractor fields with `is_plausible_username()` — the #1403 guard that stops URLs and emails from being fed back into the search loop. But the trailing branch runs unconditionally:

```python
if "username" in k and "usernames" not in k:
    if is_plausible_username(v):
        new_usernames[v] = "username"
    else:
        logger.debug("Rejected ...")     # drops the garbage value
...
if k in SUPPORTED_IDS:                     # "username" is in SUPPORTED_IDS
    new_usernames[v] = k                   # ... and re-adds it right here
```

Because `"username"` is itself in `SUPPORTED_IDS`, the bare `username` key skips the guard entirely: the plausibility check drops a URL/email/path value, then the `SUPPORTED_IDS` branch puts it straight back. socid_extractor does hand back such values under a bare `username` key (it's the exact case the `is_plausible_username` docstring calls out), so during the default recursive search that value gets substituted into every site URL template — the "wrong username" false-error cascade #1403 was meant to prevent.

Before/after:

```python
>>> parse_usernames({'username': 'https://instagram.com/zuck'}, logger)
{'https://instagram.com/zuck': 'username'}   # before
{}                                            # after
```

The fix is one line: make the `SUPPORTED_IDS` branch an `elif`. The bare `username` key is already handled with validation by the first branch, and every other id in `SUPPORTED_IDS` (`gaia_id`, `vk_id`, `orcid`, ...) is added exactly as before, since none of those keys contain "username".

I also added a regression test for the bare `username` key with URL/email/path values. The existing `parse_usernames` tests only exercised `*_username` variants, none of which are in `SUPPORTED_IDS`, so this path had no coverage — which is why the regression slipped through.

No database changes.
