### PR TITLE
Respect --dns-resolver in --self-check

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -1462,6 +1462,7 @@ async def site_self_check(
     auto_disable=False,
     diagnose=False,
     cloudflare_bypass: Optional[Dict[str, Any]] = None,
+    dns_resolver: str = 'async',
 ):
     """
     Self-check a site configuration.
@@ -1503,6 +1504,7 @@ async def site_self_check(
                     i2p_proxy=i2p_proxy,
                     cookies=cookies,
                     cloudflare_bypass=cloudflare_bypass,
+                    dns_resolver=dns_resolver,
                 )
 
                 # don't disable entries with other ids types
@@ -1631,6 +1633,7 @@ async def self_check(
     diagnose=False,
     no_progressbar=False,
     cloudflare_bypass: Optional[Dict[str, Any]] = None,
+    dns_resolver: str = 'async',
 ) -> dict:
     """
     Run self-check on sites.
@@ -1661,6 +1664,7 @@ async def self_check(
             site, logger, sem, db, silent, proxy, tor_proxy, i2p_proxy,
             skip_errors=True, auto_disable=auto_disable, diagnose=diagnose,
             cloudflare_bypass=cloudflare_bypass,
+            dns_resolver=dns_resolver,
         )
         future = asyncio.ensure_future(check_coro)
         tasks.append((site.name, future))

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -767,6 +767,7 @@ async def main():
             diagnose=args.diagnose,
             no_progressbar=args.no_progressbar,
             cloudflare_bypass=cf_bypass_config,
+            dns_resolver=args.dns_resolver,
         )
 
         is_need_update = check_result.get('needs_update', False)

--- a/maigret/submit.py
+++ b/maigret/submit.py
@@ -76,6 +76,7 @@ class Submitter:
             # Don't skip errors in submit mode - we need check both false positives/true negatives
             skip_errors=False,
             cloudflare_bypass=getattr(self, 'cloudflare_bypass', None),
+            dns_resolver=getattr(self.args, 'dns_resolver', 'async'),
         )
         return changes
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -507,3 +507,27 @@ async def test_submitter_normalizes_proxy_scheme(test_db, given, expected):
             pass
 
     assert captured == [expected]
+
+
+@pytest.mark.asyncio
+async def test_submitter_site_self_check_dns_resolver_fallback(test_db):
+    stub_args = type('Args', (object,), {'proxy': None, 'cookie_file': None, 'verbose': False})()
+    submitter = Submitter(test_db, MagicMock(), logging.getLogger(), stub_args)
+
+    with patch('maigret.submit.site_self_check', new_callable=AsyncMock) as mock_ssc:
+        await submitter.site_self_check(MagicMock(), MagicMock())
+        mock_ssc.assert_awaited_once()
+        _, kwargs = mock_ssc.call_args
+        assert kwargs.get('dns_resolver') == 'async'
+
+
+@pytest.mark.asyncio
+async def test_submitter_site_self_check_dns_resolver_forwarded(test_db):
+    stub_args = type('Args', (object,), {'proxy': None, 'cookie_file': None, 'verbose': False, 'dns_resolver': 'threaded'})()
+    submitter = Submitter(test_db, MagicMock(), logging.getLogger(), stub_args)
+
+    with patch('maigret.submit.site_self_check', new_callable=AsyncMock) as mock_ssc:
+        await submitter.site_self_check(MagicMock(), MagicMock())
+        mock_ssc.assert_awaited_once()
+        _, kwargs = mock_ssc.call_args
+        assert kwargs.get('dns_resolver') == 'threaded'


### PR DESCRIPTION
--self-check always used aiohttp's AsyncResolver (via aiodns/c-ares) and ignored the --dns-resolver threaded flag.

On machines where c-ares cannot read the DNS configuration (VPN/corporate networks, see #2688), every self-check failed with 'Could not contact DNS servers' even though normal searches worked with the threaded resolver.

This threads dns_resolver through self_check() and site_self_check() so the flag takes effect in self-check mode too.

Verification:
- Reproduced: --self-check without flag dies with DNS errors on my machine; --top 10 --dns-resolver threaded is clean.
- After fix: --self-check --use-disabled-sites --diagnose --dns-resolver threaded reaches the real network (previously it died on DNS before checking any site).