### PR TITLE
[LAPOINTE] Add 16 sites and a Vanilla engine

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -45249,6 +45249,193 @@
                 "class=\"memberHeader-blurb\"",
                 "class=\"has-no-js template-member_view\""
             ]
+        },
+        "bioinformaticsonline.com": {
+            "tags": [
+                "education",
+                "science",
+                "social"
+            ],
+            "urlMain": "https://bioinformaticsonline.com",
+            "usernameClaimed": "biostar",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://bioinformaticsonline.com/profile/{username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "\"username\":",
+                "class=\"userpoints_profile\""
+            ]
+        },
+        "forum.bmwsharkfest.org": {
+            "tags": [
+                "auto",
+                "discussion",
+                "forum",
+                "us"
+            ],
+            "urlMain": "https://forum.bmwsharkfest.org",
+            "usernameClaimed": "Mike_N_3",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
+        },
+        "forum.giderosmobile.com": {
+            "tags": [
+                "coding",
+                "discussion",
+                "forum",
+                "gaming"
+            ],
+            "urlMain": "https://forum.giderosmobile.com",
+            "usernameClaimed": "ar2rsawseen",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
+        },
+        "forum.ideavr.top": {
+            "tags": [
+                "cn",
+                "discussion",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://forum.ideavr.top",
+            "usernameClaimed": "admin123456",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
+        },
+        "forum.infinityfree.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://forum.infinityfree.com",
+            "usernameClaimed": "Greenreader9",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Discourse"
+        },
+        "forum.kjodle.net": {
+            "tags": [
+                "discussion",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://forum.kjodle.net",
+            "usernameClaimed": "kjodle",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
+        },
+        "forum.yiiframework.com": {
+            "tags": [
+                "coding",
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://forum.yiiframework.com",
+            "usernameClaimed": "samdark",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Discourse"
+        },
+        "forums.beamdog.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "gaming"
+            ],
+            "urlMain": "https://forums.beamdog.com",
+            "usernameClaimed": "JuliusBorisov",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
+        },
+        "forums.comodo.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://forums.comodo.com",
+            "usernameClaimed": "Citizen_K",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Discourse"
+        },
+        "futuresight.org": {
+            "tags": [
+                "discussion",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://futuresight.org",
+            "usernameClaimed": "Jacob",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://futuresight.org/forums/users/{username}",
+            "checkType": "status_code"
+        },
+        "lowendtalk.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://lowendtalk.com",
+            "usernameClaimed": "Jord",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
+        },
+        "meta.akkoma.dev": {
+            "tags": [
+                "coding",
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://meta.akkoma.dev",
+            "usernameClaimed": "FloatingGhost",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Discourse"
+        },
+        "nullcave.club": {
+            "tags": [
+                "discussion",
+                "forum",
+                "sharing"
+            ],
+            "urlMain": "https://nullcave.club",
+            "usernameClaimed": "lomba_II",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "otland.net": {
+            "tags": [
+                "discussion",
+                "forum",
+                "gaming"
+            ],
+            "urlMain": "https://otland.net",
+            "usernameClaimed": "Cykotitan",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "ttrpbc.com": {
+            "tags": [
+                "books",
+                "discussion",
+                "forum",
+                "gaming"
+            ],
+            "urlMain": "https://ttrpbc.com",
+            "usernameClaimed": "RichardAbbott",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
+        },
+        "vintagemoviepostersforum.com": {
+            "tags": [
+                "discussion",
+                "forum",
+                "hobby",
+                "movies"
+            ],
+            "urlMain": "https://vintagemoviepostersforum.com",
+            "usernameClaimed": "David",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Vanilla"
         }
     },
     "engines": {
@@ -45476,6 +45663,24 @@
                 "urlMain": "https://www.op.gg/",
                 "alexaRank": 331
             }
+        },
+        "Vanilla": {
+            "name": "Vanilla",
+            "site": {
+                "url": "{urlMain}{urlSubpath}/profile/{username}",
+                "checkType": "message",
+                "presenseStrs": [
+                    "Dashboard Profile",
+                    "\"DefaultAbout\"",
+                    "Section-Entry"
+                ],
+                "absenceStrs": [
+                    "filenotfound"
+                ]
+            },
+            "presenseStrs": [
+                "gdn.meta"
+            ]
         }
     },
     "tags": [

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-28T17:23:07Z",
-    "sites_count": 3347,
+    "updated_at": "2026-08-29T09:03:17Z",
+    "sites_count": 3363,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "bc34cce23f24547d08dee3c5a25d683c5b899e9d95efbc9708c447fef00d1cf1",
+    "data_sha256": "0c60175f70308fe6562b5649e788f566f752e66d407af7728b2ad8b99d7d6c5d",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3347
+## List of supported sites (search methods): total 3363
 
 Rank data fetched from Majestic Million by domains.
 
@@ -3350,17 +3350,33 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://forum.iinkor.com) [forum.iinkor.com (https://forum.iinkor.com)](https://forum.iinkor.com)*: top 100M, discussion, forum, tech*
 1. ![](https://www.google.com/s2/favicons?domain=https://poker-academie.com) [poker-academie.com (https://poker-academie.com)](https://poker-academie.com)*: top 100M, discussion, forum, fr, gambling*
 1. ![](https://www.google.com/s2/favicons?domain=https://turkiyeatlas.com) [turkiyeatlas.com (https://turkiyeatlas.com)](https://turkiyeatlas.com)*: top 100M, discussion, forum, tr, travel*
+1. ![](https://www.google.com/s2/favicons?domain=https://bioinformaticsonline.com) [bioinformaticsonline.com (https://bioinformaticsonline.com)](https://bioinformaticsonline.com)*: top 100M, education, science, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.bmwsharkfest.org) [forum.bmwsharkfest.org (https://forum.bmwsharkfest.org)](https://forum.bmwsharkfest.org)*: top 100M, auto, discussion, forum, us*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.giderosmobile.com) [forum.giderosmobile.com (https://forum.giderosmobile.com)](https://forum.giderosmobile.com)*: top 100M, coding, discussion, forum, gaming*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.ideavr.top) [forum.ideavr.top (https://forum.ideavr.top)](https://forum.ideavr.top)*: top 100M, cn, discussion, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.infinityfree.com) [forum.infinityfree.com (https://forum.infinityfree.com)](https://forum.infinityfree.com)*: top 100M, discussion, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.kjodle.net) [forum.kjodle.net (https://forum.kjodle.net)](https://forum.kjodle.net)*: top 100M, discussion, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.yiiframework.com) [forum.yiiframework.com (https://forum.yiiframework.com)](https://forum.yiiframework.com)*: top 100M, coding, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://forums.beamdog.com) [forums.beamdog.com (https://forums.beamdog.com)](https://forums.beamdog.com)*: top 100M, discussion, forum, gaming*
+1. ![](https://www.google.com/s2/favicons?domain=https://forums.comodo.com) [forums.comodo.com (https://forums.comodo.com)](https://forums.comodo.com)*: top 100M, discussion, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://futuresight.org) [futuresight.org (https://futuresight.org)](https://futuresight.org)*: top 100M, discussion, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://lowendtalk.com) [lowendtalk.com (https://lowendtalk.com)](https://lowendtalk.com)*: top 100M, discussion, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://meta.akkoma.dev) [meta.akkoma.dev (https://meta.akkoma.dev)](https://meta.akkoma.dev)*: top 100M, coding, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://nullcave.club) [nullcave.club (https://nullcave.club)](https://nullcave.club)*: top 100M, discussion, forum, sharing*
+1. ![](https://www.google.com/s2/favicons?domain=https://otland.net) [otland.net (https://otland.net)](https://otland.net)*: top 100M, discussion, forum, gaming*
+1. ![](https://www.google.com/s2/favicons?domain=https://ttrpbc.com) [ttrpbc.com (https://ttrpbc.com)](https://ttrpbc.com)*: top 100M, books, discussion, forum, gaming*
+1. ![](https://www.google.com/s2/favicons?domain=https://vintagemoviepostersforum.com) [vintagemoviepostersforum.com (https://vintagemoviepostersforum.com)](https://vintagemoviepostersforum.com)*: top 100M, discussion, forum, hobby, movies*
 
-The list was updated at (2026-08-28)
+The list was updated at (2026-08-29)
 ## Statistics
 
-Enabled/total sites: 2654/3347 = 79.29%
+Enabled/total sites: 2670/3363 = 79.39%
 
-Incomplete message checks: 349/2654 = 13.15% (false positive risks)
+Incomplete message checks: 350/2670 = 13.11% (false positive risks)
 
-Status code checks: 730/2654 = 27.51% (false positive risks)
+Status code checks: 731/2670 = 27.38% (false positive risks)
 
-False positive risk (total): 40.66%
+False positive risk (total): 40.49%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
@@ -3369,14 +3385,14 @@ Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSea
 Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
 - (337)	`/{username}`
-- (262)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
+- (264)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
 - (199)	`/user/{username}`
-- (146)	`/profile/{username}`
+- (147)	`/profile/{username}`
 - (126)	`/u/{username}`
 - (126)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
 - (126)	`{urlMain}{urlSubpath}/search.php?author={username} (phpBB/Search)`
 - (99)	`/users/{username}`
-- (80)	`{urlMain}/u/{username}/summary (Discourse)`
+- (84)	`{urlMain}/u/{username}/summary (Discourse)`
 - (76)	`/@{username}`
 - (55)	`/wiki/User:{username}`
 - (48)	`SUBDOMAIN`
@@ -3391,38 +3407,39 @@ Top 20 profile URLs:
 
 Sites by engine:
 - `uCoz`: 633/709 (89.3%)
-- `XenForo`: 212/262 (80.9%)
+- `XenForo`: 214/264 (81.1%)
 - `vBulletin`: 33/126 (26.2%)
 - `phpBB/Search`: 117/126 (92.9%)
-- `Discourse`: 72/80 (90.0%)
+- `Discourse`: 76/84 (90.5%)
 - `phpBB`: 23/29 (79.3%)
 - `DiscourseJson`: 26/26 (100.0%)
 - `engine404`: 18/23 (78.3%)
 - `op.gg`: 17/17 (100.0%)
 - `Flarum`: 16/16 (100.0%)
 - `Wordpress/Author`: 4/8 (50.0%)
+- `Vanilla`: 8/8 (100.0%)
 - `engineRedirect`: 3/4 (75.0%)
 - `phpBB2/Search`: 2/3 (66.7%)
 - `engine404get`: 2/2 (100.0%)
 
 
 Top 20 tags:
-- (1341)	`forum`
-- (455)	`social`
-- (382)	`gaming`
-- (354)	`discussion`
-- (313)	`tech`
-- (212)	`education`
+- (1356)	`forum`
+- (456)	`social`
+- (386)	`gaming`
+- (369)	`discussion`
+- (319)	`tech`
+- (213)	`education`
+- (208)	`coding`
 - (208)	`business`
-- (205)	`coding`
-- (185)	`hobby`
+- (186)	`hobby`
 - (137)	`apps`
 - (130)	`music`
 - (122)	`blog`
 - (110)	`news`
 - (105)	`art`
-- (91)	`sharing`
-- (86)	`auto`
+- (92)	`sharing`
+- (87)	`auto`
 - (71)	`shopping`
 - (70)	`photo`
 - (69)	`design`


### PR DESCRIPTION
Adds 16 sites. Eight of them run Vanilla, so this also adds a Vanilla engine template.

| site | engine | tags |
|---|---|---|
| bioinformaticsonline.com | — | social, science, education |
| forum.bmwsharkfest.org | Vanilla | forum, discussion, auto, us |
| forum.giderosmobile.com | Vanilla | forum, discussion, coding, gaming |
| forum.ideavr.top | Vanilla | forum, discussion, tech, cn |
| forum.infinityfree.com | Discourse | forum, discussion, tech |
| forum.kjodle.net | Vanilla | forum, discussion, tech |
| forum.yiiframework.com | Discourse | forum, discussion, coding |
| forums.beamdog.com | Vanilla | forum, discussion, gaming |
| forums.comodo.com | Discourse | forum, discussion, tech |
| futuresight.org | — | forum, discussion, tech |
| lowendtalk.com | Vanilla | forum, discussion, tech |
| meta.akkoma.dev | Discourse | forum, discussion, coding |
| nullcave.club | XenForo | forum, discussion, sharing |
| otland.net | XenForo | forum, discussion, gaming |
| ttrpbc.com | Vanilla | forum, discussion, gaming, books |
| vintagemoviepostersforum.com | Vanilla | forum, discussion, movies, hobby |
