### PR TITLE
Declare python-dateutil as a direct dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3535,4 +3535,4 @@ pdf = ["arabic-reshaper", "python-bidi", "xhtml2pdf"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "46241581fa0fe65a1954694043afcd390c266f16ce7f28e5a0ff9ff4bb7d5bef"
+content-hash = "bcf4f36e9eb09d11a0fa41d827c875b0be649e5acdbd0e88c86c177b8669b719"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ MarkupSafe = "^3.0.2"
 pycountry = ">=24.6.1,<27.0.0"
 PySocks = "^1.7.1"
 python-bidi = {version = "^0.6.3", optional = true}
+python-dateutil = ">=2.8.1"
 requests = "^2.32.4"
 socid-extractor = ">=0.1.1,<0.2.0"
 soupsieve = "^2.6"


### PR DESCRIPTION
`maigret/report.py` imports dateutil directly:

```python
from dateutil.tz import gettz
from dateutil.parser import parse as parse_datetime_str
```

but `python-dateutil` is not declared anywhere in `pyproject.toml`. It gets installed today only because `socid-extractor` requires `python-dateutil >=2.8.1,<3.0`, so a first-party import is riding on a second-party dependency staying where it is.

That holds until it doesn't. If socid-extractor ever drops or vendors dateutil, or a downstream packager builds from the declared metadata instead of the lock file, the import disappears. And it disappears at startup, not at report generation: `maigret/__init__.py` imports `.checking` on its first real line, so `maigret --version` is already enough to hit it.

```
ImportError: Missing required dependency while starting Maigret.
```

### The change

```toml
python-dateutil = ">=2.8.1"
```

Same floor socid-extractor already asks for. No upper bound, because a cap here would create conflicts for distro packagers without protecting against anything real.

`poetry.lock` changes exactly one line, the content-hash. `python-dateutil 2.9.0.post0` was already locked in the `main` group, so no installed version moves and nothing needs reinstalling.

### Verification

* `poetry check --lock` exits 0.
* Lock diff is content-hash only, confirmed by `git diff poetry.lock`.
* With `dateutil` blocked from the import system, `maigret --version` raises the startup `ImportError` above, which confirms the dependency is load-bearing at import time rather than optional.
