### PR TITLE
Fix Instapaper false-positive check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -4641,7 +4641,12 @@
         "Instapaper": {
             "url": "https://www.instapaper.com/p/{username}",
             "urlMain": "https://www.instapaper.com/",
-            "checkType": "status_code",
+            "urlProbe": "https://www.instapaper.com/data/profile/{username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "\"is_private\":",
+                "\"is_own_profile\":"
+            ],
             "usernameClaimed": "john",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "alexaRank": 1830,

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-02T16:00:54Z",
+    "updated_at": "2026-08-06T17:15:12Z",
     "sites_count": 3221,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "7fcd1658d7a40560042ecdb819f6cc6b15b3dbe14d689c5c6c7b03e2ef146bfa",
+    "data_sha256": "c2af7942e2d5431506c366baef270ea54d8068faad91023a453c0e706d1f99be",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -3225,18 +3225,18 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://lazada.com.my) [lazada.com.my (https://lazada.com.my)](https://lazada.com.my)*: top 100M, my, shopping*
 1. ![](https://www.google.com/s2/favicons?domain=https://lazada.co.id) [lazada.co.id (https://lazada.co.id)](https://lazada.co.id)*: top 100M, id, shopping*
 
-The list was updated at (2026-08-02)
+The list was updated at (2026-08-06)
 ## Statistics
 
 Enabled/total sites: 2547/3221 = 79.07%
 
 Incomplete message checks: 326/2547 = 12.8% (false positive risks)
 
-Status code checks: 696/2547 = 27.33% (false positive risks)
+Status code checks: 695/2547 = 27.29% (false positive risks)
 
-False positive risk (total): 40.13%
+False positive risk (total): 40.09%
 
-Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox, HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, ITVDN Forum, Imgur, Instagram, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
+Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox, HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, ITVDN Forum, Imgur, Instagram, Instapaper, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
 Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSearch
 


### PR DESCRIPTION
## Summary

- switch Instapaper from `status_code` to `checkType: message` with a `urlProbe`
  against the site's own profile API, `/data/profile/{username}`
- require the JSON-only markers `"is_private":` / `"is_own_profile":` before
  reporting an account as claimed
- regenerate the database metadata and supported-sites listing through the
  repository hook

Instapaper migrated its profile pages to a React SPA. `/p/{username}` now
returns HTTP 200 with a byte-identical 5833-byte shell (`<div id="root"></div>`)
for every username, real or not, so the status-code check reported CLAIMED for
any input.

The endpoint the SPA's own front-end calls returns profile JSON for real
accounts and falls through to that same HTML shell otherwise. Note it does
**not** 404, the front-end expects `if (404 === r.status)`, but the SPA
catch-all rewrite swallows it and the real response is HTTP 200. So `urlProbe`
alone is not enough; the check has to match on JSON body markers rather than
the status code. The display `url` is unchanged, so reports keep showing the
human-readable profile link.

Verified the probe works with plain `aiohttp`, so no `tls_fingerprint` tag is
warranted.

## Validation

- `pytest tests -q` (`405 passed, 4 skipped`)
- `maigret --self-check --site Instapaper --diagnose`. No issues reported
  (before the fix: `Unclaimed user 'noonewouldeverusethis7'
- `maigret noonewouldeverusethis7 --site Instapaper --print-not-found` . Not found
- verified `john` and `adam` are still reported as claimed
- verified `qwzx9182hhh`, `asdkjhasd8712`, `zz_test_zz_991` are reported as not found
- `sites.md` stats move accordingly: status-code checks 696
  false-positive risk 40.13% → 40.09%

Known limitation: an existing account whose profile is set to private will now
report as not-found, since the API serves the shell in that
strictly better than matching every username and is unavoidable without an
authenticated request.

Closes #2915