### PR TITLE
Fail with a clear message when the reports directory cannot be created

### DIFF
--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -795,7 +795,25 @@ async def main():
     report_dir = path.join(os.getcwd(), args.folderoutput)
 
     # Make reports folder is not exists
-    os.makedirs(report_dir, exist_ok=True)
+    try:
+        os.makedirs(report_dir, exist_ok=True)
+    except OSError as e:
+        logger.error(str(e))
+        query_notify.warning(
+            f'Could not create the reports directory {report_dir}: {e.strerror}.', '!'
+        )
+        if os.environ.get('SNAP'):
+            query_notify.warning(
+                'The snap can only write under your home directory or a connected '
+                'removable drive. Run maigret from a folder under your home, '
+                'or pass -fo PATH.',
+                '!',
+            )
+        else:
+            query_notify.warning(
+                'Run maigret from a writable directory, or pass -fo PATH.', '!'
+            )
+        sys.exit(2)
 
     # Define one report filename template
     report_filepath_tpl = path.join(report_dir, 'report_{username}{postfix}')


### PR DESCRIPTION
Running maigret from a directory it cannot write to ends the run with a raw traceback through asyncio and exit 1, before a single site is checked:

```
PermissionError: [Errno 13] Permission denied: '/var/lib/snapd/void/reports'
```

Nothing in that output tells the user what happened or what to do about it.

The snap makes it easy to hit. Outside `$HOME` and connected removable media the snap cannot see the working directory, so snapd substitutes `/var/lib/snapd/void` for it and the error names a path the user never typed. It is not snap specific though: the same traceback appears on any install run from a read-only or root-owned directory.

## What changes

`os.makedirs(report_dir)` is now guarded. On `OSError` the run stops with a message that names the directory, the reason and the fix, and exits 2 to match the other setup failures such as a missing database.

Under snap it adds one more line explaining where the path came from, since `/var/lib/snapd/void` is meaningless without it.
