### PR TITLE
Fix ReverbNation false-positive check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3815,8 +3815,8 @@
             },
             "regexCheck": "^[^\\.]+$",
             "checkType": "message",
-            "absenceStrs": [
-                "Sorry, we couldn't find that page"
+            "presenseStrs": [
+                "og:type\" content=\"band\""
             ],
             "alexaRank": 1205,
             "urlMain": "https://www.reverbnation.com/",

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3814,10 +3814,7 @@
                 "But your computer or network appears to be generating a lot of automated requests": "Too many requests"
             },
             "regexCheck": "^[^\\.]+$",
-            "checkType": "message",
-            "absenceStrs": [
-                "Sorry, we couldn't find that page"
-            ],
+            "checkType": "status_code",
             "alexaRank": 1205,
             "urlMain": "https://www.reverbnation.com/",
             "url": "https://www.reverbnation.com/{username}",

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-11T12:27:21Z",
+    "updated_at": "2026-08-11T15:39:40Z",
     "sites_count": 3221,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "3ee73d19cd301a31e32f2439fc1414731a575aafaab79ee5f4f978d8560e1931",
+    "data_sha256": "aa079ace23c582d68c40c406ac3dc68a97b6f27243933b9913cce676afc6087a",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-02T16:00:54Z",
+    "updated_at": "2026-08-04T16:07:13Z",
     "sites_count": 3221,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "7fcd1658d7a40560042ecdb819f6cc6b15b3dbe14d689c5c6c7b03e2ef146bfa",
+    "data_sha256": "6a2bf6dfb0a807a86071d9405f8fdb3a084f4df591b0e5b65caf4cfc2e224880",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -3225,16 +3225,16 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://lazada.com.my) [lazada.com.my (https://lazada.com.my)](https://lazada.com.my)*: top 100M, my, shopping*
 1. ![](https://www.google.com/s2/favicons?domain=https://lazada.co.id) [lazada.co.id (https://lazada.co.id)](https://lazada.co.id)*: top 100M, id, shopping*
 
-The list was updated at (2026-08-02)
+The list was updated at (2026-08-04)
 ## Statistics
 
 Enabled/total sites: 2547/3221 = 79.07%
 
-Incomplete message checks: 326/2547 = 12.8% (false positive risks)
+Incomplete message checks: 324/2547 = 12.72% (false positive risks)
 
-Status code checks: 696/2547 = 27.33% (false positive risks)
+Status code checks: 697/2547 = 27.37% (false positive risks)
 
-False positive risk (total): 40.13%
+False positive risk (total): 40.09%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox, HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, ITVDN Forum, Imgur, Instagram, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 


### PR DESCRIPTION
## Summary

- switch ReverbNation from obsolete message matching to its reliable HTTP status-code signal
- remove the stale absence marker that no longer appears on missing-account pages
- regenerate `db_meta.json` and `sites.md` with the repository hook

Closes #2928.

## Validation

- full suite: `405 passed, 4 skipped` (`coverage run --source=./maigret,./maigret/web -m pytest tests`)
- data tests: `4 passed` (`pytest tests/test_data.py -q`)
- live ReverbNation self-check completed successfully
- live fake username `maigret2928nonexistentalpha` reported `Not found`
- strict flake8 syntax/undefined-name gate: `0`
- generated metadata hash matches the exact `data.json` bytes (`6a2bf6dfb0a807a86071d9405f8fdb3a084f4df591b0e5b65caf4cfc2e224880`)

Note: the repository-wide `make lint` command currently also reports pre-existing style warnings and mypy errors in untouched Python files; this PR changes only site data and generated artifacts.
