### PR TITLE
False negatives

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -262,11 +262,12 @@ class SimpleAiohttpChecker(CheckerBase):
                 async with request_method(**kwargs) as response:
                     status_code = response.status
                     # A response_url check runs with redirects disabled, so any
-                    # 3xx reads as "user not found". Some sites bounce the first
-                    # request back to the SAME url to plant a session cookie
-                    # (joyreactor.cc: 302 + `Set-Cookie: jr_captcha=1`): that is
-                    # not a not-found, it is a retry request. The session keeps
-                    # the cookie, so one repeat returns the real page. Set-Cookie
+                    # 3xx reads as "user not found". Some sites intermittently
+                    # bounce a request back to the SAME url to plant a session
+                    # cookie (joyreactor.cc: 302 + `Set-Cookie: jr_captcha=1`,
+                    # roughly one request in five to seven): that is not a
+                    # not-found, it is a retry request. The session keeps the
+                    # cookie, so one repeat returns the real page. Set-Cookie
                     # is what makes it a handshake — without it, a site that
                     # always self-redirects would just cost two requests.
                     if (

--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -261,6 +261,23 @@ class SimpleAiohttpChecker(CheckerBase):
             try:
                 async with request_method(**kwargs) as response:
                     status_code = response.status
+                    # A response_url check runs with redirects disabled, so any
+                    # 3xx reads as "user not found". Some sites bounce the first
+                    # request back to the SAME url to plant a session cookie
+                    # (joyreactor.cc: 302 + `Set-Cookie: jr_captcha=1`): that is
+                    # not a not-found, it is a retry request. The session keeps
+                    # the cookie, so one repeat returns the real page. Set-Cookie
+                    # is what makes it a handshake — without it, a site that
+                    # always self-redirects would just cost two requests.
+                    if (
+                        not allow_redirects
+                        and 300 <= status_code < 400
+                        and str(response.headers.get("Location", "")) == url
+                        and response.headers.get("Set-Cookie")
+                        and attempt < transient_retries
+                    ):
+                        logger.debug(f"Self-redirect to {url}, retrying")
+                        continue
                     response_content = await response.content.read()
                     charset = self.encoding or response.charset or "utf-8"
                     decoded_content = response_content.decode(charset, "ignore")

--- a/maigret/error_detection.py
+++ b/maigret/error_detection.py
@@ -15,8 +15,13 @@ def detect_error_page(
     Three signals, checked in order:
       1. Site-specific failure markers (``fail_flags`` substring match).
       2. Generic provider / bot-protection wording (``errors.detect``).
-      3. HTTP status — 403 (unless suppressed), >=500 server. HTTP 999
-         (LinkedIn anti-bot) is a valid "not-found", not an error.
+      3. HTTP status — 403 (unless suppressed), 401 auth, 429 rate limit,
+         >=500 server. HTTP 999 (LinkedIn anti-bot) is deliberately left
+         alone, see below.
+
+    A refused request is never evidence that the username is free: without an
+    error here the caller falls through to the checkType branch, where any
+    non-2xx code means AVAILABLE — a silent false negative.
     """
     if fail_flags and html_text:
         for flag, msg in fail_flags.items():
@@ -29,7 +34,16 @@ def detect_error_page(
 
     if status_code == 403 and not ignore_403:
         return CheckError("Access denied", f"403 status code, {errors.PROXY_RECOMMENDATION}")
+    if status_code == 401:
+        return CheckError("Login required", "401 status code")
+    if status_code == 429:
+        return CheckError("Rate limited", "429 status code")
     if status_code == 999:
+        # LinkedIn's "Request denied", served to blocked clients for existing
+        # and non-existing profiles alike, so it is not really a not-found.
+        # Classifying it as an error would flip LinkedIn to UNKNOWN for every
+        # blocked IP, which reads as "LinkedIn is broken" to users. Kept as a
+        # pass-through on purpose: the caller's checkType branch decides.
         return None
     if status_code >= 500:
         return CheckError("Server", f"{status_code} status code")

--- a/maigret/errors.py
+++ b/maigret/errors.py
@@ -72,6 +72,9 @@ COMMON_ERRORS = {
         'Just a moment: bot redirect challenge', 'Cloudflare'
     ),
     'SlardarWAF': CheckError('Bot protection', 'WAF challenge'),
+    '<title>Vercel Security Checkpoint</title>': CheckError(
+        'Bot protection', 'Vercel'
+    ),
     'unusual traffic from your computer network': CheckError(
         'Captcha', 'Google rate-limit / captcha'
     ),
@@ -87,6 +90,8 @@ ERRORS_TYPES = {
     'Captcha': 'Try to switch to another IP address or to use service cookies',
     'Bot protection': 'Try to switch to another IP address',
     'Access denied': PROXY_RECOMMENDATION,
+    'Rate limited': 'Try `-n 10` to lower parallelism, or repeat the search later',
+    'Login required': 'Add authorization cookies through `--cookies-jar-file` (see cookies.txt)',
     'Censorship': 'Switch to another internet service provider',
     'Request timeout': 'Try to increase timeout or to switch to another internet service provider',
     'Connecting failure': 'Check your internet connection; if only a subset of sites fails, try `-n 10` to lower parallelism',
@@ -103,11 +108,8 @@ ERRORS_TYPES = {
     ),
 }
 
-ERRORS_REASONS = {
-    'Login required': 'Add authorization cookies through `--cookies-jar-file` (see cookies.txt)',
-}
-
 TEMPORARY_ERRORS_TYPES = [
+    'Rate limited',
     'Request timeout',
     'Unknown',
     'Request failed',

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -9275,6 +9275,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "adblockplus.org": {
+            "disabled": true,
             "tags": [
                 "apps",
                 "social",
@@ -13420,13 +13421,7 @@
                 "reading",
                 "ru"
             ],
-            "checkType": "message",
-            "presenseStrs": [
-                "на livelib.ru"
-            ],
-            "absenceStrs": [
-                "не найден"
-            ],
+            "checkType": "status_code",
             "alexaRank": 11407,
             "urlMain": "https://www.livelib.ru/",
             "url": "https://www.livelib.ru/reader/{username}",
@@ -14525,6 +14520,7 @@
             ]
         },
         "DLive": {
+            "disabled": true,
             "absenceStrs": [
                 "Channel not found"
             ],
@@ -14545,6 +14541,7 @@
             ]
         },
         "Nkj": {
+            "disabled": true,
             "tags": [
                 "ru",
                 "science"
@@ -14915,6 +14912,7 @@
             ]
         },
         "Repl.it": {
+            "disabled": true,
             "tags": [
                 "apps",
                 "coding",
@@ -15195,6 +15193,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Funnyjunk": {
+            "disabled": true,
             "tags": [
                 "anime",
                 "forum",
@@ -15620,17 +15619,11 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "mel.fm": {
-            "absenceStrs": [
-                "l-page-404__text-not-found"
-            ],
-            "presenseStrs": [
-                "Введите e-mail"
-            ],
             "url": "https://mel.fm/blog/{username}",
             "urlMain": "https://mel.fm",
-            "usernameClaimed": "ivan-ivanov30",
+            "usernameClaimed": "sos-detskie-derevni",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "checkType": "message",
+            "checkType": "status_code",
             "alexaRank": 26031,
             "tags": [
                 "ru"
@@ -15692,6 +15685,7 @@
             ]
         },
         "Fatsecret": {
+            "disabled": true,
             "tags": [
                 "au"
             ],
@@ -16281,6 +16275,7 @@
             ]
         },
         "dumskaya.net": {
+            "disabled": true,
             "absenceStrs": [
                 "><img  class=nobo  src=/banner/ps2_/ alt="
             ],
@@ -16799,6 +16794,10 @@
             "usernameUnclaimed": "noonewouldeverusethis"
         },
         "ViewBug": {
+            "disabled": true,
+            "protection": [
+                "aws_waf_js_challenge"
+            ],
             "absenceStrs": [
                 "missing-photos"
             ],
@@ -17098,23 +17097,6 @@
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
-        "thoughts.com": {
-            "tags": [
-                "blog"
-            ],
-            "checkType": "message",
-            "absenceStrs": [
-                "<title>Page not found"
-            ],
-            "presenseStrs": [
-                "user-activity"
-            ],
-            "urlMain": "http://thoughts.com",
-            "url": "http://thoughts.com/members/{username}",
-            "usernameUnclaimed": "noonewouldeverusethis7",
-            "usernameClaimed": "jules60",
-            "alexaRank": 48335
-        },
         "profi.ru": {
             "absenceStrs": [
                 "page-404__paragraph"
@@ -17232,6 +17214,7 @@
             "alexaRank": 48831
         },
         "Gapyear": {
+            "disabled": true,
             "tags": [
                 "gb",
                 "travel"
@@ -17509,6 +17492,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Golbis": {
+            "disabled": true,
             "tags": [
                 "news",
                 "ru"
@@ -17999,6 +17983,7 @@
             ]
         },
         "Zoomir.ir": {
+            "disabled": true,
             "absenceStrs": [
                 "txtSearch"
             ],
@@ -19766,6 +19751,7 @@
             ]
         },
         "HackTheBox": {
+            "disabled": true,
             "tags": [
                 "education",
                 "hacking"
@@ -39127,14 +39113,11 @@
             ]
         },
         "tikbuddy.com": {
-            "presenseStrs": [
-                "nickName"
-            ],
             "url": "https://tikbuddy.com/en/tiktok/{username}",
             "urlMain": "https://tikbuddy.com",
-            "usernameClaimed": "sergey.ivanov29",
+            "usernameClaimed": "charlidamelio",
             "usernameUnclaimed": "noonewouldeverusethis9",
-            "checkType": "message",
+            "checkType": "status_code",
             "source": "TikTok",
             "tags": [
                 "business",

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-25T11:08:15Z",
-    "sites_count": 3303,
+    "updated_at": "2026-08-25T11:47:46Z",
+    "sites_count": 3302,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "8529d66ebf6d57baf89865f1269d7ac0864b99a58a73f8fad021afc87f609d9c",
+    "data_sha256": "edd5b8d6494a4b231c82515987a94c6114f08f670812d50bd8b63dc96ee00f49",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3303
+## List of supported sites (search methods): total 3302
 
 Rank data fetched from Majestic Million by domains.
 
@@ -283,7 +283,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://f6s.com/) [F6S (https://f6s.com/)](https://f6s.com/)*: top 5K, business, networking*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://boosty.to) [Boosty (https://boosty.to)](https://boosty.to)*: top 10K, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://soup.io) [Soup (https://soup.io)](https://soup.io)*: top 10K, blog, sharing, social*
-1. ![](https://www.google.com/s2/favicons?domain=https://adblockplus.org) [adblockplus.org (https://adblockplus.org)](https://adblockplus.org)*: top 10K, apps, social, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://adblockplus.org) [adblockplus.org (https://adblockplus.org)](https://adblockplus.org)*: top 10K, apps, social, tech*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.hackster.io) [Hackster (https://www.hackster.io)](https://www.hackster.io)*: top 10K, education, hobby, tech*
 1. ![](https://www.google.com/s2/favicons?domain=https://dreamwidth.org/profile) [Dreamwidth (https://dreamwidth.org/profile)](https://dreamwidth.org/profile)*: top 10K, blog, discussion, social*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://xvideos.com/) [Xvideos (https://xvideos.com/)](https://xvideos.com/)*: top 10K, porn*
@@ -459,9 +459,9 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://www.avforums.com) [Avforums (https://www.avforums.com)](https://www.avforums.com)*: top 100K, forum, gb*
 1. ![](https://www.google.com/s2/favicons?domain=http://www.mobypicture.com) [Mobypicture (http://www.mobypicture.com)](http://www.mobypicture.com)*: top 100K, photo*
 1. ![](https://www.google.com/s2/favicons?domain=https://advego.com/) [Advego (https://advego.com/)](https://advego.com/)*: top 100K, freelance, ru*
-1. ![](https://www.google.com/s2/favicons?domain=https://www.nkj.ru/) [Nkj (https://www.nkj.ru/)](https://www.nkj.ru/)*: top 100K, ru, science*
-1. ![](https://www.google.com/s2/favicons?domain=https://www.hackthebox.com/) [HackTheBox (https://www.hackthebox.com/)](https://www.hackthebox.com/)*: top 100K, education, hacking*
-1. ![](https://www.google.com/s2/favicons?domain=https://dlive.tv) [DLive (https://dlive.tv)](https://dlive.tv)*: top 100K, social, streaming*
+1. ![](https://www.google.com/s2/favicons?domain=https://www.nkj.ru/) [Nkj (https://www.nkj.ru/)](https://www.nkj.ru/)*: top 100K, ru, science*, search is disabled
+1. ![](https://www.google.com/s2/favicons?domain=https://www.hackthebox.com/) [HackTheBox (https://www.hackthebox.com/)](https://www.hackthebox.com/)*: top 100K, education, hacking*, search is disabled
+1. ![](https://www.google.com/s2/favicons?domain=https://dlive.tv) [DLive (https://dlive.tv)](https://dlive.tv)*: top 100K, social, streaming*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.trakt.tv/) [Trakt (https://www.trakt.tv/)](https://www.trakt.tv/)*: top 100K, movies, social, streaming, video*
 1. ![](https://www.google.com/s2/favicons?domain=https://tjournal.ru) [TJournal (https://tjournal.ru)](https://tjournal.ru)*: top 100K, news, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.trueachievements.com) [TrueAchievements (https://www.trueachievements.com)](https://www.trueachievements.com)*: top 100K, gaming*
@@ -480,7 +480,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://eksisozluk.com) [Eksisozluk (https://eksisozluk.com)](https://eksisozluk.com)*: top 100K, forum, tr*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.voices.com/) [Voices (https://www.voices.com/)](https://www.voices.com/)*: top 100K, business, freelance, networking*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.nhattao.com) [nhattao.com (https://www.nhattao.com)](https://www.nhattao.com)*: top 100K, forum, shopping, vn*
-1. ![](https://www.google.com/s2/favicons?domain=https://repl.it/) [Repl.it (https://repl.it/)](https://repl.it/)*: top 100K, apps, coding, education*
+1. ![](https://www.google.com/s2/favicons?domain=https://repl.it/) [Repl.it (https://repl.it/)](https://repl.it/)*: top 100K, apps, coding, education*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.codewars.com) [Codewars (https://www.codewars.com)](https://www.codewars.com)*: top 100K, coding, education, forum*
 1. ![](https://www.google.com/s2/favicons?domain=https://davesgarden.com) [Davesgarden (https://davesgarden.com)](https://davesgarden.com)*: top 100K, us*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.tiendanube.com/) [Tiendanube (https://www.tiendanube.com/)](https://www.tiendanube.com/)*: top 100K, ar, shopping*
@@ -495,7 +495,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://www.opennet.ru/) [OpenNet (https://www.opennet.ru/)](https://www.opennet.ru/)*: top 100K, coding, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://linuxfr.org/) [Linuxfr (https://linuxfr.org/)](https://linuxfr.org/)*: top 100K, fr, tech*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.cfd-online.com) [cfd-online (https://www.cfd-online.com)](https://www.cfd-online.com)*: top 100K, education, forum, science*
-1. ![](https://www.google.com/s2/favicons?domain=https://funnyjunk.com/) [Funnyjunk (https://funnyjunk.com/)](https://funnyjunk.com/)*: top 100K, anime, forum, gaming, sharing*
+1. ![](https://www.google.com/s2/favicons?domain=https://funnyjunk.com/) [Funnyjunk (https://funnyjunk.com/)](https://funnyjunk.com/)*: top 100K, anime, forum, gaming, sharing*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://3dtoday.ru/) [3dtoday (https://3dtoday.ru/)](https://3dtoday.ru/)*: top 100K, 3d, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.bibsonomy.org) [Bibsonomy (https://www.bibsonomy.org)](https://www.bibsonomy.org)*: top 100K, education, research, sharing*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.fixya.com) [fixya (https://www.fixya.com)](https://www.fixya.com)*: top 100K, forum, tech*
@@ -513,7 +513,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://freelance.ru) [freelance.ru (https://freelance.ru)](https://freelance.ru)*: top 100K, freelance, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.wishlistr.com) [Wishlistr (https://www.wishlistr.com)](https://www.wishlistr.com)*: top 100K, apps, shopping, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.travelblog.org) [Travelblog (https://www.travelblog.org)](https://www.travelblog.org)*: top 100K, blog, travel*, search is disabled
-1. ![](https://www.google.com/s2/favicons?domain=https://www.fatsecret.com) [Fatsecret (https://www.fatsecret.com)](https://www.fatsecret.com)*: top 100K, au*
+1. ![](https://www.google.com/s2/favicons?domain=https://www.fatsecret.com) [Fatsecret (https://www.fatsecret.com)](https://www.fatsecret.com)*: top 100K, au*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://uid.me/) [uID.me (by username) (https://uid.me/)](https://uid.me/)*: top 100K, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://uid.me/) [uID.me (by uguid) (https://uid.me/)](https://uid.me/)*: top 100K, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://mel.fm) [mel.fm (https://mel.fm)](https://mel.fm)*: top 100K, ru*
@@ -548,7 +548,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://platzi.com/) [Platzi (https://platzi.com/)](https://platzi.com/)*: top 100K, education, es*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.gardenstew.com) [Gardenstew (https://www.gardenstew.com)](https://www.gardenstew.com)*: top 100K, forum, hobby*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=http://www.tagged.com) [Tagged (http://www.tagged.com)](http://www.tagged.com)*: top 100K, dating, networking, social*
-1. ![](https://www.google.com/s2/favicons?domain=https://dumskaya.net) [dumskaya.net (https://dumskaya.net)](https://dumskaya.net)*: top 100K, news, ru*
+1. ![](https://www.google.com/s2/favicons?domain=https://dumskaya.net) [dumskaya.net (https://dumskaya.net)](https://dumskaya.net)*: top 100K, news, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://partnerkin.com) [partnerkin.com (https://partnerkin.com)](https://partnerkin.com)*: top 100K, business, crypto, finance, ru*
 1. ![](https://www.google.com/s2/favicons?domain=http://www.writingforums.org/) [writingforums.org (http://www.writingforums.org/)](http://www.writingforums.org/)*: top 100K, ca, forum*
 1. ![](https://www.google.com/s2/favicons?domain=https://chatujme.cz/) [Chatujme.cz (https://chatujme.cz/)](https://chatujme.cz/)*: top 100K, cz, dating*
@@ -581,7 +581,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://www.mouthshut.com/) [Mouthshut (https://www.mouthshut.com/)](https://www.mouthshut.com/)*: top 100K, in, review*
 1. ![](https://www.google.com/s2/favicons?domain=https://eva.ru/) [Eva (https://eva.ru/)](https://eva.ru/)*: top 100K, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.travellerspoint.com) [TravellersPoint (https://www.travellerspoint.com)](https://www.travellerspoint.com)*: top 100K, blog, travel*, search is disabled
-1. ![](https://www.google.com/s2/favicons?domain=https://www.viewbug.com) [ViewBug (https://www.viewbug.com)](https://www.viewbug.com)*: top 100K, art, photo, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://www.viewbug.com) [ViewBug (https://www.viewbug.com)](https://www.viewbug.com)*: top 100K, art, photo, social*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.exophase.com/) [Exophase (https://www.exophase.com/)](https://www.exophase.com/)*: top 100K, gaming*
 1. ![](https://www.google.com/s2/favicons?domain=https://1337x.to) [1337x (https://1337x.to)](https://1337x.to)*: top 100K, torrent*
 1. ![](https://www.google.com/s2/favicons?domain=https://videosift.com) [Videosift (https://videosift.com)](https://videosift.com)*: top 100K, forum, social, video*, search is disabled
@@ -603,9 +603,8 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://zora.co) [Zora (https://zora.co)](https://zora.co)*: top 100K, crypto, nft, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.donationalerts.com/) [DonationsAlerts (https://www.donationalerts.com/)](https://www.donationalerts.com/)*: top 100K, finance, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.ecoustics.com/) [Ecoustics (https://www.ecoustics.com/)](https://www.ecoustics.com/)*: top 100K, hk, music*, search is disabled
-1. ![](https://www.google.com/s2/favicons?domain=http://thoughts.com) [thoughts.com (http://thoughts.com)](http://thoughts.com)*: top 100K, blog*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.interpals.net/) [InterPals (https://www.interpals.net/)](https://www.interpals.net/)*: top 100K, dating, networking, social*
-1. ![](https://www.google.com/s2/favicons?domain=https://www.gapyear.com) [Gapyear (https://www.gapyear.com)](https://www.gapyear.com)*: top 100K, gb, travel*
+1. ![](https://www.google.com/s2/favicons?domain=https://www.gapyear.com) [Gapyear (https://www.gapyear.com)](https://www.gapyear.com)*: top 100K, gb, travel*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.myinstants.com) [Myinstants (https://www.myinstants.com)](https://www.myinstants.com)*: top 100K, fi, music*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.mybuilder.com) [Mybuilder (https://www.mybuilder.com)](https://www.mybuilder.com)*: top 100K, gb, hk*
 1. ![](https://www.google.com/s2/favicons?domain=https://aniworld.to/) [Ani World (https://aniworld.to/)](https://aniworld.to/)*: top 100K, anime, de*
@@ -621,7 +620,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://author.today) [author.today (https://author.today)](https://author.today)*: top 100K, reading, ru*
 1. ![](https://www.google.com/s2/favicons?domain=http://gcup.ru) [gcup.ru (http://gcup.ru)](http://gcup.ru)*: top 100K, gaming, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://mywed.com/ru) [Mywed (https://mywed.com/ru)](https://mywed.com/ru)*: top 100K, photo, ru*
-1. ![](https://www.google.com/s2/favicons?domain=https://golbis.com) [Golbis (https://golbis.com)](https://golbis.com)*: top 100K, news, ru*
+1. ![](https://www.google.com/s2/favicons?domain=https://golbis.com) [Golbis (https://golbis.com)](https://golbis.com)*: top 100K, news, ru*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.sooplive.co.kr/) [Soop (https://www.sooplive.co.kr/)](https://www.sooplive.co.kr/)*: top 100K, kr*
 1. ![](https://www.google.com/s2/favicons?domain=https://freelancehunt.com) [Freelancehunt (https://freelancehunt.com)](https://freelancehunt.com)*: top 100K, freelance, ru, ua*
 1. ![](https://www.google.com/s2/favicons?domain=https://atcoder.jp/) [Atcoder (https://atcoder.jp/)](https://atcoder.jp/)*: top 100K, coding, jp*
@@ -641,7 +640,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://www.homebrewtalk.com) [homebrewtalk.com (https://www.homebrewtalk.com)](https://www.homebrewtalk.com)*: top 100K, forum, hobby, us*
 1. ![](https://www.google.com/s2/favicons?domain=http://www.tfw2005.com/boards/) [tfw2005.com (http://www.tfw2005.com/boards/)](http://www.tfw2005.com/boards/)*: top 100K, forum, us*
 1. ![](https://www.google.com/s2/favicons?domain=https://lemmy.world) [Lemmy World (https://lemmy.world)](https://lemmy.world)*: top 100K, discussion, forum, lemmy, social*
-1. ![](https://www.google.com/s2/favicons?domain=https://www.zoomit.ir) [Zoomir.ir (https://www.zoomit.ir)](https://www.zoomit.ir)*: top 100K, forum, ir, news*
+1. ![](https://www.google.com/s2/favicons?domain=https://www.zoomit.ir) [Zoomir.ir (https://www.zoomit.ir)](https://www.zoomit.ir)*: top 100K, forum, ir, news*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://cent.co/) [Cent (https://cent.co/)](https://cent.co/)*: top 100K, art, crypto, finance, social, writing*
 1. ![](https://www.google.com/s2/favicons?domain=https://VJudge.net/) [Vjudge (https://VJudge.net/)](https://VJudge.net/)*: top 100K, coding, education*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.phpbbguru.net/community) [phpbbguru.net (https://www.phpbbguru.net/community)](https://www.phpbbguru.net/community)*: top 100K, coding, forum, ru*
@@ -3310,15 +3309,15 @@ Rank data fetched from Majestic Million by domains.
 The list was updated at (2026-08-25)
 ## Statistics
 
-Enabled/total sites: 2624/3303 = 79.44%
+Enabled/total sites: 2611/3302 = 79.07%
 
-Incomplete message checks: 343/2624 = 13.07% (false positive risks)
+Incomplete message checks: 340/2611 = 13.02% (false positive risks)
 
-Status code checks: 718/2624 = 27.36% (false positive risks)
+Status code checks: 718/2611 = 27.5% (false positive risks)
 
-False positive risk (total): 40.43%
+False positive risk (total): 40.52%
 
-Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox, HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
+Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
 Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSearch
 
@@ -3338,8 +3337,8 @@ Top 20 profile URLs:
 - (48)	`SUBDOMAIN`
 - (38)	`/members/?username={username}`
 - (32)	`/author/{username}`
-- (29)	`/members/{username}`
 - (29)	`{urlMain}{urlSubpath}/memberlist.php?username={username} (phpBB)`
+- (28)	`/members/{username}`
 - (26)	`{urlMain}/u/{username} (DiscourseJson)`
 - (18)	`/people/{username}`
 - (18)	`/forum/search.php?keywords=&terms=all&author={username}`
@@ -3374,7 +3373,7 @@ Top 20 tags:
 - (182)	`hobby`
 - (136)	`apps`
 - (130)	`music`
-- (123)	`blog`
+- (122)	`blog`
 - (108)	`news`
 - (104)	`art`
 - (89)	`sharing`

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -147,7 +147,8 @@ def test_detect_error_page_403_ignored():
 
 
 def test_detect_error_page_999_linkedin():
-    # LinkedIn returns 999 on bot suspicion — must NOT be reported as Server error
+    # LinkedIn returns 999 on bot suspicion. Deliberately not an error: making
+    # it one turns LinkedIn UNKNOWN for every blocked IP.
     assert detect_error_page("", 999, {}, ignore_403=False) is None
 
 

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -34,5 +34,12 @@ def test_no_error():
     assert detect_error_page("ok", 200, {}, ignore_403=False) is None
 
 
+def test_http_429_is_rate_limit():
+    err = detect_error_page("x", 429, {}, ignore_403=False)
+
+    assert err.type == "Rate limited"
+
+
 def test_ignore_linkedin_999_status():
+    # 999 stays a pass-through on purpose, see detect_error_page.
     assert detect_error_page("", 999, {}, ignore_403=False) is None


### PR DESCRIPTION
Two commits, two separate reviews.

## Code

`detect_error_page` only classified 403, 999 and >=500, so a 401 or 429 fell through to the `checkType` branch, where any non-2xx code means the username is free. A blocked or rate-limited request was reported as a confirmed absence, which looks exactly like a normal result. 401 now returns "Login required", 429 returns "Rate limited" and is registered as temporary so a retry can clear it, and Vercel's Security Checkpoint joins the generic bot-protection markers.

999 is deliberately left as a pass-through. LinkedIn serves it to blocked clients for existing and missing profiles alike, but classifying it as an error would flip LinkedIn to UNKNOWN for every blocked IP. The reasoning now sits in a comment next to the branch so it does not get "fixed" later.

Separately, a `response_url` check runs with redirects disabled, so any 3xx read as not-found. joyreactor.cc intermittently answers a request with 302 back to the same url plus `Set-Cookie: jr_captcha=1`, which is a handshake, not an absence. One repeat now goes out when `Location` matches the request url and a cookie was set. Without the `Set-Cookie` condition a site that always self-redirects would just cost two requests.

## Sites

Checked 2026-08-16 from a datacenter IP with two HTTP clients, plain and browser-impersonating, against a real and an invented username.

Restored. All three had rotten `message` markers sitting on top of an intact 200/404 split, so they move to `status_code`:

| site | what broke |
|---|---|
| LiveLib | `absenceStrs` `"не найден"` is ordinary page text present on live profiles too, and `presenseStrs` `"на livelib.ru"` matched nothing, so the check answered AVAILABLE for everyone |
| mel.fm | `presenseStrs` `"Введите e-mail"` is a subscription form that left the markup. `usernameClaimed` `ivan-ivanov30` was dead as well, replaced with `sos-detskie-derevni` |
| tikbuddy.com | the site redirects to crevideo.com and `"nickName"` is gone from the HTML. `usernameClaimed` swapped to `charlidamelio` for longevity, the old one still works |

Disabled. Each returns the same response for a real and an invented username:

| site | what was observed |
|---|---|
| adblockplus.org | forum replaced by a help centre, no author search left |
| DLive | byte-identical 7559 B SPA shell, GraphQL host `graphigo.prd.dlive.tv` no longer resolves |
| Fatsecret | login wall |
| Funnyjunk | login wall, 403 to an impersonating client |
| Gapyear | every path including the homepage answers 404 with a WP Engine "Site is not available" placeholder, 1957 B |
| Golbis | 410 Gone |
| HackTheBox | register-check API answers 419, it needs a CSRF token |
| Nkj | profiles are addressed by numeric id, not by name |
| Repl.it | login wall |
| ViewBug | HTTP 202 AWS WAF JS challenge, tagged `aws_waf_js_challenge` |
| Zoomir.ir | 410 Gone |
| dumskaya.net | an invented username renders some other real user's profile, no static marker can separate them |

Deleted. `thoughts.com` redirects to a Dynadot for-sale page, there is no backend left to tell accounts apart. That is the delete criterion rather than a disable, unlike Golbis and Zoomir where the service is alive and only dropped the section.

`db_meta.json` and `sites.md` are regenerated in the same commit, the signature covers the raw bytes of `data.json`.

The longer write-up, false negative classes and why this was fixed in code rather than in the entries, lives in the `maigret-citadel` notes, §7.75 of `site-checks-guide.md` and the 2026-08-16 run in §7.53.
