### PR TITLE
docs: mention Novita as an OpenAI-compatible endpoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ maigret user --ai
 maigret user --ai --ai-model gpt-4o-mini
 ```
 
-The key can also be set as `openai_api_key` in `settings.json`. The endpoint defaults to `https://api.openai.com/v1`, but `openai_api_base_url` in `settings.json` can point to any OpenAI-compatible API (Azure OpenAI, OpenRouter, a local server, …). See the [settings docs](https://maigret.readthedocs.io/en/latest/settings.html) for the full list of options.
+The key can also be set as `openai_api_key` in `settings.json`. The endpoint defaults to `https://api.openai.com/v1`, but `openai_api_base_url` in `settings.json` can point to any OpenAI-compatible API (Azure OpenAI, OpenRouter, Novita, a local server, …). See the [settings docs](https://maigret.readthedocs.io/en/latest/settings.html) for the full list of options.
 
 ### Tor / I2P / proxies
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -252,8 +252,8 @@ chat completion API. Three settings control how that request is made:
    * - ``openai_api_base_url``
      - ``https://api.openai.com/v1``
      - Base URL of the chat completion API. Point this at any
-       OpenAI-compatible service (Azure OpenAI, OpenRouter, a local
-       server, …) to use it instead of OpenAI directly.
+       OpenAI-compatible service (Azure OpenAI, OpenRouter, Novita, a
+       local server, …) to use it instead of OpenAI directly.
 
 Example ``~/.maigret/settings.json`` snippet using a non-OpenAI
 endpoint:


### PR DESCRIPTION

## Summary

The `--ai` flag already accepts any OpenAI-compatible `base_url` via `openai_api_base_url` in `settings.json`. This adds Novita alongside the existing Azure OpenAI / OpenRouter examples so users know it's an available option.

## Changes

- `README.md`: added Novita to the list of example OpenAI-compatible endpoints in the `--ai` section.
- `docs/source/settings.rst`: added Novita to the same example list in the `openai_api_base_url` setting description.

## Verification

- No code changes; documentation-only diff.
- `python3 -m pytest -q` on this branch and on the exact base commit both produce the same result, with no new failures introduced by this change.
