### PR TITLE
Improve graph visualization and readability

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -1,5 +1,6 @@
 import ast
 import csv
+import html
 import io
 import ipaddress
 import json
@@ -172,32 +173,84 @@ def save_json_report(filename: str, username: str, results: dict, report_type: s
         generate_json_report(username, results, f, report_type=report_type)
 
 
+GRAPH_VISUAL_OPTIONS = {
+    'interaction': {
+        'hover': True,
+        'navigationButtons': True,
+        'keyboard': {'enabled': True},
+    },
+    'nodes': {
+        'borderWidth': 2,
+        'font': {'color': '#e2e8f0', 'face': 'Arial', 'size': 14},
+    },
+    'edges': {
+        'color': {
+            'color': '#64748b',
+            'highlight': '#f8fafc',
+            'hover': '#cbd5e1',
+            'inherit': False,
+        },
+        'smooth': False,
+    },
+    'groups': {
+        'identity': {
+            'color': {'background': '#7c3aed', 'border': '#c4b5fd'},
+        },
+        'account': {
+            'color': {'background': '#d97706', 'border': '#fcd34d'},
+        },
+        'site': {
+            'color': {'background': '#059669', 'border': '#6ee7b7'},
+        },
+        'metadata': {
+            'color': {'background': '#2563eb', 'border': '#93c5fd'},
+        },
+    },
+    'physics': {
+        'stabilization': {
+            'enabled': True,
+            'iterations': 200,
+            'updateInterval': 25,
+            'fit': True,
+        },
+    },
+}
+
+
 class MaigretGraph:
-    other_params: dict = {'size': 10, 'group': 3}
-    site_params: dict = {'size': 15, 'group': 2}
-    username_params: dict = {'size': 20, 'group': 1}
+    max_label_length = 48
+    other_params: dict = {'size': 10, 'group': 'metadata'}
+    site_params: dict = {'size': 15, 'group': 'site'}
+    account_params: dict = {'size': 15, 'group': 'account'}
+    username_params: dict = {'size': 20, 'group': 'identity'}
 
     def __init__(self, graph):
         self.G = graph
 
-    def add_node(self, key, value, color=None):
-        node_name = f'{key}: {value}'
+    def add_node(self, key, value):
+        value_text = str(value)
+        node_name = f'{key}: {value_text}'
 
         params = dict(self.other_params)
         if key in SUPPORTED_IDS:
             params = dict(self.username_params)
-        elif value.startswith('http'):
+        elif key == 'site':
             params = dict(self.site_params)
+        elif key == 'account':
+            params = dict(self.account_params)
 
-        params['title'] = node_name
-        if color:
-            params['color'] = color
+        params['label'] = (
+            node_name
+            if len(node_name) <= self.max_label_length
+            else f'{node_name[: self.max_label_length - 3]}...'
+        )
+        params['title'] = f'<b>{html.escape(str(key))}</b><br>{html.escape(value_text)}'
 
         self.G.add_node(node_name, **params)
         return node_name
 
-    def link(self, node1_name, node2_name):
-        self.G.add_edge(node1_name, node2_name, weight=2)
+    def link(self, node1_name, node2_name, title):
+        self.G.add_edge(node1_name, node2_name, weight=2, title=title)
 
 
 def _build_maigret_graph(username_results: list, db: MaigretDatabase):
@@ -226,9 +279,7 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
             # base site node
             site_base_url = website_name
             if site_base_url not in base_site_nodes:
-                base_site_nodes[site_base_url] = graph.add_node(
-                    'site', site_base_url, color='#28a745'
-                )  # Green color
+                base_site_nodes[site_base_url] = graph.add_node('site', site_base_url)
 
             site_base_node_name = base_site_nodes[site_base_url]
 
@@ -243,8 +294,8 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
             account_node_name = site_account_nodes[account_node_id]
 
             # link username → account → site
-            graph.link(username_node_name, account_node_name)
-            graph.link(account_node_name, site_base_node_name)
+            graph.link(username_node_name, account_node_name, 'Matched account')
+            graph.link(account_node_name, site_base_node_name, 'Hosted on site')
 
             def process_ids(parent_node, ids):
                 for k, v in ids.items():
@@ -276,7 +327,9 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
                             processed_values[value_key] = list_node_name
                             for vv in v_data:
                                 data_node_name = graph.add_node(vv, site_base_url)
-                                graph.link(list_node_name, data_node_name)
+                                graph.link(
+                                    list_node_name, data_node_name, 'Extracted value'
+                                )
 
                                 add_ids = {
                                     a: b for b, a in db.extract_ids_from_url(vv).items()
@@ -297,7 +350,11 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
                                     processed_values[new_username_key] = (
                                         new_username_node_name
                                     )
-                                    graph.link(ids_data_name, new_username_node_name)
+                                    graph.link(
+                                        ids_data_name,
+                                        new_username_node_name,
+                                        'Derived identifier',
+                                    )
 
                             add_ids = {
                                 k: v for v, k in db.extract_ids_from_url(v).items()
@@ -305,13 +362,20 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
                             if add_ids:
                                 process_ids(ids_data_name, add_ids)
 
-                    graph.link(parent_node, ids_data_name)
+                    graph.link(parent_node, ids_data_name, 'Extracted profile data')
 
             if status.ids_data:
                 process_ids(account_node_name, status.ids_data)
 
-    # Remove overly long nodes
-    nodes_to_remove = [node for node in G.nodes if len(str(node)) > 100]
+    # Keep structural nodes addressable and shorten only their displayed labels.
+    # Large extracted values are still omitted to avoid cluttering the graph.
+    nodes_to_remove = [
+        node
+        for node, data in G.nodes(data=True)
+        if len(str(node)) > 100
+        and data.get('group') == 'metadata'
+        and G.degree(node) <= 1
+    ]
     G.remove_nodes_from(nodes_to_remove)
 
     # Remove site nodes with only one connection
@@ -332,9 +396,19 @@ def save_graph_report(filename: str, username_results: list, db: MaigretDatabase
     # cdn_resources="in_line": self-contained HTML, no lib/ folder written
     # relative to the process cwd (pyvis's default "local" mode does that,
     # which breaks when the report is served from a different directory).
-    nt = Network(notebook=True, height="100vh", width="100%", cdn_resources="in_line")
+    nt = Network(
+        notebook=True,
+        height="100vh",
+        width="100%",
+        bgcolor="#0f172a",
+        font_color="#e2e8f0",
+        cdn_resources="in_line",
+    )
     nt.from_nx(G)
-    nt.show(filename)
+    nt.set_options(json.dumps(GRAPH_VISUAL_OPTIONS))
+    graph_html = nt.generate_html(notebook=True)
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(graph_html)
 
 
 def _graph_to_cypher(G) -> str:

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-06T10:19:04Z",
+    "updated_at": "2026-08-10T06:43:23Z",
     "sites_count": 3221,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "e73eb88f900a85fd80af9d8f976d1407bf8d18db99b9563ca6316a4dc54f0e70",
+    "data_sha256": "d848a3c2f8db77337900daf759b40bacf533fbe0413b633a488209ba82ce49f9",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-10T06:43:23Z",
+    "updated_at": "2026-08-06T10:19:04Z",
     "sites_count": 3221,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "d848a3c2f8db77337900daf759b40bacf533fbe0413b633a488209ba82ce49f9",
+    "data_sha256": "e73eb88f900a85fd80af9d8f976d1407bf8d18db99b9563ca6316a4dc54f0e70",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -30,14 +31,17 @@ from maigret.report import (
     generate_report_context,
     generate_json_report,
     get_plaintext_report,
+    MaigretGraph,
+    _build_maigret_graph,
     _graph_to_cypher,
     _is_safe_report_image_url,
     _pdf_report_link_callback,
     _BLANK_IMAGE_PATH,
+    save_graph_report,
 )
 from maigret.errors import CheckError
 from maigret.result import MaigretCheckResult, MaigretCheckStatus
-from maigret.sites import MaigretSite
+from maigret.sites import MaigretDatabase, MaigretSite
 
 
 GOOD_RESULT = MaigretCheckResult('', '', '', MaigretCheckStatus.CLAIMED)
@@ -297,6 +301,105 @@ SUPPOSED_BROKEN_GEO = "Geo: us <span class=\"text-muted\">(2)</span>"
 
 SUPPOSED_INTERESTS = "Interests: photo <span class=\"text-muted\">(2)</span>, news <span class=\"text-muted\">(1)</span>, social <span class=\"text-muted\">(1)</span>"
 SUPPOSED_BROKEN_INTERESTS = "Interests: news <span class=\"text-muted\">(1)</span>, photo <span class=\"text-muted\">(1)</span>, social <span class=\"text-muted\">(1)</span>"
+
+
+def test_maigret_graph_styles_nodes_and_escapes_titles():
+    import networkx as nx
+
+    G = nx.Graph()
+    graph = MaigretGraph(G)
+    username = graph.add_node('username', 'alice')
+    account = graph.add_node('account', 'https://example.com/' + 'a' * 60)
+    site = graph.add_node('site', 'Example')
+    metadata = graph.add_node('bio', '<script>alert("x")</script> & details')
+
+    assert G.nodes[username]['group'] == 'identity'
+    assert G.nodes[account]['group'] == 'account'
+    assert G.nodes[site]['group'] == 'site'
+    assert G.nodes[metadata]['group'] == 'metadata'
+    assert len(G.nodes[account]['label']) <= 48
+    assert G.nodes[account]['label'].endswith('...')
+    assert G.nodes[metadata]['title'] == (
+        '<b>bio</b><br>&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; details'
+    )
+
+    graph.link(username, account, 'Matched account')
+    assert G.edges[username, account]['title'] == 'Matched account'
+
+
+def test_maigret_graph_preserves_connected_topology():
+    import networkx as nx
+
+    long_account_url = 'https://example.com/users/' + 'a' * 100
+    long_derived_username = 'b' * 110
+    username_results = [
+        (
+            'alice',
+            'username',
+            {
+                'Example': {
+                    'status': MaigretCheckResult(
+                        'alice',
+                        'Example',
+                        long_account_url,
+                        MaigretCheckStatus.CLAIMED,
+                        ids_data={'custom_username': long_derived_username},
+                    ),
+                    'url_user': long_account_url,
+                }
+            },
+        ),
+        (
+            'bob',
+            'username',
+            {
+                'Example': {
+                    'status': MaigretCheckResult(
+                        'bob',
+                        'Example',
+                        'https://example.com/users/bob',
+                        MaigretCheckStatus.CLAIMED,
+                    ),
+                    'url_user': 'https://example.com/users/bob',
+                }
+            },
+        ),
+    ]
+
+    G = _build_maigret_graph(username_results, MaigretDatabase())
+    long_account_node = f'account: {long_account_url}'
+    long_metadata_node = f'custom_username: {long_derived_username}'
+    derived_identity_node = f'username: {long_derived_username}'
+    site_node = 'site: Example'
+
+    assert long_account_node in G
+    assert len(G.nodes[long_account_node]['label']) <= 48
+    assert long_metadata_node in G
+    assert derived_identity_node in G
+    assert site_node in G
+    assert nx.is_connected(G)
+    assert G.edges['username: alice', long_account_node]['title'] == 'Matched account'
+    assert G.edges[long_account_node, site_node]['title'] == 'Hosted on site'
+    assert all('title' in data for _, _, data in G.edges(data=True))
+
+
+def test_save_graph_report_uses_dark_self_contained_visualization(tmp_path, default_db):
+    filename = tmp_path / 'graph.html'
+
+    save_graph_report(str(filename), TEST, default_db)
+
+    graph_html = filename.read_text(encoding='utf-8')
+    options_match = re.search(r'var options = (\{.*?\});', graph_html, re.DOTALL)
+    assert options_match is not None
+    options = json.loads(options_match.group(1))
+
+    assert '#0f172a' in graph_html
+    assert options['interaction']['navigationButtons'] is True
+    assert options['edges']['smooth'] is False
+    assert options['physics']['stabilization']['iterations'] == 200
+    assert options['groups']['identity']['color']['background'] == '#7c3aed'
+    assert options['groups']['metadata']['color']['background'] == '#2563eb'
+    assert 'lib/bindings' not in graph_html
 
 
 def test_generate_report_template():


### PR DESCRIPTION
## Summary

- add a dark, high-contrast graph theme with distinct identity, account, site, and metadata groups
- shorten displayed labels while preserving complete escaped values in hover details
- label existing relationships without adding tag or site-to-site edges
- add navigation controls and bound stabilization to 200 iterations
- retain long structural nodes and metadata bridges while continuing to prune oversized leaf metadata
- write generated graph HTML explicitly as UTF-8 for reliable Windows and web output

## Design rationale

The semantic graph topology is unchanged, so Neo4j output and existing identity/account relationships remain intact. This avoids the disconnected clusters and additional physics work from the earlier tag-linking approach. Visual options are applied through PyVis set_options rather than mutating its internal options object.

## Comparison

Both screenshots use the same deterministic report fixture at 1440x900.

### Before

![Graph before](https://raw.githubusercontent.com/Sushanth012/maigret/pr-assets-graph-2510/graph-before.png)

### After

![Graph after](https://raw.githubusercontent.com/Sushanth012/maigret/pr-assets-graph-2510/graph-after.png)

## Testing

- tests/test_report.py and tests/test_web.py: 85 passed, 2 skipped
- full suite: 405 passed, 4 skipped, 3 existing Windows baseline failures
- the unchanged failures cover Cloudflare error text timing, Windows path separators, and asynchronous completion ordering
- changed-range Black checks passed
- strict Flake8 undefined-name/syntax gate passed
- generated HTML tested in headless Microsoft Edge at 1440x900

Closes #2510