### PR TITLE
Fix graph reports for non-string identity values

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -189,7 +189,7 @@ class MaigretGraph:
         params = dict(self.other_params)
         if key in SUPPORTED_IDS:
             params = dict(self.username_params)
-        elif value.startswith('http'):
+        elif isinstance(value, str) and value.startswith('http'):
             params = dict(self.site_params)
 
         params['title'] = node_name
@@ -255,7 +255,7 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
                         k.endswith('_count')
                         or k.startswith('is_')
                         or k.endswith('_at')
-                        or k in 'image'
+                        or k == 'image'
                     ):
                         continue
 
@@ -281,11 +281,13 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
                                 data_node_name = graph.add_node(vv, site_base_url)
                                 graph.link(list_node_name, data_node_name)
 
-                                add_ids = {
-                                    a: b for b, a in db.extract_ids_from_url(vv).items()
-                                }
-                                if add_ids:
-                                    process_ids(data_node_name, add_ids)
+                                if isinstance(vv, str):
+                                    add_ids = {
+                                        a: b
+                                        for b, a in db.extract_ids_from_url(vv).items()
+                                    }
+                                    if add_ids:
+                                        process_ids(data_node_name, add_ids)
                             ids_data_name = list_node_name
                         else:
                             ids_data_name = graph.add_node(k, norm_v)
@@ -302,11 +304,12 @@ def _build_maigret_graph(username_results: list, db: MaigretDatabase):
                                     )
                                     graph.link(ids_data_name, new_username_node_name)
 
-                            add_ids = {
-                                k: v for v, k in db.extract_ids_from_url(v).items()
-                            }
-                            if add_ids:
-                                process_ids(ids_data_name, add_ids)
+                            if isinstance(v, str):
+                                add_ids = {
+                                    k: v for v, k in db.extract_ids_from_url(v).items()
+                                }
+                                if add_ids:
+                                    process_ids(ids_data_name, add_ids)
 
                     graph.link(parent_node, ids_data_name)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -32,6 +32,7 @@ from maigret.report import (
     generate_report_context,
     generate_json_report,
     get_plaintext_report,
+    _build_maigret_graph,
     _graph_to_cypher,
     _is_safe_report_image_url,
     _pdf_report_link_callback,
@@ -40,7 +41,7 @@ from maigret.report import (
 )
 from maigret.errors import CheckError
 from maigret.result import MaigretCheckResult, MaigretCheckStatus
-from maigret.sites import MaigretSite
+from maigret.sites import MaigretDatabase, MaigretSite
 
 GOOD_RESULT = MaigretCheckResult('', '', '', MaigretCheckStatus.CLAIMED)
 BAD_RESULT = MaigretCheckResult('', '', '', MaigretCheckStatus.AVAILABLE)
@@ -373,6 +374,49 @@ def test_generate_neo4j_report():
     assert len(bio_lines) == 1
     assert bio_lines[0].endswith(";")
     assert "o\\'brien\\nbreak" in bio_lines[0]
+
+
+def test_build_graph_accepts_non_string_identity_values():
+    status = MaigretCheckResult(
+        'user',
+        'ExampleSite',
+        'https://example.com/user',
+        MaigretCheckStatus.CLAIMED,
+        ids_data={
+            'uid': 4242,
+            'age': 30,
+            'verified': True,
+            'aliases': [1234, 'https://example.com/alias'],
+            'metadata': {'source': 'api'},
+            'image': 'https://example.com/avatar.png',
+        },
+    )
+    results = [
+        (
+            'user',
+            'username',
+            {
+                'ExampleSite': {
+                    'status': status,
+                    'url_user': 'https://example.com/user',
+                }
+            },
+        )
+    ]
+    db = MaigretDatabase().update_site(
+        MaigretSite('ExampleSite', {'url': 'https://example.com/{username}'})
+    )
+
+    graph = _build_maigret_graph(results, db)
+
+    assert 'uid: 4242' in graph
+    assert 'age: 30' in graph
+    assert 'verified: True' in graph
+    assert "metadata: {'source': 'api'}" in graph
+    assert '1234: ExampleSite' in graph
+    assert 'username: alias' in graph
+    assert graph.has_edge('account: https://example.com/user', 'age: 30')
+    assert not any(str(node).startswith('image:') for node in graph)
 
 
 def test_generate_txt_report():


### PR DESCRIPTION
## Summary

- accept non-string extracted identity values in graph and Neo4j reports
- only attempt URL ID extraction for strings
- fix the identity-field filter so only `image` is skipped
- add regression coverage for numeric, boolean, list, and mapping values

Fixes #3044

## Testing

- `pytest tests/test_report.py -q` (49 passed, 2 skipped)
- `pytest tests -m "not slow" -q` (438 passed, 3 skipped, 24 deselected)
- critical flake8 check on changed files (0 errors)