### PR TITLE
fix: disable PulmonaryHypertensionNews (false-positive)

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -27567,7 +27567,8 @@
             "tags": [
                 "education",
                 "news"
-            ]
+            ],
+            "disabled": true
         },
         "amateurvoyeurforum.com": {
             "urlMain": "https://www.amateurvoyeurforum.com",


### PR DESCRIPTION
## Summary

Disable `PulmonaryHypertensionNews` site entry — returns 403 for all usernames (both claimed and unclaimed) due to TLS fingerprint protection.

## Problem

The Maigret bot auto-probe reported **CLAIMED** for three random usernames on this site. Testing shows the site returns HTTP 403 for all requests, regardless of username existence.

## Fix

Added `disabled: true` to the site entry in `data.json`. This prevents false-positive results while preserving the entry for future re-evaluation if the site's protection changes.

## Testing

```bash
# Before fix: false-positive on random usernames
maigret --site PulmonaryHypertensionNews --username noonewouldeverusethis7
# Result: CLAIMED (incorrect)

# After fix: site is skipped
maigret --site PulmonaryHypertensionNews --username noonewouldeverusethis7
# Result: site not found (disabled)
```

Closes #2916

🤖 Generated with [Claude Code](https://claude.com/claude-code)