### PR TITLE
Attach the Windows binary to published releases

### DIFF
--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -3,6 +3,8 @@ name: Package exe with PyInstaller - Windows
 on:
   push:
     branches: [main, dev]
+  release:
+    types: [published]
 
 # Two builds racing on the same branch could leave the nightly tag pointing at
 # one commit while the .exe attached to the release was built from the other.
@@ -65,7 +67,7 @@ jobs:
       # pinned to the first build forever while the attached .exe keeps being
       # replaced on every push.
       - name: Move the nightly tag to the built commit
-        if: success()
+        if: success() && github.event_name == 'push'
         run: |
           set -euo pipefail
           git tag --force "$NIGHTLY_TAG" "$GITHUB_SHA"
@@ -74,7 +76,7 @@ jobs:
           git push --force origin "refs/tags/$NIGHTLY_TAG"
 
       - name: Create New Release and Upload PyInstaller Binary to Release
-        if: success()
+        if: success() && github.event_name == 'push'
         uses: ncipollo/release-action@v1.14.0
         id: create_release
         with:
@@ -117,3 +119,21 @@ jobs:
 
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      # A published release already has its title, notes and prerelease flag set
+      # by whoever published it. release-action would overwrite all three with its
+      # own defaults during an update, so every omit*DuringUpdate is on: this step
+      # attaches the binary and touches nothing else.
+      - name: Attach the binary to the published release
+        if: success() && github.event_name == 'release'
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          allowUpdates: true
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          omitDraftDuringUpdate: true
+          artifactErrorsFailBuild: true
+          replacesArtifacts: true
+          artifacts: maigret_standalone.exe
+          tag: ${{ github.event.release.tag_name }}

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -13,6 +13,12 @@ from, which caused three separate problems:
 
 These tests read the workflow as data, so they fail if any of the three
 conditions is reintroduced.
+
+The workflow also attaches the binary to releases a human publishes, which is a
+second ``release-action`` step with the opposite requirements: it must not touch
+the title, the notes or the prerelease flag that the publisher chose. Both steps
+are covered below, and each must stay guarded on a specific ``github.event_name``
+so neither ever runs on the other's event.
 """
 
 import os
@@ -37,12 +43,34 @@ def workflow():
         return yaml.safe_load(f)
 
 
+def _release_action_steps(workflow):
+    steps = workflow["jobs"]["build"]["steps"]
+    return [s for s in steps if RELEASE_ACTION in s.get("uses", "")]
+
+
+def _only_step_for_event(workflow, event):
+    matching = [
+        s
+        for s in _release_action_steps(workflow)
+        if f"github.event_name == '{event}'" in s.get("if", "")
+    ]
+    assert len(matching) == 1, (
+        f"expected exactly one {RELEASE_ACTION} step guarded on the {event!r} "
+        f"event, found {len(matching)}"
+    )
+    return matching[0]
+
+
 @pytest.fixture(scope="module")
 def release_step(workflow):
-    steps = workflow["jobs"]["build"]["steps"]
-    matching = [s for s in steps if RELEASE_ACTION in s.get("uses", "")]
-    assert len(matching) == 1, f"expected exactly one {RELEASE_ACTION} step"
-    return matching[0]
+    """The nightly development release, published on every push to a branch."""
+    return _only_step_for_event(workflow, "push")
+
+
+@pytest.fixture(scope="module")
+def published_release_step(workflow):
+    """The step attaching the binary to a release a human published."""
+    return _only_step_for_event(workflow, "release")
 
 
 def _push_branches(workflow):
@@ -94,3 +122,38 @@ def test_release_tag_is_moved_to_the_built_commit(workflow, release_step):
         "first build while the release keeps getting new binaries"
     )
     assert workflow.get("permissions", {}).get("contents") == "write"
+
+
+def test_every_release_step_is_guarded_by_event(workflow):
+    # An unguarded step would run on both events: on a published release it
+    # would mint a junk nightly-vX.Y.Z tag, and on a push it would try to
+    # update a release that does not exist.
+    for step in _release_action_steps(workflow):
+        assert "github.event_name" in step.get("if", ""), (
+            f"{step.get('name')!r} is not guarded by event and would run on both"
+        )
+
+
+def test_published_release_keeps_the_metadata_it_was_given(published_release_step):
+    # Whoever published the release chose its title, notes, prerelease and draft
+    # state. release-action replaces all four with its own defaults while
+    # updating unless every omit is set, so this step must only add the asset.
+    options = published_release_step["with"]
+    for key in (
+        "omitNameDuringUpdate",
+        "omitBodyDuringUpdate",
+        "omitPrereleaseDuringUpdate",
+        "omitDraftDuringUpdate",
+    ):
+        assert str(options.get(key)).lower() == "true", (
+            f"{key} is not set; publishing would overwrite the release notes"
+        )
+
+
+def test_published_release_targets_the_published_tag(published_release_step):
+    # NIGHTLY_TAG expands to `nightly-v0.6.6` on a release event, so the step
+    # has to name the tag from the event payload instead.
+    tag = published_release_step["with"]["tag"]
+    assert "github.event.release.tag_name" in tag, (
+        f"expected the published tag, got {tag!r}"
+    )


### PR DESCRIPTION
## The gap

`pyinstaller.yml` builds `maigret_standalone.exe`, but it only runs on pushes to `main` and `dev`. The binary therefore lives only on the two moving `nightly-*` tags, and every stable release from v0.6.1 to v0.6.5 has no assets at all.

That is awkward for anyone on Windows. The changelog says 0.6.5 is out, the release page has nothing to download, and the only exe on offer is a nightly that will point at a different commit tomorrow. It also blocks winget and Scoop, which need a stable URL and a hash they can pin.

## What changes

The workflow also listens for `release: types: [published]`, the same trigger `python-publish.yml` already uses for the PyPI upload. `actions/checkout` resolves `refs/tags/<tag>` on that event, so the exe is built from the released code and not from the head of a branch.

The two steps that exist only for nightlies are guarded on `github.event_name == 'push'`:

- moving the `nightly-*` tag, which would otherwise create a junk `nightly-v0.6.6` beside the real tag
- creating the "Development Windows Release", which would otherwise compete with the real one

A new step attaches the binary to the published release with every `omit*DuringUpdate` flag set, so it leaves the title, body, prerelease and draft state exactly as the person publishing chose them.

## Tested end to end

Ran on a throwaway repository with the Wine PyInstaller step replaced by a stub writing `event`, `ref` and `sha` into a fake exe. Everything after that step was byte identical to this branch.

Push to `main`: the `nightly-main` tag moved to the built commit, the prerelease was created with the exe attached, and `GET /releases/latest` answered 404, so a nightly never claims the latest marker.

Publishing `v0.0.1` with a hand written title, hand written notes and `prerelease: false`:

| check | result |
|---|---|
| exe attached | yes |
| title after the run | unchanged |
| body after the run | unchanged, verbatim |
| prerelease / draft | still false / false |
| junk `nightly-v0.0.1` tag | not created |
| nightly release touched | no |
| latest marker | moved to `v0.0.1` |

And the ref, which is the whole point. The two attached binaries carry the ref they were built from:

```
release asset  event=release  ref=refs/tags/v0.0.1
nightly asset  event=push     ref=refs/heads/main
```

## Worth knowing

Existing releases are not backfilled. This starts with the next one.

A release now costs two PyInstaller runs, one on the tag and one on the push to `main` that follows a couple of minutes later. They land in different concurrency groups, `refs/tags/...` against `refs/heads/main`, so they do not cancel each other.
