### PR TITLE
fix: don't let the SUPPORTED_IDS branch re-add a rejected username in extract_ids_from_page

### DIFF
--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -84,8 +84,9 @@ def extract_ids_from_page(url, logger, timeout=5) -> dict:
         else:
             print(get_dict_ascii_tree(info.items(), new_line=False), ' ')
         for k, v in info.items():
-
-            if k in SUPPORTED_IDS:
+            # keys containing "username" are owned by extract_usernames() below,
+            # which validates them; adding them here would bypass that check
+            if "username" not in k and k in SUPPORTED_IDS:
                 results[v] = k
 
         for username in extract_usernames(info, logger):

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -75,3 +75,44 @@ def test_extract_ids_from_page_username_contract():
         )
 
     assert result == {"emily": "username"}
+
+
+def test_extract_ids_from_page_rejects_bare_username_url():
+    logger = Mock()
+
+    with patch("maigret.maigret.parse") as mock_parse, \
+         patch("maigret.maigret.extract") as mock_extract:
+
+        mock_parse.return_value = ("<html></html>", {})
+
+        # socid_extractor returned a URL under the bare `username` key
+        mock_extract.return_value = {"username": "https://instagram.com/zuck"}
+
+        result = extract_ids_from_page(
+            "https://example.com/profile",
+            logger,
+            timeout=5,
+        )
+
+    assert result == {}
+
+
+def test_extract_ids_from_page_keeps_other_supported_ids():
+    logger = Mock()
+
+    with patch("maigret.maigret.parse") as mock_parse, \
+         patch("maigret.maigret.extract") as mock_extract:
+
+        mock_parse.return_value = ("<html></html>", {})
+        mock_extract.return_value = {
+            "gaia_id": "123456789",
+            "profile_username": "emily",
+        }
+
+        result = extract_ids_from_page(
+            "https://example.com/profile",
+            logger,
+            timeout=5,
+        )
+
+    assert result == {"123456789": "gaia_id", "emily": "username"}


### PR DESCRIPTION
Closes #2911

`extract_ids_from_page()` has the same bug #2907 fixed in `checking.py::parse_usernames()`: `"username"` is itself in `SUPPORTED_IDS`, so the `if k in SUPPORTED_IDS` loop stores a bare `username` value unvalidated, bypassing the `is_plausible_username()` guard that `extract_usernames()` applies in its own separate pass. A URL or email returned by socid_extractor under a bare `username` key becomes a recursive search target via `maigret --parse-url`. This skips `"username"`-containing keys in that loop, since `extract_usernames()` already owns them; other supported IDs (gaia_id, vk_id, orcid, ...) are unaffected.

Two regression tests added in `tests/test_extractors.py`: the bare-`username`-with-URL case fails without the fix and passes with it (stash-verified), and a second asserts other `SUPPORTED_IDS` still come through.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
