### PR TITLE
Drop the update_sitesmd console script

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,8 +12,8 @@ else
     exit 1
 fi
 
-echo 'Activating update_sitesmd hook script...'
-run update_sitesmd
+echo 'Regenerating data.json and sites.md...'
+run python -m utils.update_site_data
 
 echo 'Regenerating db_meta.json...'
 run python utils/generate_db_meta.py

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -283,7 +283,7 @@ HTML reports contain the same data and open in any browser.
 
 If pip prints warnings like::
 
-   WARNING: The scripts maigret and update_sitesmd are installed in
+   WARNING: The script maigret is installed in
    '/home/<user>/.local/bin' which is not on PATH.
 
 …and ``maigret --version`` then fails with ``command not found``, your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,4 +100,3 @@ black = ">=25.1,<27.0"
 [tool.poetry.scripts]
 # Run with: poetry run maigret <username>
 maigret = "maigret.maigret:run"
-update_sitesmd = "utils.update_site_data:main"


### PR DESCRIPTION
`utils/` is in neither the sdist nor the wheel, so the declared entry point ships a command that fails on every install:

    $ update_sitesmd
    ModuleNotFoundError: No module named 'utils'

It only works in a dev checkout, where maigret is installed editable and the repository root is on sys.path.

- `pyproject.toml`: drop the `update_sitesmd` script.
- `.githooks/pre-commit`: run `python -m utils.update_site_data` instead.
- `installation.rst`: the quoted pip warning named both scripts, now one.