### PR TITLE
Fixes of false positives

### DIFF
--- a/maigret/errors.py
+++ b/maigret/errors.py
@@ -72,6 +72,11 @@ COMMON_ERRORS = {
         'Just a moment: bot redirect challenge', 'Cloudflare'
     ),
     'SlardarWAF': CheckError('Bot protection', 'WAF challenge'),
+    # Anubis proof-of-work interstitial: serves HTTP 200 on every path, so
+    # without this marker every username reads as claimed (joyreactor.cc).
+    '/.within.website/x/': CheckError('Bot protection', 'Anubis challenge'),
+    # Same shape, different vendor: HTTP 202 + a JS proof-of-work (fixya.com).
+    'window.POW_CHALLENGE_DATA': CheckError('Bot protection', 'PoW challenge'),
     '<title>Vercel Security Checkpoint</title>': CheckError(
         'Bot protection', 'Vercel'
     ),

--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -5,7 +5,10 @@
             "urlMain": "https://www.codedex.io",
             "usernameClaimed": "loc210z",
             "usernameUnclaimed": "noonewouldeverusethis7",
-            "checkType": "status_code",
+            "checkType": "message",
+            "presenseStrs": [
+                ") | Codédex\""
+            ],
             "tags": [
                 "coding"
             ]
@@ -12644,6 +12647,7 @@
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Championat": {
+            "disabled": true,
             "tags": [
                 "ru",
                 "sport"
@@ -15318,14 +15322,15 @@
             "usernameClaimed": "anonismus",
             "usernameUnclaimed": "noneownsthisusername"
         },
-        "forum.heroesworld.ru": {
+        "heroesworld.ru": {
             "tags": [
                 "forum",
                 "ru"
             ],
-            "engine": "vBulletin",
-            "urlMain": "https://forum.heroesworld.ru",
-            "usernameClaimed": "alex",
+            "checkType": "status_code",
+            "urlMain": "https://heroesworld.ru",
+            "url": "https://heroesworld.ru/user/{username}/",
+            "usernameClaimed": "hwkeeper",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },
         "Terraria Forums": {
@@ -42619,6 +42624,9 @@
                 "gaming"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/br/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=br",
             "usernameClaimed": "Blaze51",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42629,6 +42637,9 @@
                 "us"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/na/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=na",
             "usernameClaimed": "Blaze51",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42638,6 +42649,9 @@
                 "gaming"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/me/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=me",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42648,6 +42662,9 @@
                 "se"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/eune/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=eune",
             "usernameClaimed": "Blaze51",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42657,6 +42674,9 @@
                 "gaming"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/euw/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=euw",
             "usernameClaimed": "Blaze51",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42667,6 +42687,9 @@
                 "gaming"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/oce/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=oce",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42677,6 +42700,9 @@
                 "kr"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/kr/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=kr",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42687,6 +42713,9 @@
                 "jp"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/jp/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=jp",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42697,6 +42726,9 @@
                 "gaming"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/las/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=las",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42707,6 +42739,9 @@
                 "mx"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/lan/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=lan",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42717,6 +42752,9 @@
                 "ru"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/ru/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=ru",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42727,6 +42765,9 @@
                 "tr"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/tr/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=tr",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42737,6 +42778,9 @@
                 "sg"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/sg/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=sg",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42747,6 +42791,9 @@
                 "ph"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/ph/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=ph",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42757,6 +42804,9 @@
                 "tw"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/tw/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=tw",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42767,6 +42817,9 @@
                 "vn"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/vn/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=vn",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -42777,6 +42830,9 @@
                 "th"
             ],
             "engine": "op.gg",
+            "presenseStrs": [
+                "href=\"/lol/summoners/th/"
+            ],
             "url": "https://op.gg/lol/summoners/search?q={username}&region=th",
             "usernameClaimed": "adam",
             "usernameUnclaimed": "noonewouldeverusethis7"
@@ -45189,9 +45245,6 @@
             "name": "op.gg",
             "site": {
                 "checkType": "message",
-                "presenseStrs": [
-                    "href=\"/lol/summoners/"
-                ],
                 "absenceStrs": [
                     ">“No search results for"
                 ],

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-28T08:51:43Z",
+    "updated_at": "2026-08-28T11:22:09Z",
     "sites_count": 3330,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "387ccc5779163dc75d89d00cf26e727be418b9511f344ad4c58ade7ed1c3c3ba",
+    "data_sha256": "8a799b30710b95aa3f2abc84ef4c44ebb47547274f396e241f8f89648ef2654f",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -373,7 +373,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://write.as) [write.as (https://write.as)](https://write.as)*: top 10K, blog, social, writing*
 1. ![](https://www.google.com/s2/favicons?domain=https://www.fark.com/) [Fark (https://www.fark.com/)](https://www.fark.com/)*: top 10K, discussion, forum, news, us*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.warriorforum.com/) [Warrior Forum (https://www.warriorforum.com/)](https://www.warriorforum.com/)*: top 10K, business, forum*
-1. ![](https://www.google.com/s2/favicons?domain=https://www.championat.com/) [Championat (https://www.championat.com/)](https://www.championat.com/)*: top 10K, ru, sport*
+1. ![](https://www.google.com/s2/favicons?domain=https://www.championat.com/) [Championat (https://www.championat.com/)](https://www.championat.com/)*: top 10K, ru, sport*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://www.are.na) [are.na (https://www.are.na)](https://www.are.na)*: top 10K, art, education, sharing, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://mstdn.social/) [Mstdn.social (https://mstdn.social/)](https://mstdn.social/)*: top 10K, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://booth.pm/) [Booth (https://booth.pm/)](https://booth.pm/)*: top 10K, jp, shopping*
@@ -1795,7 +1795,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://archive.storycorps.org) [Storycorps (https://archive.storycorps.org)](https://archive.storycorps.org)*: top 100M, archive, education, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://forums.serebii.net) [forums.serebii.net (https://forums.serebii.net)](https://forums.serebii.net)*: top 100M, discussion, forum, gaming*, search is disabled
 1. ![](https://www.google.com/s2/favicons?domain=https://forum.zorin.com) [forum.zorin.com (https://forum.zorin.com)](https://forum.zorin.com)*: top 100M, education, forum, tech*
-1. ![](https://www.google.com/s2/favicons?domain=https://forum.heroesworld.ru) [forum.heroesworld.ru (https://forum.heroesworld.ru)](https://forum.heroesworld.ru)*: top 100M, forum, ru*
+1. ![](https://www.google.com/s2/favicons?domain=https://heroesworld.ru) [heroesworld.ru (https://heroesworld.ru)](https://heroesworld.ru)*: top 100M, forum, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://forums.terraria.org/index.php) [Terraria Forums (https://forums.terraria.org/index.php)](https://forums.terraria.org/index.php)*: top 100M, forum, gaming*
 1. ![](https://www.google.com/s2/favicons?domain=https://community.smartthings.com) [community.smartthings.com (https://community.smartthings.com)](https://community.smartthings.com)*: top 100M, forum, tech*
 1. ![](https://www.google.com/s2/favicons?domain=https://forums.golfmonthly.com) [forums.golfmonthly.com (https://forums.golfmonthly.com)](https://forums.golfmonthly.com)*: top 100M, forum, gb, hobby, sport*
@@ -3337,13 +3337,13 @@ Rank data fetched from Majestic Million by domains.
 The list was updated at (2026-08-28)
 ## Statistics
 
-Enabled/total sites: 2638/3330 = 79.22%
+Enabled/total sites: 2637/3330 = 79.19%
 
-Incomplete message checks: 345/2638 = 13.08% (false positive risks)
+Incomplete message checks: 345/2637 = 13.08% (false positive risks)
 
-Status code checks: 727/2638 = 27.56% (false positive risks)
+Status code checks: 726/2637 = 27.53% (false positive risks)
 
-False positive risk (total): 40.64%
+False positive risk (total): 40.61%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
@@ -3353,10 +3353,10 @@ Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
 - (337)	`/{username}`
 - (254)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
-- (195)	`/user/{username}`
+- (196)	`/user/{username}`
 - (146)	`/profile/{username}`
-- (127)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
 - (126)	`/u/{username}`
+- (126)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
 - (126)	`{urlMain}{urlSubpath}/search.php?author={username} (phpBB/Search)`
 - (99)	`/users/{username}`
 - (79)	`{urlMain}/u/{username}/summary (Discourse)`
@@ -3375,7 +3375,7 @@ Top 20 profile URLs:
 Sites by engine:
 - `uCoz`: 633/709 (89.3%)
 - `XenForo`: 204/254 (80.3%)
-- `vBulletin`: 34/127 (26.8%)
+- `vBulletin`: 33/126 (26.2%)
 - `phpBB/Search`: 117/126 (92.9%)
 - `Discourse`: 71/79 (89.9%)
 - `phpBB`: 23/29 (79.3%)

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -43,3 +43,19 @@ def test_http_429_is_rate_limit():
 def test_ignore_linkedin_999_status():
     # 999 stays a pass-through on purpose, see detect_error_page.
     assert detect_error_page("", 999, {}, ignore_403=False) is None
+
+def test_pow_challenge_pages_are_bot_protection():
+    # Both serve a 2xx on every path, so without a marker every username
+    # would read as claimed.
+    anubis = detect_error_page(
+        '<link rel="stylesheet" href="/.within.website/x/xess/xess.min.css">',
+        200,
+        {},
+        ignore_403=False,
+    )
+    pow_js = detect_error_page(
+        "window.POW_CHALLENGE_DATA={challenge_nonce:'2bafb0f5'};", 202, {}, ignore_403=False
+    )
+
+    assert anubis.type == "Bot protection"
+    assert pow_js.type == "Bot protection"


### PR DESCRIPTION
All six sites answered the same way for any username, so the check reported a claim for everyone.

Anubis and the `window.POW_CHALLENGE_DATA` interstitial are vendor products used far beyond these two sites, so their markers go into `COMMON_ERRORS` instead of into the two entries.

| site | what it does now | fix |
| --- | --- | --- |
| joyreactor.cc | Anubis proof-of-work page, HTTP 200 on every path | global marker `/.within.website/x/` |
| fixya | HTTP 202 with a JS proof-of-work on every path | global marker `window.POW_CHALLENGE_DATA` |
| championat | every `/user/*` returns the same 686-byte SberID auth stub | disabled, profiles are behind login |
| forum.heroesworld.ru | redirects to the forum index, absence marker never present | moved to `heroesworld.ru/user/{username}/`, 404 on miss |
| Codédex | `status_code` flapped to 200 on a missing profile, about once in fifteen requests | `message` check on the og:title of a real profile |
| OP.GG, 17 region entries | search falls back to other regions, the engine marker matched any of them | marker moved into each site with its region baked in |

Measured from one vantage point (Hetzner DE) with the client settings maigret uses. Self-check passes on both legs of every changed entry, suite is green, one test added for the new markers.
