### PR TITLE
Disable ForumJizni false-positive check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -25225,7 +25225,8 @@
             "alexaRank": 612390,
             "urlMain": "http://www.forumjizni.ru",
             "usernameClaimed": "luhoy2",
-            "usernameUnclaimed": "noonewouldeverusethis7"
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "disabled": true
         },
         "Nekto": {
             "tags": [


### PR DESCRIPTION
## Summary

- disable the ForumJizni site entry
- prevent its vBulletin fallback from reporting arbitrary usernames as claimed

ForumJizni currently returns the same non-profile response for both the recorded account and an impossible username. Because that response contains none of the vBulletin engine's absence markers, the message check treats every username as claimed. Disabling the unreliable entry follows the project's documented fallback until the site exposes a stable profile signal again.

## Validation

- reproduced CLAIMED for both `luhoy2` and `noonewouldeverusethis7` before the change
- `python -m pytest tests/test_data.py -q`: 4 passed
- `python -m json.tool maigret/resources/data.json`: valid JSON
- default scan now excludes the disabled site

Closes #2901