### PR TITLE
Fix diagnostic database loading on Windows

### DIFF
--- a/utils/check_top_n.py
+++ b/utils/check_top_n.py
@@ -266,7 +266,7 @@ async def check_site(site_name: str, config: dict, timeout: int = 15) -> SiteChe
 
 def load_sites(db_path: Path) -> Dict[str, dict]:
     """Load all sites from data.json."""
-    with open(db_path) as f:
+    with open(db_path, encoding="utf-8") as f:
         data = json.load(f)
     return data.get("sites", {})
 

--- a/utils/site_check.py
+++ b/utils/site_check.py
@@ -624,7 +624,7 @@ def load_site_from_db(site_name: str) -> Tuple[Optional[dict], Optional['Maigret
     """Load site config from data.json. Returns (config_dict, MaigretSite or None)."""
     db_path = Path(__file__).parent.parent / "maigret" / "resources" / "data.json"
 
-    with open(db_path) as f:
+    with open(db_path, encoding="utf-8") as f:
         data = json.load(f)
 
     config = None


### PR DESCRIPTION
## Summary

- decode `data.json` explicitly as UTF-8 in `site_check.py`
- apply the same fix to `check_top_n.py` so both documented diagnostics work independently of the system locale

## Why

These utilities used Python's platform-default text encoding. On Windows systems using cp1252, loading the UTF-8 site database failed before any diagnosis could run:

```text
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d
```

The database is UTF-8 and the repository's other current database utilities already specify that encoding.

## Validation

- reproduced the crash with `python utils/site_check.py --site Icheckmovies --diagnose` before the fix
- the same command completes after the fix
- `python utils/check_top_n.py --top 0` completes on Windows
- `python -m pytest tests/test_data.py tests/test_utils.py -q`: 27 passed
- `git diff --check` passes