### PR TITLE
Document the snap as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ Run Maigret in the browser via cloud shells or Jupyter notebooks:
 <a href="https://colab.research.google.com/gist/soxoj/879b51bc3b2f8b695abb054090645000/maigret-collab.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab" height="45"></a>
 <a href="https://mybinder.org/v2/gist/soxoj/9d65c2f4d3bec5dd25949197ea73cf3a/HEAD"><img src="https://mybinder.org/badge_logo.svg" alt="Open In Binder" height="45"></a>
 
+### Snap (Linux)
+
+<a href="https://snapcraft.io/maigret"><img src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" alt="Get it from the Snap Store" height="50"></a>
+
+```bash
+sudo snap install maigret
+
+# usage
+maigret username
+```
+
+Available for amd64 and arm64, no Python required. The snap is strictly confined and can write inside your home directory, so run it from there. For USB drives, connect the interface once with `sudo snap connect maigret:removable-media`.
+
 ### Local installation (pip)
 
 ```bash

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -76,6 +76,40 @@ Press one of the buttons below and follow the instructions to launch it in your 
 
    Binder: https://mybinder.org/v2/gist/soxoj/9d65c2f4d3bec5dd25949197ea73cf3a/HEAD
 
+Snap (Linux)
+------------
+
+Maigret is on the `Snap Store <https://snapcraft.io/maigret>`_ for amd64 and
+arm64. It needs neither Python nor pip:
+
+.. only:: html
+
+   .. image:: https://snapcraft.io/static/images/badges/en/snap-store-black.svg
+      :target: https://snapcraft.io/maigret
+      :alt: Get it from the Snap Store
+      :height: 50
+
+.. code-block:: bash
+
+   sudo snap install maigret
+
+   # usage
+   maigret username
+
+The snap is strictly confined: it can read and write your home directory and
+very little else. Run it from a directory under ``$HOME`` and reports land in
+``./reports`` as usual. Running it from somewhere it cannot see, ``/tmp`` for
+instance, fails before the search starts.
+
+Access to USB drives and other removable media is not connected by default:
+
+.. code-block:: bash
+
+   sudo snap connect maigret:removable-media
+
+Updates arrive on their own through snapd, so the bundled site database and the
+code both stay current without any action.
+
 Local installation from PyPi
 ----------------------------
 


### PR DESCRIPTION
The snap has been on `latest/stable` since 26.08, for amd64 and arm64, and is mentioned nowhere a user would look. The only match in the repository is `settings.rst`, in passing, as an example of an install whose directory is not writable.

- `README.md`: a "Snap (Linux)" subsection before the pip one, with the official Snap Store badge at the same height as the Cloud Shell buttons above it.
- `docs/source/installation.rst`: the same, between Cloud Shells and PyPI, with the badge under `only:: html` like the other buttons on that page, plus what strict confinement means in practice, the `removable-media` interface, and automatic updates through snapd.