### PR TITLE
[LAPOINTE] Add 17 sites

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -45024,6 +45024,231 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "url": "https://openforum.hetclub.org/profile/{username}",
             "checkType": "status_code"
+        },
+        "forum.lvivport.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "news",
+                "ua"
+            ],
+            "urlMain": "https://forum.lvivport.com",
+            "usernameClaimed": "Lanktocha",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "forum.onlinesoccermanager.nl": {
+            "tags": [
+                "discussion",
+                "forum",
+                "gaming",
+                "nl",
+                "sport"
+            ],
+            "urlMain": "https://forum.onlinesoccermanager.nl",
+            "usernameClaimed": "star-wars-67",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://forum.onlinesoccermanager.nl/user/{username}",
+            "checkType": "status_code"
+        },
+        "fpvua.org": {
+            "tags": [
+                "discussion",
+                "forum",
+                "hobby",
+                "ua"
+            ],
+            "urlMain": "https://fpvua.org",
+            "usernameClaimed": "Magshifter",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "immobilio.it": {
+            "tags": [
+                "business",
+                "discussion",
+                "forum",
+                "it"
+            ],
+            "urlMain": "https://immobilio.it",
+            "usernameClaimed": "PyerSilvio",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "fanforum.uscho.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "sport"
+            ],
+            "urlMain": "https://fanforum.uscho.com",
+            "usernameClaimed": "Kepler",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "foforum.fr": {
+            "tags": [
+                "discussion",
+                "forum",
+                "fr"
+            ],
+            "urlMain": "https://foforum.fr",
+            "usernameClaimed": "brunette",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://foforum.fr/members/?username={username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "memberHeader-content",
+                "Vous devez être connecté pour faire cela."
+            ],
+            "ignore403": true
+        },
+        "forum.gamesource.it": {
+            "tags": [
+                "discussion",
+                "forum",
+                "gaming",
+                "it"
+            ],
+            "urlMain": "https://forum.gamesource.it",
+            "usernameClaimed": "pissio",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "forum.lottoced.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "gambling"
+            ],
+            "urlMain": "https://forum.lottoced.com",
+            "usernameClaimed": "Zac",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://forum.lottoced.com/members/?username={username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "memberHeader-content",
+                "Per procedere, devi prima accedere al forum."
+            ],
+            "ignore403": true
+        },
+        "forum.media2.pl": {
+            "tags": [
+                "discussion",
+                "forum",
+                "news",
+                "pl"
+            ],
+            "urlMain": "https://forum.media2.pl",
+            "usernameClaimed": "bartheq",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://forum.media2.pl/memberlist.php?mode=viewprofile&un={username}",
+            "checkType": "status_code"
+        },
+        "forum.welcome-suisse.ch": {
+            "tags": [
+                "ch",
+                "discussion",
+                "forum",
+                "travel"
+            ],
+            "urlMain": "https://forum.welcome-suisse.ch",
+            "usernameClaimed": "Alain74",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Discourse"
+        },
+        "forums.talkseafishing.co.uk": {
+            "tags": [
+                "discussion",
+                "forum",
+                "gb",
+                "hobby"
+            ],
+            "urlMain": "https://forums.talkseafishing.co.uk",
+            "usernameClaimed": "Trampster",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "funny.grizly.club": {
+            "tags": [
+                "photo",
+                "ru"
+            ],
+            "urlMain": "https://funny.grizly.club",
+            "usernameClaimed": "deva",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://funny.grizly.club/user/{username}",
+            "checkType": "status_code"
+        },
+        "weblogistics.vn": {
+            "tags": [
+                "business",
+                "discussion",
+                "forum",
+                "vn"
+            ],
+            "urlMain": "https://weblogistics.vn",
+            "usernameClaimed": "nanang",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "bbs.aw-ol.com": {
+            "tags": [
+                "cn",
+                "coding",
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://bbs.aw-ol.com",
+            "usernameClaimed": "yuzukitsuru",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://bbs.aw-ol.com/user/{username}",
+            "checkType": "status_code"
+        },
+        "forum.iinkor.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://forum.iinkor.com",
+            "usernameClaimed": "jassim1",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "poker-academie.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "fr",
+                "gambling"
+            ],
+            "urlMain": "https://poker-academie.com",
+            "usernameClaimed": "Grimaldi44",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.poker-academie.com/forum/u/{username}/summary",
+            "checkType": "message",
+            "presenseStrs": [
+                "class=\"user-crawler\"",
+                "class='username'"
+            ]
+        },
+        "turkiyeatlas.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "tr",
+                "travel"
+            ],
+            "urlMain": "https://turkiyeatlas.com",
+            "usernameClaimed": "عناقيد",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://turkiyeatlas.com/forum/members/?username={username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "class=\"memberHeader-blurb\"",
+                "class=\"has-no-js template-member_view\""
+            ]
         }
     },
     "engines": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-28T11:22:09Z",
-    "sites_count": 3330,
+    "updated_at": "2026-08-28T17:23:07Z",
+    "sites_count": 3347,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "8a799b30710b95aa3f2abc84ef4c44ebb47547274f396e241f8f89648ef2654f",
+    "data_sha256": "bc34cce23f24547d08dee3c5a25d683c5b899e9d95efbc9708c447fef00d1cf1",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3330
+## List of supported sites (search methods): total 3347
 
 Rank data fetched from Majestic Million by domains.
 
@@ -3333,17 +3333,34 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://mmo-dev.info) [mmo-dev.info (https://mmo-dev.info)](https://mmo-dev.info)*: top 100M, discussion, forum, gaming, ru*
 1. ![](https://www.google.com/s2/favicons?domain=https://newf319.com) [newf319.com (https://newf319.com)](https://newf319.com)*: top 100M, discussion, finance, forum, vn*
 1. ![](https://www.google.com/s2/favicons?domain=https://openforum.hetclub.org) [openforum.hetclub.org (https://openforum.hetclub.org)](https://openforum.hetclub.org)*: top 100M, auto, discussion, forum, us*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.lvivport.com) [forum.lvivport.com (https://forum.lvivport.com)](https://forum.lvivport.com)*: top 100M, discussion, forum, news, ua*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.onlinesoccermanager.nl) [forum.onlinesoccermanager.nl (https://forum.onlinesoccermanager.nl)](https://forum.onlinesoccermanager.nl)*: top 100M, discussion, forum, gaming, nl, sport*
+1. ![](https://www.google.com/s2/favicons?domain=https://fpvua.org) [fpvua.org (https://fpvua.org)](https://fpvua.org)*: top 100M, discussion, forum, hobby, ua*
+1. ![](https://www.google.com/s2/favicons?domain=https://immobilio.it) [immobilio.it (https://immobilio.it)](https://immobilio.it)*: top 100M, business, discussion, forum, it*
+1. ![](https://www.google.com/s2/favicons?domain=https://fanforum.uscho.com) [fanforum.uscho.com (https://fanforum.uscho.com)](https://fanforum.uscho.com)*: top 100M, discussion, forum, sport*
+1. ![](https://www.google.com/s2/favicons?domain=https://foforum.fr) [foforum.fr (https://foforum.fr)](https://foforum.fr)*: top 100M, discussion, forum, fr*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.gamesource.it) [forum.gamesource.it (https://forum.gamesource.it)](https://forum.gamesource.it)*: top 100M, discussion, forum, gaming, it*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.lottoced.com) [forum.lottoced.com (https://forum.lottoced.com)](https://forum.lottoced.com)*: top 100M, discussion, forum, gambling*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.media2.pl) [forum.media2.pl (https://forum.media2.pl)](https://forum.media2.pl)*: top 100M, discussion, forum, news, pl*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.welcome-suisse.ch) [forum.welcome-suisse.ch (https://forum.welcome-suisse.ch)](https://forum.welcome-suisse.ch)*: top 100M, ch, discussion, forum, travel*
+1. ![](https://www.google.com/s2/favicons?domain=https://forums.talkseafishing.co.uk) [forums.talkseafishing.co.uk (https://forums.talkseafishing.co.uk)](https://forums.talkseafishing.co.uk)*: top 100M, discussion, forum, gb, hobby*
+1. ![](https://www.google.com/s2/favicons?domain=https://funny.grizly.club) [funny.grizly.club (https://funny.grizly.club)](https://funny.grizly.club)*: top 100M, photo, ru*
+1. ![](https://www.google.com/s2/favicons?domain=https://weblogistics.vn) [weblogistics.vn (https://weblogistics.vn)](https://weblogistics.vn)*: top 100M, business, discussion, forum, vn*
+1. ![](https://www.google.com/s2/favicons?domain=https://bbs.aw-ol.com) [bbs.aw-ol.com (https://bbs.aw-ol.com)](https://bbs.aw-ol.com)*: top 100M, cn, coding, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.iinkor.com) [forum.iinkor.com (https://forum.iinkor.com)](https://forum.iinkor.com)*: top 100M, discussion, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://poker-academie.com) [poker-academie.com (https://poker-academie.com)](https://poker-academie.com)*: top 100M, discussion, forum, fr, gambling*
+1. ![](https://www.google.com/s2/favicons?domain=https://turkiyeatlas.com) [turkiyeatlas.com (https://turkiyeatlas.com)](https://turkiyeatlas.com)*: top 100M, discussion, forum, tr, travel*
 
 The list was updated at (2026-08-28)
 ## Statistics
 
-Enabled/total sites: 2637/3330 = 79.19%
+Enabled/total sites: 2654/3347 = 79.29%
 
-Incomplete message checks: 345/2637 = 13.08% (false positive risks)
+Incomplete message checks: 349/2654 = 13.15% (false positive risks)
 
-Status code checks: 726/2637 = 27.53% (false positive risks)
+Status code checks: 730/2654 = 27.51% (false positive risks)
 
-False positive risk (total): 40.61%
+False positive risk (total): 40.66%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
@@ -3352,18 +3369,18 @@ Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSea
 Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
 - (337)	`/{username}`
-- (254)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
-- (196)	`/user/{username}`
+- (262)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
+- (199)	`/user/{username}`
 - (146)	`/profile/{username}`
 - (126)	`/u/{username}`
 - (126)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
 - (126)	`{urlMain}{urlSubpath}/search.php?author={username} (phpBB/Search)`
 - (99)	`/users/{username}`
-- (79)	`{urlMain}/u/{username}/summary (Discourse)`
+- (80)	`{urlMain}/u/{username}/summary (Discourse)`
 - (76)	`/@{username}`
 - (55)	`/wiki/User:{username}`
 - (48)	`SUBDOMAIN`
-- (40)	`/members/?username={username}`
+- (42)	`/members/?username={username}`
 - (32)	`/author/{username}`
 - (29)	`/members/{username}`
 - (29)	`{urlMain}{urlSubpath}/memberlist.php?username={username} (phpBB)`
@@ -3374,10 +3391,10 @@ Top 20 profile URLs:
 
 Sites by engine:
 - `uCoz`: 633/709 (89.3%)
-- `XenForo`: 204/254 (80.3%)
+- `XenForo`: 212/262 (80.9%)
 - `vBulletin`: 33/126 (26.2%)
 - `phpBB/Search`: 117/126 (92.9%)
-- `Discourse`: 71/79 (89.9%)
+- `Discourse`: 72/80 (90.0%)
 - `phpBB`: 23/29 (79.3%)
 - `DiscourseJson`: 26/26 (100.0%)
 - `engine404`: 18/23 (78.3%)
@@ -3390,23 +3407,23 @@ Sites by engine:
 
 
 Top 20 tags:
-- (1325)	`forum`
+- (1341)	`forum`
 - (455)	`social`
-- (380)	`gaming`
-- (338)	`discussion`
-- (312)	`tech`
+- (382)	`gaming`
+- (354)	`discussion`
+- (313)	`tech`
 - (212)	`education`
-- (206)	`business`
-- (204)	`coding`
-- (183)	`hobby`
+- (208)	`business`
+- (205)	`coding`
+- (185)	`hobby`
 - (137)	`apps`
 - (130)	`music`
 - (122)	`blog`
-- (108)	`news`
+- (110)	`news`
 - (105)	`art`
 - (91)	`sharing`
 - (86)	`auto`
 - (71)	`shopping`
-- (69)	`photo`
+- (70)	`photo`
 - (69)	`design`
 - (68)	`finance`


### PR DESCRIPTION
Adds 17 sites.

| site | engine | tags |
|---|---|---|
| forum.lvivport.com | XenForo | forum, discussion, ua, news |
| forum.onlinesoccermanager.nl | — | forum, discussion, nl, gaming, sport |
| fpvua.org | XenForo | forum, discussion, ua, hobby |
| immobilio.it | XenForo | forum, discussion, it, business |
| fanforum.uscho.com | XenForo | forum, discussion, sport |
| foforum.fr | — | forum, discussion, fr |
| forum.gamesource.it | XenForo | forum, discussion, it, gaming |
| forum.lottoced.com | — | forum, discussion, gambling |
| forum.media2.pl | — | forum, discussion, pl, news |
| forum.welcome-suisse.ch | Discourse | forum, discussion, ch, travel |
| forums.talkseafishing.co.uk | XenForo | forum, discussion, uk, hobby |
| funny.grizly.club | — | ru, photo |
| weblogistics.vn | XenForo | forum, discussion, vn, business |
| bbs.aw-ol.com | — | forum, discussion, cn, coding |
| forum.iinkor.com | XenForo | forum, discussion, ar, tech |
| poker-academie.com | — | forum, discussion, fr, gambling |
| turkiyeatlas.com | — | forum, discussion, tr, travel |
