### PR TITLE
Move snapcraft.yaml to snap/ and migrate to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,16 +1,18 @@
-title: Maigret
-icon: static/maigret.png
 name: maigret
+title: Maigret
 summary: 🕵️‍♂️ Collect a dossier on a person by username from thousands of sites.
 description: |
   **Maigret** collects a dossier on a person **by username only**, checking for accounts on a huge number of sites and gathering all the available information from web pages. No API keys required.
-  
+
   Currently supported more than 3000 sites, search is launched against 500 popular sites in descending order of popularity by default. Also supported checking of Tor sites, I2P sites, and domains (via DNS resolving).
 
-version: 0.6.4
+  Reports are written to a `reports/` folder in the current directory, so run maigret from somewhere under your home directory or a removable drive.
+
+icon: static/maigret.png
 license: MIT
-base: core22
+base: core24
 confinement: strict
+adopt-info: maigret
 
 source-code: https://github.com/soxoj/maigret
 issues:
@@ -24,9 +26,15 @@ parts:
   maigret:
     plugin: python
     source: .
+    override-pull: |
+      craftctl default
+      craftctl set version="$(sed -n "s/^__version__ = '\(.*\)'/\1/p" maigret/__version__.py)"
 
-type: app
 apps:
   maigret:
     command: bin/maigret
-    plugs: [ network, network-bind, home ]
+    plugs:
+      - network
+      - network-bind
+      - home
+      - removable-media


### PR DESCRIPTION
Brings `snapcraft.yaml` up to date so the snap can actually be published. The file has been in the repository unpublished, and as written it would not have produced a working snap on a current base.

## Changes

`snapcraft.yaml` moved to `snap/snapcraft.yaml` via `git mv`, which is the location snapcraft and the CI actions expect, and keeps the repository root clearer. The other accepted locations are the root, `.snapcraft.yaml` and `build-aux/snap/`; snapcraft's own project uses `snap/`.

`base: core22` → `core24`, so Ubuntu 22.04 / Python 3.10 becomes 24.04 / Python 3.12. core22 is the oldest base still supported and core26 has only just landed, so core24 is the conservative choice with a documented migration path.

The hardcoded `version: 0.6.4` is replaced by `adopt-info` plus a `craftctl set version` that reads `maigret/__version__.py`, so releases no longer need a manual bump here.

Added the `removable-media` plug, otherwise reports cannot be written to an external drive under strict confinement, and it is the one plug that does not connect automatically. Added the `website` metadata field, which the store lint asks for. Dropped `type: app`, which is the default.

The description now mentions that reports are written to `reports/` in the current directory, since strict confinement makes that matter to the user.

## Verification

Built with snapcraft 8 on core24 and produced `maigret_0.6.4_amd64.snap`, with the version coming from `__version__.py` rather than the yaml. Installed with `--dangerous` and ran a real search: the report landed in `~/snap-test/reports/`, and the bundled 3221-site database is present at `lib/python3.12/site-packages/maigret/resources/data.json`. The icon from `static/maigret.png` is picked up correctly into `meta/gui/icon.png`.

Note this branch predates the read-only database fix in #2973; that fix is what makes the snap usable in practice, since strict confinement mounts the package read-only.
