### PR TITLE
XenForo: count the Hebrew and Persian login notice as presence

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -44655,6 +44655,8 @@
                     "Для того, чтобы это сделать, нужно сначала войти на форум.",
                     "You must be logged-in to do that.",
                     "You must be logged in to do that.",
+                    "הינך נדרש להתחבר כדי לבצע פעולה זו.",
+                    "برای انجام این کار باید به انجمن ورود کنید",
                     "memberHeader-content",
                     "profilePage"
                 ],

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-27T08:37:44Z",
+    "updated_at": "2026-08-28T05:28:46Z",
     "sites_count": 3305,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "48b116438c14af6a7fb10e6dbd481a4a04a0ab933d973bf09c6898da2245beff",
+    "data_sha256": "3d1c01b5ba3a39671d319584b1f078683bdbe92a764cca9256b44dc4f4b20fc8",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }


### PR DESCRIPTION
A XenForo board can let a member hide their profile from guests. The
profile then answers 403 with a login page, and the engine already handles that
- `You must be logged-in to do that.` and its Russian, French and Turkish
translations are presence strings, not absence ones.

The list has no Hebrew or Persian. On `tapuz.co.il` two of the seven members its
own directory offers are login-walled, and on `forumroman.com` one of four; all
of them are reported as available today.

Both strings were checked against the absence page of four XenForo boards -
prog.co.il, tapuz.co.il, iranjoman.com, forumroman.com - and appear on none of
them.