### PR TITLE
Add bunq.me as supported site

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -3179,6 +3179,21 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
+        "bunq": {
+            "urlMain": "https://bunq.me",
+            "tags": [
+                "finance",
+                "fintech",
+                "nl"
+            ],
+            "url": "https://bunq.me/{username}",
+            "checkType": "message",
+            "usernameClaimed": "ali",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "absenceStrs": [
+                "This profile does not exist"
+            ]
+        },
         "Itch.io": {
             "tags": [
                 "apps",

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-24T08:21:34Z",
-    "sites_count": 3287,
+    "updated_at": "2026-08-25T07:08:11Z",
+    "sites_count": 3288,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "9aee75c7e4f67d5bc8c2b7c20198c1d3195da366ccdb80777c9569c2208d0b4e",
+    "data_sha256": "9e025f968808715fd7250bb243b2de80609af787d7327910b2a6b9d6c1753272",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3287
+## List of supported sites (search methods): total 3288
 
 Rank data fetched from Majestic Million by domains.
 
@@ -1252,6 +1252,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://forums.envato.com) [Envato (https://forums.envato.com)](https://forums.envato.com)*: top 100M, au, forum*
 1. ![](https://www.google.com/s2/favicons?domain=https://diveforum.spb.ru/) [Diveforum (https://diveforum.spb.ru/)](https://diveforum.spb.ru/)*: top 100M, forum, ru*
 1. ![](https://www.google.com/s2/favicons?domain=http://poteryashka.spb.ru) [poteryashka.spb.ru (http://poteryashka.spb.ru)](http://poteryashka.spb.ru)*: top 100M, forum, geosocial, ru*
+1. ![](https://www.google.com/s2/favicons?domain=https://bunq.me) [bunq (https://bunq.me)](https://bunq.me)*: top 100M, finance, fintech, nl*
 1. ![](https://www.google.com/s2/favicons?domain=https://forums.ea.com) [forums.ea.com (https://forums.ea.com)](https://forums.ea.com)*: top 100M, forum, gaming*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://comicvine.gamespot.com/) [ComicvineGamespot (https://comicvine.gamespot.com/)](https://comicvine.gamespot.com/)*: top 100M, gaming*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://gamefaqs.gamespot.com) [Gamefaqs (https://gamefaqs.gamespot.com)](https://gamefaqs.gamespot.com)*: top 100M, gaming*
@@ -3291,16 +3292,16 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://gitea.siberat.id) [gitea.siberat.id (https://gitea.siberat.id)](https://gitea.siberat.id)*: top 100M, coding, id*
 1. ![](https://www.google.com/s2/favicons?domain=https://openjscad.nodebb.com) [openjscad.nodebb.com (https://openjscad.nodebb.com)](https://openjscad.nodebb.com)*: top 100M, 3d, coding, discussion, forum*
 
-The list was updated at (2026-08-24)
+The list was updated at (2026-08-25)
 ## Statistics
 
-Enabled/total sites: 2609/3287 = 79.37%
+Enabled/total sites: 2610/3288 = 79.38%
 
-Incomplete message checks: 341/2609 = 13.07% (false positive risks)
+Incomplete message checks: 342/2610 = 13.1% (false positive risks)
 
-Status code checks: 710/2609 = 27.21% (false positive risks)
+Status code checks: 710/2610 = 27.2% (false positive risks)
 
-False positive risk (total): 40.28%
+False positive risk (total): 40.30%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox, HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
@@ -3308,7 +3309,7 @@ Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSea
 
 Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
-- (334)	`/{username}`
+- (335)	`/{username}`
 - (242)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
 - (189)	`/user/{username}`
 - (145)	`/profile/{username}`
@@ -3365,5 +3366,5 @@ Top 20 tags:
 - (84)	`auto`
 - (71)	`shopping`
 - (69)	`photo`
+- (68)	`finance`
 - (67)	`design`
-- (67)	`finance`


### PR DESCRIPTION
bunq.me is bunq's payment-request link service (e.g. bunq.me/ali). Uses a message-based check: a claimed profile renders normally, while an unclaimed one serves "This profile does not exist" on its 404 page.