### PR TITLE
fix: write report files with an explicit utf-8 encoding

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -722,7 +722,7 @@ def make_protocol_checker(options: Dict[str, Any], protocol: str):
 
 
 def debug_response_logging(url, html_text, status_code, check_error):
-    with open("debug.log", "a") as f:
+    with open("debug.log", "a", encoding="utf-8") as f:
         status = status_code or "No response"
         f.write(f"url: {url}\nerror: {check_error}\nr: {status}\n")
         if html_text:

--- a/maigret/report.py
+++ b/maigret/report.py
@@ -337,7 +337,15 @@ def save_graph_report(filename: str, username_results: list, db: MaigretDatabase
     # which breaks when the report is served from a different directory).
     nt = Network(notebook=True, height="100vh", width="100%", cdn_resources="in_line")
     nt.from_nx(G)
-    nt.show(filename)
+    # Render and write the file here instead of calling nt.show(): pyvis opens
+    # the target with open(name, "w+"), i.e. the locale encoding, which on
+    # Windows is a non-UTF-8 codepage (cp1252 by default). The inlined
+    # vis-network bundle carries several hundred non-ASCII characters of its
+    # own, so the write failed with UnicodeEncodeError for every graph report,
+    # whatever was scanned. The template already declares a utf-8 charset.
+    html = nt.generate_html(name=filename, notebook=True)
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(html)
 
 
 def _graph_to_cypher(G) -> str:
@@ -557,7 +565,9 @@ def generate_report_template(is_pdf: bool):
     """
 
     def get_resource_content(filename):
-        return open(os.path.join(maigret_path, "resources", filename)).read()
+        path = os.path.join(maigret_path, "resources", filename)
+        with open(path, encoding="utf-8") as f:
+            return f.read()
 
     maigret_path = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -1,4 +1,7 @@
 import asyncio
+import subprocess
+import sys
+import textwrap
 from argparse import ArgumentTypeError
 
 from unittest.mock import Mock
@@ -339,6 +342,53 @@ def test_debug_response_logging_no_response(tmp_path, monkeypatch):
     debug_response_logging("https://example.com", None, None, CheckError("Timeout"))
     out = (tmp_path / "debug.log").read_text()
     assert "No response" in out
+
+
+def test_debug_response_logging_writes_non_ascii_page(tmp_path):
+    """Debug mode dumps whole response bodies, and plenty of sites answer in
+    Cyrillic or CJK. Writing those with the locale codepage (cp1252 on a
+    default Windows install) raised UnicodeEncodeError from inside the check.
+    Run it under -X warn_default_encoding so dropping the explicit encoding
+    fails here as well, not only on a non-utf-8 machine.
+    """
+    probe = tmp_path / "debug_log_probe.py"
+    probe.write_text(
+        textwrap.dedent(
+            """
+            from maigret.checking import debug_response_logging
+
+            debug_response_logging(
+                "https://example.com/привет",
+                "<html>Привет 日本語</html>",
+                200,
+                None,
+            )
+            print("OK")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "warn_default_encoding",
+            "-W",
+            "error::EncodingWarning",
+            str(probe),
+        ],
+        cwd=str(tmp_path),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    out = (tmp_path / "debug.log").read_bytes().decode("utf-8")
+    assert "<html>Привет 日本語</html>" in out
 
 
 def _make_site(data_overrides=None):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -926,6 +926,78 @@ def test_import_maigret_without_pdf_extras():
     assert "OK" in result.stdout
 
 
+def test_save_graph_report_writes_utf8(tmp_path):
+    """The graph HTML must be written with an explicit encoding.
+
+    pyvis inlines the whole vis-network bundle, which carries several hundred
+    non-ASCII characters of its own, and its show() opens the target file
+    without an encoding argument. That means the locale codepage, so on a
+    default Windows install (cp1252) every graph report died with
+    UnicodeEncodeError no matter what was scanned. The check runs in a fresh
+    interpreter under -X warn_default_encoding so a return to the implicit
+    locale encoding fails here too, not only on a non-utf-8 machine.
+    """
+    target = tmp_path / "report_graph.html"
+    probe = tmp_path / "graph_probe.py"
+    code = textwrap.dedent(
+        f"""
+        from maigret.report import save_graph_report
+        from maigret.result import MaigretCheckResult, MaigretCheckStatus
+        from maigret.sites import MaigretDatabase
+
+        status = MaigretCheckResult(
+            'алекс',
+            'GitHub',
+            'https://github.com/алекс',
+            MaigretCheckStatus.CLAIMED,
+        )
+        results = [
+            (
+                'алекс',
+                'username',
+                {{
+                    'GitHub': {{
+                        'status': status,
+                        'url_user': 'https://github.com/алекс',
+                    }}
+                }},
+            )
+        ]
+
+        save_graph_report({str(target)!r}, results, MaigretDatabase())
+        print("OK")
+        """
+    )
+    probe.write_text(code, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "warn_default_encoding",
+            "-W",
+            "error::EncodingWarning",
+            str(probe),
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+    html = target.read_bytes().decode("utf-8")
+    assert '<meta charset="utf-8">' in html
+    # the inlined bundle is what used to blow up: it carries non-ASCII of its
+    # own, and it has to survive the round trip
+    assert "\u00a9" in html
+    # the scanned username reaches the graph too (pyvis escapes it into the
+    # embedded JSON, hence the \uXXXX form)
+    assert r"username: \u0430\u043b\u0435\u043a\u0441" in html
+
+
 def test_text_report():
     context = generate_report_context(TEST)
     report_text = get_plaintext_report(context)


### PR DESCRIPTION
On Windows, `--graph` crashes and the web interface can't finish a single scan.

`save_graph_report` hands the file to pyvis's `show()`, which opens it with `open(name, "w+")`, i.e. the locale encoding. On a default Windows install that is cp1252, and the vis-network bundle pyvis inlines carries ~900 non-ASCII characters of its own, so the write fails whatever the scan contained:

```
$ maigret soxoj --site GitHub --graph
  File "maigret/report.py", line 340, in save_graph_report
    nt.show(filename)
UnicodeEncodeError: 'charmap' codec can't encode characters in position 263607-263621
```

The run dies there, before the remaining reports and the text summary, and leaves a 0-byte `report_soxoj_graph.html`. `build_reports()` writes a graph for every web scan, so on Windows every scan ends as "Search failed" with the results discarded - I confirmed that with a real scan through the app, not just from the unit test. pyvis 0.3.2 is still the current release (2023), so there is nothing to pick up upstream.

So render the html and write it here with `encoding="utf-8"` - the template already declares that charset. `debug_response_logging` and the report template read had the same implicit encoding and get the same treatment; the first one crashes under `-d` on any page the local codepage can't represent, which is most non-Latin sites.

Three tests already in the suite fail on a non-utf-8 machine before this change and pass after it: `test_build_reports_computes_found_count`, `test_real_report_generation_does_not_crash` and `test_live_scan_streams_found_and_done`. They are green on CI either way because the runners are utf-8, so the new tests do the writes in a subprocess under `-X warn_default_encoding -W error::EncodingWarning` - that fails on any platform if the explicit encoding goes away again.

Offline suite on Windows: 14 failures before, 11 after; the remaining ones are unrelated (xmind temp files, chmod, DNS).

Separately, the donate banner's heart character crashes a redirected run on Windows (`maigret user > out.txt`) for the same underlying reason. That one is about console output rather than report files, so I kept it out of this PR - happy to send it as a follow-up if you want it.
