### PR TITLE
Add a website link to the snap metadata

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ base: core24
 confinement: strict
 adopt-info: maigret
 
+website: https://maigret.readthedocs.io
 source-code: https://github.com/soxoj/maigret
 issues:
   - https://github.com/soxoj/maigret/issues


### PR DESCRIPTION
snapcraft's metadata linter warns that the `website` field is missing, and the store listing page shows a Website link that would otherwise be empty.

Pointing it at the documentation rather than the repository, since `source-code` already carries the GitHub URL. With this the build passes all four linters silently.