### PR TITLE
Drop the zero-width joiner from the snap summary

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: maigret
 title: Maigret
-summary: 🕵️‍♂️ Collect a dossier on a person by username from thousands of sites.
+summary: 🕵️ Collect a dossier on a person by username from thousands of sites.
 description: |
   **Maigret** collects a dossier on a person **by username only**, checking for accounts on a huge number of sites and gathering all the available information from web pages. No API keys required.
 


### PR DESCRIPTION
The Snap Store rejects any upload whose summary contains unicode control characters, and the detective emoji in ours is a ZWJ sequence: U+1F575 U+FE0F U+200D U+2642 U+FE0F. The joiner is category Cf, so the upload fails review with `summary: Control/private unicode characters are not allowed` after processing completes.