### PR TITLE
Adding support for bunq.me

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -43623,6 +43623,21 @@
             "absenceStrs": [
                 "Halaman Tidak Ditemukan"
             ]
+        },
+        "bunq": {
+            "urlMain": "https://bunq.me",
+            "tags": [
+                "finance",
+                "fintech",
+                "nl"
+            ],
+            "url": "https://bunq.me/{username}",
+            "checkType": "message",
+            "usernameClaimed": "ali",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "absenceStrs": [
+                "This profile does not exist"
+            ]
         }
     },
     "engines": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-18T11:16:22Z",
-    "sites_count": 3224,
+    "updated_at": "2026-08-19T16:44:32Z",
+    "sites_count": 3225,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "92877f7961c95e9993e3ffd996a1a9371393f8936b60db4a40150241f0355085",
+    "data_sha256": "62137844d779b4d5e9857d1bdf3ba8418ca7425a74349c6c25b1d440ebf16ae1",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3224
+## List of supported sites (search methods): total 3225
 
 Rank data fetched from Majestic Million by domains.
 
@@ -3227,17 +3227,18 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://lazada.com.ph) [lazada.com.ph (https://lazada.com.ph)](https://lazada.com.ph)*: top 100M, ph, shopping*
 1. ![](https://www.google.com/s2/favicons?domain=https://lazada.com.my) [lazada.com.my (https://lazada.com.my)](https://lazada.com.my)*: top 100M, my, shopping*
 1. ![](https://www.google.com/s2/favicons?domain=https://lazada.co.id) [lazada.co.id (https://lazada.co.id)](https://lazada.co.id)*: top 100M, id, shopping*
+1. ![](https://www.google.com/s2/favicons?domain=https://bunq.me) [bunq (https://bunq.me)](https://bunq.me)*: top 100M, finance, fintech, nl*
 
-The list was updated at (2026-08-18)
+The list was updated at (2026-08-19)
 ## Statistics
 
-Enabled/total sites: 2546/3224 = 78.97%
+Enabled/total sites: 2547/3225 = 78.98%
 
-Incomplete message checks: 324/2546 = 12.73% (false positive risks)
+Incomplete message checks: 325/2547 = 12.76% (false positive risks)
 
-Status code checks: 693/2546 = 27.22% (false positive risks)
+Status code checks: 693/2547 = 27.21% (false positive risks)
 
-False positive risk (total): 39.95%
+False positive risk (total): 39.97%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox, HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
@@ -3245,7 +3246,7 @@ Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSea
 
 Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
-- (327)	`/{username}`
+- (328)	`/{username}`
 - (221)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
 - (180)	`/user/{username}`
 - (143)	`/profile/{username}`


### PR DESCRIPTION
bunq.me is a service part of a Dutch bank where people can start fundraising or they can use send payment requests. It shows self-reported name and IBAN (which also reports the country). Would it be possible to grab this data as well using socid-extractor?