### PR TITLE
Fix rendering of non-string identity values

### DIFF
--- a/maigret/utils.py
+++ b/maigret/utils.py
@@ -96,7 +96,7 @@ def get_dict_ascii_tree(items, prepend="", new_line=True):
 
         if isinstance(item, tuple):
             field_name, field_value = item
-            if field_value.startswith("['"):
+            if isinstance(field_value, str) and field_value.startswith("['"):
                 is_last_item = num == len(items) - 1
                 prepend_symbols = " " * 3 if is_last_item else f" {skip_result} "
                 data = ascii_data_display(field_value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,6 +191,10 @@ def test_get_dict_ascii_tree():
     )
 
 
+def test_get_dict_ascii_tree_handles_non_string_values():
+    assert get_dict_ascii_tree([('uid', 42)], new_line=False) == '└─uid: 42'
+
+
 def test_get_match_ratio():
     fun = get_match_ratio(["test", "maigret", "username"])
 


### PR DESCRIPTION
## Problem

Extracted identity metadata can contain numeric values, but the console tree renderer calls `startswith` on every value. A claimed result containing an integer ID therefore crashes during output formatting.

## Changes

- restrict serialized-list detection to string values
- add a regression test covering an integer identity field

## Verification

- `python -m pytest tests/test_utils.py::test_get_dict_ascii_tree_handles_non_string_values tests/test_utils.py::test_get_dict_ascii_tree -q`
- `python -m pytest tests/test_utils.py tests/test_notify.py -q` (38 passed)
