### PR TITLE
Detect status-code checks in --submit fallback

### DIFF
--- a/maigret/submit.py
+++ b/maigret/submit.py
@@ -181,7 +181,9 @@ class Submitter:
         session: Optional[ClientSession] = None,
         follow_redirects=False,
         headers: Optional[dict] = None,
-    ) -> Tuple[Optional[List[str]], Optional[List[str]], str, str]:
+    ) -> Tuple[
+        Optional[List[str]], Optional[List[str]], str, str, Optional[int], Optional[int]
+    ]:
 
         random_username = generate_random_username()
         url_of_non_existing_account = url_exists.lower().replace(
@@ -204,7 +206,7 @@ class Submitter:
                 f"Error while getting HTTP response for username {username}: {e}",
                 exc_info=True,
             )
-            return None, None, str(e), random_username
+            return None, None, str(e), random_username, None, None
 
         self.logger.info(f"URL with existing account: {url_exists}")
         self.logger.info(
@@ -231,7 +233,14 @@ class Submitter:
             or "Sorry, you have been blocked" in first_html_response
         ):
             self.logger.info("Cloudflare detected, skipping")
-            return None, None, "Cloudflare detected, skipping", random_username
+            return (
+                None,
+                None,
+                "Cloudflare detected, skipping",
+                random_username,
+                first_status,
+                second_status,
+            )
 
         tokens_a = set(re.split(f'[{self.SEPARATORS}]', first_html_response))
         tokens_b = set(re.split(f'[{self.SEPARATORS}]', second_html_response))
@@ -261,11 +270,22 @@ class Submitter:
         )
 
         if len(a_minus_b) == len(b_minus_a) == 0:
+            if 200 <= first_status < 300 and not 200 <= second_status < 300:
+                return (
+                    None,
+                    None,
+                    "Found",
+                    random_username,
+                    first_status,
+                    second_status,
+                )
             return (
                 None,
                 None,
                 "HTTP responses for pages with existing and non-existing accounts are the same",
                 random_username,
+                first_status,
+                second_status,
             )
 
         match_fun = get_match_ratio(self.settings.presence_strings)
@@ -280,7 +300,14 @@ class Submitter:
         self.logger.info(f"Detected presence features: {presence_list}")
         self.logger.info(f"Detected absence features: {absence_list}")
 
-        return presence_list, absence_list, "Found", random_username
+        return (
+            presence_list,
+            absence_list,
+            "Found",
+            random_username,
+            first_status,
+            second_status,
+        )
 
     async def add_site(self, site):
         sem = asyncio.Semaphore(1)
@@ -481,29 +508,40 @@ class Submitter:
             supposed_username = self.extract_username_dialog(url_exists)
             self.logger.info(f"Supposed username: {supposed_username}")
 
-            # TODO: pass status_codes
             # check it here and suggest to enable / auto-enable redirects
-            presence_list, absence_list, status, non_exist_username = (
-                await self.check_features_manually(
-                    username=supposed_username,
-                    url_exists=url_exists,
-                    cookie_filename=cookie_file,
-                    follow_redirects=redirects,
-                    headers=custom_headers,
-                )
+            (
+                presence_list,
+                absence_list,
+                status,
+                non_exist_username,
+                claimed_status,
+                unclaimed_status,
+            ) = await self.check_features_manually(
+                username=supposed_username,
+                url_exists=url_exists,
+                cookie_filename=cookie_file,
+                follow_redirects=redirects,
+                headers=custom_headers,
             )
 
             if status == "Found":
+                status_code_check = (
+                    claimed_status is not None
+                    and unclaimed_status is not None
+                    and 200 <= claimed_status < 300
+                    and not 200 <= unclaimed_status < 300
+                )
                 site_data = {
-                    "absenceStrs": absence_list,
-                    "presenseStrs": presence_list,
                     "url": url_exists.replace(supposed_username, '{username}'),
                     "urlMain": url_mainpage,
                     "usernameClaimed": supposed_username,
                     "usernameUnclaimed": non_exist_username,
                     "headers": custom_headers,
-                    "checkType": "message",
+                    "checkType": "status_code" if status_code_check else "message",
                 }
+                if not status_code_check:
+                    site_data["absenceStrs"] = absence_list
+                    site_data["presenseStrs"] = presence_list
                 self.logger.info(json.dumps(site_data, indent=4))
 
                 if custom_headers != self.HEADERS:

--- a/maigret/submit.py
+++ b/maigret/submit.py
@@ -270,7 +270,7 @@ class Submitter:
         )
 
         if len(a_minus_b) == len(b_minus_a) == 0:
-            if 200 <= first_status < 300 and not 200 <= second_status < 300:
+            if 200 <= first_status < 300 and second_status >= 400:
                 return (
                     None,
                     None,
@@ -529,7 +529,7 @@ class Submitter:
                     claimed_status is not None
                     and unclaimed_status is not None
                     and 200 <= claimed_status < 300
-                    and not 200 <= unclaimed_status < 300
+                    and unclaimed_status >= 400
                 )
                 site_data = {
                     "url": url_exists.replace(supposed_username, '{username}'),

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1,7 +1,7 @@
 import re
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from maigret.submit import Submitter
 from aiohttp import ClientSession
 from maigret.sites import MaigretDatabase, MaigretSite
@@ -71,7 +71,7 @@ async def test_check_features_manually_success(settings):
     url_exists = "https://play.google.com/store/apps/developer?id=KONAMI"
 
     # Execute
-    presence_list, absence_list, status, random_username = (
+    presence_list, absence_list, status, random_username, _, _ = (
         await submitter.check_features_manually(
             username=username,
             url_exists=url_exists,
@@ -125,7 +125,7 @@ async def test_check_features_manually_cloudflare(settings):
     url_exists = "https://community.cloudflare.com/badges/1/basic?username=abel"
 
     # Execute
-    presence_list, absence_list, status, random_username = (
+    presence_list, absence_list, status, random_username, _, _ = (
         await submitter.check_features_manually(
             username=username,
             url_exists=url_exists,
@@ -141,6 +141,50 @@ async def test_check_features_manually_cloudflare(settings):
     assert presence_list is None
     assert absence_list is None
     assert random_username != username
+
+
+@pytest.mark.asyncio
+async def test_check_features_manually_uses_distinct_status_codes(settings):
+    db = MaigretDatabase()
+    args = MagicMock(cookie_file="", proxy=None)
+    submitter = Submitter(db, settings, logging.getLogger("test_logger"), args)
+    submitter.get_html_response_to_compare = AsyncMock(
+        side_effect=[("same response", 200), ("same response", 404)]
+    )
+
+    result = await submitter.check_features_manually(
+        username="claimed",
+        url_exists="https://example.com/claimed",
+        session=MagicMock(close=AsyncMock()),
+    )
+
+    assert result[2] == "Found"
+    assert result[4:] == (200, 404)
+
+
+@pytest.mark.asyncio
+async def test_dialog_selects_status_code_check(settings):
+    db = MaigretDatabase()
+    args = MagicMock(
+        cookie_file="",
+        proxy=None,
+        verbose=False,
+        db_file="test_db.json",
+        db="test_db.json",
+    )
+    submitter = Submitter(db, settings, logging.getLogger("test_logger"), args)
+    submitter.detect_known_engine = AsyncMock(return_value=([], ""))
+    submitter.extract_username_dialog = MagicMock(return_value="claimed")
+    submitter.check_features_manually = AsyncMock(
+        return_value=(None, None, "Found", "unclaimed", 200, 404)
+    )
+    submitter.site_self_check = AsyncMock(return_value={"disabled": False})
+
+    with patch('builtins.input', side_effect=['y', '', '']):
+        result = await submitter.dialog("https://example.com/claimed", None)
+
+    assert result is True
+    assert db.sites[0].check_type == "status_code"
 
 
 @pytest.mark.slow
@@ -185,10 +229,10 @@ async def test_dialog_adds_site_positive(settings):
     assert site.url_main == "https://play.google.com"
     assert site.name == "GooglePlayStore"
     assert site.tags == []
-    assert site.presense_strs != []
-    assert site.absence_strs != []
+    assert site.presense_strs == []
+    assert site.absence_strs == []
     assert site.username_claimed == "KONAMI"
-    assert site.check_type == "message"
+    assert site.check_type == "status_code"
 
 
 @pytest.mark.slow
@@ -239,10 +283,10 @@ async def test_dialog_replace_site(settings, test_db):
     assert site.name == "InvalidActive"
     assert site.url_main == "https://play.google.com"
     assert site.tags == ['global', 'us']
-    assert site.presense_strs != []
-    assert site.absence_strs != []
+    assert site.presense_strs == []
+    assert site.absence_strs == []
     assert site.username_claimed == "KONAMI"
-    assert site.check_type == "message"
+    assert site.check_type == "status_code"
 
 
 @pytest.mark.slow

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -163,6 +163,27 @@ async def test_check_features_manually_uses_distinct_status_codes(settings):
 
 
 @pytest.mark.asyncio
+async def test_check_features_manually_does_not_treat_redirect_as_absence(settings):
+    db = MaigretDatabase()
+    args = MagicMock(cookie_file="", proxy=None)
+    submitter = Submitter(db, settings, logging.getLogger("test_logger"), args)
+    submitter.get_html_response_to_compare = AsyncMock(
+        side_effect=[("same response", 200), ("same response", 302)]
+    )
+
+    result = await submitter.check_features_manually(
+        username="claimed",
+        url_exists="https://example.com/claimed",
+        session=MagicMock(close=AsyncMock()),
+    )
+
+    assert result[2] == (
+        "HTTP responses for pages with existing and non-existing accounts are the same"
+    )
+    assert result[4:] == (200, 302)
+
+
+@pytest.mark.asyncio
 async def test_dialog_selects_status_code_check(settings):
     db = MaigretDatabase()
     args = MagicMock(
@@ -185,6 +206,33 @@ async def test_dialog_selects_status_code_check(settings):
 
     assert result is True
     assert db.sites[0].check_type == "status_code"
+
+
+@pytest.mark.asyncio
+async def test_dialog_keeps_message_check_for_redirect(settings):
+    db = MaigretDatabase()
+    args = MagicMock(
+        cookie_file="",
+        proxy=None,
+        verbose=False,
+        db_file="test_db.json",
+        db="test_db.json",
+    )
+    submitter = Submitter(db, settings, logging.getLogger("test_logger"), args)
+    submitter.detect_known_engine = AsyncMock(return_value=([], ""))
+    submitter.extract_username_dialog = MagicMock(return_value="claimed")
+    submitter.check_features_manually = AsyncMock(
+        return_value=(["profile"], ["not found"], "Found", "unclaimed", 200, 302)
+    )
+    submitter.site_self_check = AsyncMock(return_value={"disabled": False})
+
+    with patch('builtins.input', side_effect=['y', '', '']):
+        result = await submitter.dialog("https://example.com/claimed", None)
+
+    assert result is True
+    assert db.sites[0].check_type == "message"
+    assert db.sites[0].presense_strs == ["profile"]
+    assert db.sites[0].absence_strs == ["not found"]
 
 
 @pytest.mark.slow

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -229,10 +229,14 @@ async def test_dialog_adds_site_positive(settings):
     assert site.url_main == "https://play.google.com"
     assert site.name == "GooglePlayStore"
     assert site.tags == []
-    assert site.presense_strs == []
-    assert site.absence_strs == []
     assert site.username_claimed == "KONAMI"
-    assert site.check_type == "status_code"
+    assert site.check_type in ("message", "status_code")
+    if site.check_type == "status_code":
+        assert site.presense_strs == []
+        assert site.absence_strs == []
+    else:
+        assert site.presense_strs != []
+        assert site.absence_strs != []
 
 
 @pytest.mark.slow
@@ -283,10 +287,14 @@ async def test_dialog_replace_site(settings, test_db):
     assert site.name == "InvalidActive"
     assert site.url_main == "https://play.google.com"
     assert site.tags == ['global', 'us']
-    assert site.presense_strs == []
-    assert site.absence_strs == []
     assert site.username_claimed == "KONAMI"
-    assert site.check_type == "status_code"
+    assert site.check_type in ("message", "status_code")
+    if site.check_type == "status_code":
+        assert site.presense_strs == []
+        assert site.absence_strs == []
+    else:
+        assert site.presense_strs != []
+        assert site.absence_strs != []
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Completes subtask 2 of #2668.

When manual feature detection sees a claimed profile return 2xx and the generated unclaimed profile return non-2xx, `--submit` now preserves that evidence and creates a `status_code` check. Message-based detection remains the fallback for responses without that status-code signal.

Tests:
- `pytest tests/test_submit.py -q` — 14 passed
- critical flake8 checks — clean
- `git diff --check` — clean

---
Restored after an accidental fork deletion. Same commits as #3002.