### PR TITLE
fix: keep every cookie of a domain when importing a cookies.txt

### DIFF
--- a/maigret/activation.py
+++ b/maigret/activation.py
@@ -191,13 +191,18 @@ def import_aiohttp_cookies(cookiestxt_filename):
     cookies = CookieJar()
 
     cookies_list = []
-    for domain in cookies_obj._cookies.values():  # type: ignore[attr-defined]
-        for key, cookie in next(iter(domain.values())).items():
-            c: Morsel = Morsel()
-            c.set(key, cookie.value, cookie.value)
-            c["domain"] = cookie.domain
-            c["path"] = cookie.path
-            cookies_list.append((key, c))
+    # Iterate the jar itself rather than its internal {domain: {path: {name}}}
+    # mapping: picking a single path bucket per domain silently dropped every
+    # cookie stored under the domain's other paths.
+    for cookie in cookies_obj:
+        c: Morsel = Morsel()
+        # A valueless cookie ("name" with no "=value") parses as value None,
+        # which used to reach the wire as the literal string "None".
+        value = cookie.value or ""
+        c.set(cookie.name, value, value)
+        c["domain"] = cookie.domain
+        c["path"] = cookie.path
+        cookies_list.append((cookie.name, c))
 
     cookies.update_cookies(cookies_list)
 

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -69,6 +69,74 @@ async def test_import_aiohttp_cookies(cookie_test_server):
     assert result == {'cookies': {'a': 'b'}}
 
 
+# A real browser export usually stores several cookies per domain under
+# different paths. COOKIES_TXT above happens to keep everything on "/", which
+# is why the path handling below went untested for so long.
+MULTIPATH_COOKIES_TXT = """# Netscape HTTP Cookie File
+.example.com	TRUE	/	FALSE	2147483647	sessionid	SESSION
+.example.com	TRUE	/account	FALSE	2147483647	csrftoken	CSRF
+.example.com	TRUE	/api	FALSE	2147483647	authtoken	AUTH
+"""
+
+# A cookie stored with no value at all: the name column is empty and the value
+# column carries the name, which http.cookiejar parses as value None.
+VALUELESS_COOKIE_TXT = """# Netscape HTTP Cookie File
+.example.com	TRUE	/	FALSE	2147483647		consent
+"""
+
+
+def _write(tmp_path, content):
+    cookies_file = tmp_path / "cookies.txt"
+    cookies_file.write_text(content, encoding="utf-8")
+    return str(cookies_file)
+
+
+@pytest.mark.asyncio
+async def test_import_aiohttp_cookies_keeps_every_path_of_a_domain(tmp_path):
+    """All of a domain's cookies must survive the import, not just one path.
+
+    MozillaCookieJar stores cookies as {domain: {path: {name: cookie}}}. Taking
+    a single path bucket per domain silently discarded every cookie saved under
+    the domain's other paths, so an authenticated scan went out missing its CSRF
+    and auth tokens and simply looked logged out.
+    """
+    cookie_jar = import_aiohttp_cookies(_write(tmp_path, MULTIPATH_COOKIES_TXT))
+
+    imported = {morsel.key for morsel in cookie_jar}
+    assert imported == {"sessionid", "csrftoken", "authtoken"}
+
+
+@pytest.mark.asyncio
+async def test_import_aiohttp_cookies_offers_each_cookie_on_its_own_path(tmp_path):
+    """Path scoping still has to hold once every cookie is imported."""
+    cookie_jar = import_aiohttp_cookies(_write(tmp_path, MULTIPATH_COOKIES_TXT))
+
+    def sent_to(url):
+        return {
+            key: morsel.value
+            for key, morsel in cookie_jar.filter_cookies(yarl.URL(url)).items()
+        }
+
+    assert sent_to("http://www.example.com/") == {"sessionid": "SESSION"}
+    assert sent_to("http://www.example.com/account/profile") == {
+        "sessionid": "SESSION",
+        "csrftoken": "CSRF",
+    }
+    assert sent_to("http://www.example.com/api/v1/users") == {
+        "sessionid": "SESSION",
+        "authtoken": "AUTH",
+    }
+
+
+@pytest.mark.asyncio
+async def test_import_aiohttp_cookies_does_not_invent_a_none_value(tmp_path):
+    """A valueless cookie must not reach the wire as the literal text 'None'."""
+    cookie_jar = import_aiohttp_cookies(_write(tmp_path, VALUELESS_COOKIE_TXT))
+
+    sent = cookie_jar.filter_cookies(yarl.URL("http://www.example.com/"))
+    assert sent["consent"].value == ""
+
+
 # ---- OnlyFans signing tests (pure-compute, no network) ----
 
 


### PR DESCRIPTION
`import_aiohttp_cookies` only imports one path's worth of cookies per domain. The rest are dropped silently.

It walks `MozillaCookieJar`'s internal `{domain: {path: {name: cookie}}}` mapping and calls `next(iter(...))` on the path level, which picks a single path bucket and discards the others:

```python
for domain in cookies_obj._cookies.values():
    for key, cookie in next(iter(domain.values())).items():
```

Browser exports routinely spread a domain's cookies over several paths, and the ones that land outside `/` tend to be the ones that matter. With a jar holding `sessionid` on `/`, `csrftoken` on `/account` and `authtoken` on `/api`, only `sessionid` is imported.

I checked what actually goes over the wire, with the jar built by the current code and a request to `http://www.example.com/account/profile`:

```
Cookie header the site received:
    sessionid=SESSION_VALUE
```

`csrftoken` applies to that exact path and never arrives. After the change:

```
Cookie header the site received:
    csrftoken=CSRF_VALUE; sessionid=SESSION_VALUE
```

The failure is quiet, which is the annoying part. Nothing logs a warning; the site just answers as if you were logged out, so `--cookie-file` looks like it worked and the account is reported available.

The fix is to iterate the jar itself. That is the documented interface, it yields every cookie, and it also drops the private-attribute access and its `type: ignore`. Path scoping does not change: aiohttp still decides which of the imported cookies apply to a URL, and the new tests pin that, including a same-name-different-path pair resolving per path.

One small thing came along with it. Reading `cookie.value` off a properly typed `Cookie` makes it visible that the value is optional, and a valueless cookie was being sent as the literal string `None`. It now imports as an empty value. Happy to split that out if you would rather keep this to one thing.

The existing `test_import_aiohttp_cookies` keeps every cookie on `/`, which is why this stayed hidden. Added three regression tests: multi-path import, per-path delivery, and the valueless case. All three fail on current `main` and pass with the change.

Full suite on Linux is not something I can run here, but locally the failure set is byte-identical to clean `main` (compared against a worktree at `af3de56`), with 3 more passing tests and no new failures.
