### PR TITLE
Fix SOCKS5 proxy scheme mismatch between the two HTTP transports

### DIFF
--- a/docs/source/command-line-options.rst
+++ b/docs/source/command-line-options.rst
@@ -72,6 +72,10 @@ the given HTTP or SOCKS proxy. Example: ``socks5://127.0.0.1:1080``,
 routing the whole run through Tor (``--proxy socks5://127.0.0.1:9050``),
 a residential proxy, or any corporate gateway. No default.
 
+``socks5://`` and ``socks5h://`` are interchangeable: Maigret rewrites the
+scheme to the spelling expected by the transport handling each site, so
+either one resolves hostnames **at the proxy** for the whole database.
+
 ``--tor-proxy TOR_PROXY_URL`` - Gateway used **only** for ``.onion``
 sites in the database **(default: socks5://127.0.0.1:9050)**. Clearweb
 sites are unaffected — for them Maigret uses your direct connection or

--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -59,6 +59,59 @@ def _is_dns_error(exc: Exception) -> bool:
     return any(m in text for m in _DNS_ERROR_MARKERS)
 
 
+# The two HTTP transports disagree about what a SOCKS5 proxy URL means.
+#
+#   python_socks (via aiohttp_socks, used by SimpleAiohttpChecker)
+#     accepts exactly socks5/socks4/http and raises
+#     ValueError('Invalid scheme component: socks5h') on anything else, so
+#     socks5h:// is a hard crash before a single request is made. Its rdns
+#     flag defaults to True for SOCKS5, so socks5:// there already means
+#     proxy-side DNS.
+#
+#   libcurl (via curl_cffi, used by CurlCffiChecker for tls_fingerprint sites)
+#     keeps the classic distinction: socks5:// resolves the hostname on the
+#     client and passes an address to the proxy, socks5h:// passes the
+#     hostname and lets the proxy resolve it.
+#
+# So a single `--proxy socks5://...` resolves most of the database at the
+# proxy but the tls_fingerprint sites locally: their hostnames leak to the
+# local resolver, and geo-balanced hosts get resolved for the wrong network.
+# See issue #2955.
+#
+# Normalizing the scheme per transport makes both spellings mean proxy-side
+# DNS everywhere, so users need not know which transport handles which site.
+# Only SOCKS5 is remapped: python_socks defaults rdns to False for SOCKS4,
+# so rewriting socks4 would change behavior instead of aligning it.
+PYTHON_SOCKS_TRANSPORT = 'python_socks'
+LIBCURL_TRANSPORT = 'libcurl'
+
+_PROXY_SCHEME_ALIASES = {
+    PYTHON_SOCKS_TRANSPORT: {'socks5h': 'socks5'},
+    LIBCURL_TRANSPORT: {'socks5': 'socks5h'},
+}
+
+
+def normalize_proxy_scheme(proxy: Optional[str], transport: str) -> Optional[str]:
+    """Rewrite a proxy URL's scheme to the spelling `transport` understands.
+
+    Only the scheme is rewritten; host, port, credentials and path are passed
+    through as given, as are non-SOCKS5 schemes, schemeless values and empty
+    values.
+    """
+    if not proxy:
+        return proxy
+
+    scheme, separator, remainder = proxy.partition('://')
+    if not separator:
+        return proxy
+
+    replacement = _PROXY_SCHEME_ALIASES[transport].get(scheme.lower())
+    if replacement is None:
+        return proxy
+
+    return f'{replacement}://{remainder}'
+
+
 SUPPORTED_IDS = (
     "username",
     "yandex_public_id",
@@ -142,7 +195,7 @@ class CheckerBase:
 class SimpleAiohttpChecker(CheckerBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.proxy = kwargs.get('proxy')
+        self.proxy = normalize_proxy_scheme(kwargs.get('proxy'), PYTHON_SOCKS_TRANSPORT)
         self.cookie_jar = kwargs.get('cookie_jar')
         # 'async' (default) uses aiohttp's DefaultResolver, which is AsyncResolver
         # (powered by aiodns / c-ares) when aiodns is installed. 'threaded' uses
@@ -339,7 +392,7 @@ class CurlCffiChecker(CheckerBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.browser_emulate = kwargs.get('browser_emulate', 'chrome')
-        self.proxy = kwargs.get('proxy')
+        self.proxy = normalize_proxy_scheme(kwargs.get('proxy'), LIBCURL_TRANSPORT)
 
     def prepare(self, url, headers=None, allow_redirects=True, timeout=0, method='get', payload=None, encoding=None):
         self.url = url

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -272,7 +272,8 @@ def setup_arguments_parser(settings: Settings):
         action="store",
         dest="proxy",
         default=settings.proxy_url,
-        help="Make requests over a proxy. e.g. socks5://127.0.0.1:1080",
+        help="Make requests over a proxy. e.g. socks5://127.0.0.1:1080 "
+        "(socks5:// and socks5h:// are equivalent, both resolve at the proxy)",
     )
     parser.add_argument(
         "--tor-proxy",

--- a/maigret/submit.py
+++ b/maigret/submit.py
@@ -14,7 +14,11 @@ from .result import MaigretCheckResult
 from .settings import Settings
 from .sites import MaigretDatabase, MaigretEngine, MaigretSite
 from .utils import get_random_user_agent
-from .checking import site_self_check
+from .checking import (
+    site_self_check,
+    normalize_proxy_scheme,
+    PYTHON_SOCKS_TRANSPORT,
+)
 from .utils import get_match_ratio, generate_random_username
 
 
@@ -37,7 +41,10 @@ class Submitter:
 
         from aiohttp_socks import ProxyConnector
 
-        proxy = self.args.proxy
+        # Same python_socks scheme constraint as SimpleAiohttpChecker: socks5h
+        # is rejected outright, so --submit through a SOCKS proxy would crash
+        # without this. See issue #2955.
+        proxy = normalize_proxy_scheme(self.args.proxy, PYTHON_SOCKS_TRANSPORT)
         cookie_jar = None
         if args.cookie_file:
             if not os.path.exists(args.cookie_file):

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -1851,3 +1851,99 @@ async def test_simple_aiohttp_checker_does_not_retry_generic_proxy_error():
 
     assert len(calls) == 1  # no retry
     assert error.type == 'Proxy'
+
+
+# --- SOCKS proxy scheme normalization tests (issue #2955) ---
+
+
+@pytest.mark.parametrize(
+    'given, expected',
+    [
+        # socks5h is rejected outright by python_socks, so it must be rewritten
+        ('socks5h://127.0.0.1:1080', 'socks5://127.0.0.1:1080'),
+        # socks5 already means proxy-side DNS there: pass through untouched
+        ('socks5://127.0.0.1:1080', 'socks5://127.0.0.1:1080'),
+        # schemes python_socks handles natively must not be touched
+        ('http://127.0.0.1:8080', 'http://127.0.0.1:8080'),
+        ('socks4://127.0.0.1:1080', 'socks4://127.0.0.1:1080'),
+    ],
+)
+def test_aiohttp_checker_normalizes_proxy_scheme(given, expected):
+    from maigret.checking import SimpleAiohttpChecker
+
+    assert SimpleAiohttpChecker(logger=Mock(), proxy=given).proxy == expected
+
+
+@pytest.mark.parametrize(
+    'given, expected',
+    [
+        # libcurl resolves locally for socks5, leaking hostnames past the proxy
+        ('socks5://127.0.0.1:1080', 'socks5h://127.0.0.1:1080'),
+        ('socks5h://127.0.0.1:1080', 'socks5h://127.0.0.1:1080'),
+        ('http://127.0.0.1:8080', 'http://127.0.0.1:8080'),
+        ('socks4://127.0.0.1:1080', 'socks4://127.0.0.1:1080'),
+    ],
+)
+def test_curl_cffi_checker_normalizes_proxy_scheme(given, expected):
+    from maigret.checking import CurlCffiChecker
+
+    assert CurlCffiChecker(logger=Mock(), proxy=given).proxy == expected
+
+
+def test_proxied_aiohttp_checker_normalizes_proxy_scheme():
+    """--tor-proxy / --i2p-proxy go through the subclass, and .onion / .i2p
+    names only resolve at the proxy, so the same normalization must apply."""
+    from maigret.checking import ProxiedAiohttpChecker
+
+    checker = ProxiedAiohttpChecker(logger=Mock(), proxy='socks5h://127.0.0.1:9050')
+    assert checker.proxy == 'socks5://127.0.0.1:9050'
+
+
+def test_both_checkers_agree_on_proxy_side_dns():
+    """Whichever spelling the user passes, both transports end up resolving
+    at the proxy."""
+    from maigret.checking import SimpleAiohttpChecker, CurlCffiChecker
+
+    for spelling in ('socks5://127.0.0.1:1080', 'socks5h://127.0.0.1:1080'):
+        # socks5 + python_socks rdns default of True == socks5h + libcurl
+        assert SimpleAiohttpChecker(logger=Mock(), proxy=spelling).proxy == (
+            'socks5://127.0.0.1:1080'
+        )
+        assert CurlCffiChecker(logger=Mock(), proxy=spelling).proxy == (
+            'socks5h://127.0.0.1:1080'
+        )
+
+
+@pytest.mark.parametrize(
+    'transport, given, expected',
+    [
+        # credentials, IPv6 literals and paths must survive untouched
+        (
+            'python_socks',
+            'socks5h://user:p%40ss@proxy.example:1080',
+            'socks5://user:p%40ss@proxy.example:1080',
+        ),
+        (
+            'libcurl',
+            'socks5://user:p%40ss@[::1]:1080',
+            'socks5h://user:p%40ss@[::1]:1080',
+        ),
+        # the scheme match is case-insensitive, like every other URL scheme
+        ('python_socks', 'SOCKS5H://127.0.0.1:1080', 'socks5://127.0.0.1:1080'),
+        ('libcurl', 'Socks5://127.0.0.1:1080', 'socks5h://127.0.0.1:1080'),
+        # only the leading scheme is rewritten, never a match inside the URL
+        (
+            'libcurl',
+            'http://user:socks5://@127.0.0.1:8080',
+            'http://user:socks5://@127.0.0.1:8080',
+        ),
+        # no proxy configured, or a value with no scheme at all
+        ('python_socks', None, None),
+        ('libcurl', '', ''),
+        ('libcurl', '127.0.0.1:1080', '127.0.0.1:1080'),
+    ],
+)
+def test_normalize_proxy_scheme(transport, given, expected):
+    from maigret.checking import normalize_proxy_scheme
+
+    assert normalize_proxy_scheme(given, transport) == expected

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -358,3 +358,52 @@ def test_dialog_nonexistent_site_name_no_crash():
     )
     assert old_site is not None
     assert old_site.name == "ValidActive"
+
+
+# --- SOCKS proxy scheme normalization tests (issue #2955) ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'given, expected',
+    [
+        # python_socks rejects socks5h outright, so --submit through a SOCKS
+        # proxy used to crash with "Invalid scheme component: socks5h"
+        ('socks5h://127.0.0.1:1080', 'socks5://127.0.0.1:1080'),
+        ('socks5://127.0.0.1:1080', 'socks5://127.0.0.1:1080'),
+        ('http://127.0.0.1:8080', 'http://127.0.0.1:8080'),
+    ],
+)
+async def test_submitter_normalizes_proxy_scheme(test_db, given, expected):
+    args = MagicMock()
+    args.cookie_file = ""
+    args.proxy = given
+
+    captured = []
+
+    class _DummyConnector:
+        def __init__(self, *args, **kwargs):
+            # aiohttp's ClientSession expects these on its connector
+            self._loop = None
+            self.closed = False
+
+        async def close(self):
+            pass
+
+        @property
+        def force_close(self):
+            return False
+
+    def fake_from_url(url, **kwargs):
+        captured.append(url)
+        return _DummyConnector()
+
+    # Only the URL handed to python_socks matters here; whether ClientSession
+    # then accepts the dummy connector is irrelevant to this assertion.
+    with patch('aiohttp_socks.ProxyConnector.from_url', side_effect=fake_from_url):
+        try:
+            Submitter(test_db, MagicMock(), logging.getLogger(), args)
+        except Exception:
+            pass
+
+    assert captured == [expected]


### PR DESCRIPTION
## Summary

- normalize the `--proxy` scheme per transport in `SimpleAiohttpChecker` and `CurlCffiChecker`, so either spelling resolves at the proxy
- apply the same normalization in `submit.py`, which builds a `ProxyConnector` directly and hit the same crash
- document that `socks5://` and `socks5h://` are interchangeable

The two transports disagree about what a SOCKS5 proxy URL means. `python_socks(via `aiohttp_socks`) accepts only `socks5`/`socks4`/`http` and raises `Invalid scheme component: socks5h` before any request is made; its `rdns` flag defaults to `True`, so `socks5://` there already means proxy-side DNS. `libcurl` (via `curl_cffi`, used for the 108 `tls_fingerprint` sites) keeps the classic split, where `socks5://` resolves locally and `socks5h://` resolves at the proxy.

So `--proxy socks5h://...` crashed on most of the database, and `--proxy socks5://...` quietly resolved the `tls_fingerprint` sites through the local resolver, leaking those hostnames past the proxy and resolving geo-balanced hosts for the wrong network.

`normalize_proxy_scheme()` rewrites only the scheme, never the host, port or credentials. SOCKS4 is deliberately left alone: `python_socks` defaults `rdns` to `False` there, so rewriting it would change behavior rather than align it. `--tor-proxy` and `--i2p-proxy` inherit the fix through `ProxiedAiohttpChecker`.

`submit.py` is not mentioned in the issue, but it calls `ProxyConnector.from_url()` directly rather than going through a checker, so `--submit` with `socks5h://` raised the same `ValueError`.

## Validation

Against a local SOCKS5 server logging the CONNECT address type, with a target host only the proxy can resolve. ATYP=3 means the hostname reached the proxy, ATYP=1 means the client resolved it first:

| | before | after |
|---|---|---|
| aiohttp `socks5://` | OK, ATYP=3 | OK, ATYP=3 |
| aiohttp `socks5h://` | `ValueError` | OK, ATYP=3 |
| curl_cffi `socks5://` | `curl: (6) Could not resolve host` | OK, ATYP=3 |
| curl_cffi `socks5h://` | OK, ATYP=3 | OK, ATYP=3 |

- end-to-end CLI over one normal site and one `tls_fingerprint` site: before,
  `socks5h://` returned 0 accounts TYP=1 CONNECT.
  After, both spellings return the same results with every CONNECT as ATYP=3
- `pytest tests -q` (`439 passed, 4
- 21 new network-free regression tests. The 13 covering rewritten schemes fail
  on `main`, the rest pin the pass-4`, credentials,
  IPv6 literals, schemeless and empty values)
- `black` / `flake8` clean, `mypy` ain`

Closes #2955