### PR TITLE
fix: update HuggingFace URL to API endpoint for accurate profile extractions

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3080,7 +3080,8 @@
         },
         "HuggingFace": {
             "checkType": "status_code",
-            "url": "https://huggingface.co/api/users/{username}/overview",
+            "url": "https://huggingface.co/{username}",
+            "urlProbe": "https://huggingface.co/api/users/{username}/overview",
             "urlMain": "https://huggingface.co/",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3080,7 +3080,7 @@
         },
         "HuggingFace": {
             "checkType": "status_code",
-            "url": "https://huggingface.co/{username}",
+            "url": "https://huggingface.co/api/users/{username}/overview",
             "urlMain": "https://huggingface.co/",
             "usernameClaimed": "blue",
             "usernameUnclaimed": "noonewouldeverusethis7",


### PR DESCRIPTION
* Updates the HuggingFace extraction URL in `data.json` to utilize the `/api/users/{username}/overview` endpoint instead of the standard profile page.
* Resolves an issue where HuggingFace profiles were not properly parsed due to the lack of structured JSON data on the standard profile route.
* Leverages the `socid-extractor`'s newly added HuggingFace API scheme to parse profile details efficiently.
    - Check: https://github.com/soxoj/socid-extractor/pull/275