### PR TITLE
fix: update ReverbNation site check to prevent false positives

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3816,8 +3816,9 @@
                 "But your computer or network appears to be generating a lot of automated requests": "Too many requests"
             },
             "regexCheck": "^[^\\.]+$",
-            "checkType": "message",
+            "checkType": "status_code",
             "absenceStrs": [
+                "The page you were looking for doesn't exist",
                 "Sorry, we couldn't find that page"
             ],
             "alexaRank": 1205,


### PR DESCRIPTION
## Problem

The Telegram Maigret bot auto-probe reported **CLAIMED** for site `ReverbNation` on three random usernames (Fixes #2928).

## Root Cause

ReverbNation's404 page changed from "Sorry, we couldn't find that page" to "The page you were looking for doesn't exist (404 Not found)". The `absenceStrs` didn't match the new response, so all usernames were considered CLAIMED.

## Fix

1. Add new `absenceStr` matching the actual404 response
2. Change `checkType` to `status_code` for more reliable detection (404 = not found)

## Verification

```bash
# Before fix: CLAIMED (false positive)
maigret noonewouldeverusethis7 --site ReverbNation

# After fix: NOT FOUND (correct)
maigret noonewouldeverusethis7 --site ReverbNation
```