### PR TITLE
fix: keep the startup banners from crashing on a non-UTF-8 stdout

### DIFF
--- a/maigret/notify.py
+++ b/maigret/notify.py
@@ -271,6 +271,27 @@ PATREON_URL = "https://www.patreon.com/soxoj"
 INTRO_TEXT = "MAIGRET - collect a dossier by username from 3000+ sites"
 
 
+def _print_encodable(text: str) -> None:
+    """Print text the active stdout encoding may not be able to represent.
+
+    On Windows, Python takes stdout's encoding from the process ANSI
+    codepage, which is cp1252 on a default install and has no U+2665. The
+    banners below carry one, so printing them raised UnicodeEncodeError
+    before a single site was checked, and --no-color did not help because
+    the character sits in that branch too. PYTHONIOENCODING cannot rescue
+    the PyInstaller build, which ignores PYTHON* environment variables.
+
+    Catching the write rather than reconfiguring the stream is deliberate:
+    colorama's init() replaces sys.stdout with a wrapper that has no
+    reconfigure(), so a stream-level fix would depend on running first.
+    """
+    try:
+        print(text)
+    except UnicodeEncodeError:
+        encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+        print(text.encode(encoding, errors="replace").decode(encoding, errors="replace"))
+
+
 def _format_intro(use_color: bool) -> str:
     if not use_color:
         return f"[+] {INTRO_TEXT}"
@@ -283,7 +304,7 @@ def print_intro_banner(no_color: bool = False, silent: bool = False) -> None:
     """Print the Maigret intro tagline. Skipped only in silent (--ai) mode."""
     if silent:
         return
-    print(_format_intro(use_color=not no_color))
+    _print_encodable(_format_intro(use_color=not no_color))
 
 
 def _format_donate_banner(use_color: bool) -> str:
@@ -304,4 +325,4 @@ def print_donate_banner(no_color: bool = False, silent: bool = False) -> None:
     """Print a colored donation banner. Skipped only in silent (--ai) mode."""
     if silent:
         return
-    print(_format_donate_banner(use_color=not no_color))
+    _print_encodable(_format_donate_banner(use_color=not no_color))

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -204,3 +204,52 @@ def test_update_shows_extractor_field_when_verbose(monkeypatch):
     out = "\n".join(captured)
     assert "uid: 42" in out
     assert "_extractor: SomeSchemeAPI" in out
+
+
+def test_banners_survive_a_stdout_that_cannot_encode_them(tmp_path):
+    """The banners carry '♥', which the Windows ANSI codepage (cp1252 on a
+    default install) cannot encode, so printing them raised UnicodeEncodeError
+    before a single site was checked. --no-color did not help: the character is
+    in that branch too, and the PyInstaller build ignores PYTHONIOENCODING, so
+    there was no way around it from outside.
+
+    Run the banners in a child process whose stdout really is cp1252 rather
+    than mocking the failure, so this fails on any machine if the guard goes.
+    """
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    probe = tmp_path / "banner_probe.py"
+    probe.write_text(
+        textwrap.dedent(
+            """
+            from maigret.notify import print_intro_banner, print_donate_banner
+
+            print_intro_banner(no_color=True)
+            print_donate_banner(no_color=True)
+            print_intro_banner(no_color=False)
+            print_donate_banner(no_color=False)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"
+    result = subprocess.run(
+        [sys.executable, str(probe)],
+        capture_output=True,
+        encoding="cp1252",
+        errors="replace",
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, (
+        f"the banner must not crash the run: stderr={result.stderr!r}"
+    )
+    assert "Support Maigret" in result.stdout, (
+        f"the banner must still be printed: stdout={result.stdout!r}"
+    )


### PR DESCRIPTION
## The crash

On a Windows box whose ANSI codepage is not UTF-8 — cp1252 is the default install — maigret dies before it checks a single site:

```
UnicodeEncodeError: 'charmap' codec can't encode character '♥'
  in position 1: character maps to <undefined>
```

`_format_donate_banner` puts `♥` (U+2665) in the text, and `print()` encodes with the codepage Python took for stdout. Reproduced on current `main` (`5059b4b`):

```
PYTHONIOENCODING=cp1252   returncode=1   UnicodeEncodeError: '♥'
PYTHONIOENCODING=utf-8    returncode=0
```

Two things make it worse than it first looks:

- **`--no-color` does not help.** The character is in *both* branches of the formatter, the plain one included, so the obvious workaround for a terminal problem does nothing.
- **`PYTHONIOENCODING` cannot rescue the packaged build.** `maigret_standalone.exe` is a PyInstaller bundle, and PyInstaller strips `PYTHON*` variables from the child environment. `chcp 65001` does not help either — it changes the console codepage, not the ANSI codepage Python reads. So for a user of the released binary there is no way around this from outside the process.

The banner prints unconditionally at startup, so the effect is that maigret does not run at all on those machines.

## The fix

`_print_encodable` catches the failing write and re-renders the text in something the stream can hold, so the banner degrades instead of taking the process down.

Catching the write rather than reconfiguring the stream is deliberate, and it is the part I would most like a second opinion on. `colorama.init()` — called from `QueryNotifyPrint.__init__` — replaces `sys.stdout` with a wrapper that has no `.reconfigure()`, so a stream-level fix only works if it runs first, and it would then quietly stop working the moment something constructs a notifier earlier. Catching the write does not depend on ordering.

Both banners go through it. `_format_donate_banner` also carries an em dash, which cp1252 happens to have but several other codepages do not, so it is covered by the same guard rather than by a second special case.

## Test

`test_banners_survive_a_stdout_that_cannot_encode_them` runs the banners in a child process whose stdout really is cp1252, rather than mocking the failure — so it fails on any machine if the guard goes, not only on a Windows one. It follows the child-process shape already used by `test_debug_response_logging_writes_non_ascii_page`.

**Mutation-checked.** Restoring the plain `print()` on the donate banner:

```
FAILED tests/test_notify.py::test_banners_survive_a_stdout_that_cannot_encode_them
1 failed, 14 deselected
```

Restored: `15 passed`.

## Notes on the lint gates

- `flake8 --select=E9,F63,F7,F82` (the blocking pass): **0**.
- `mypy --check-untyped-defs maigret/notify.py`: one error, `Library stubs not installed for "colorama"`, which reproduces unchanged on `main`.
- `flake8` warning pass reports `E401` at `tests/test_notify.py:134` and `E303` at `:182`. Both reproduce identically on unmodified `main` — my test starts at line 209.
- I did **not** run `make format`. `black --check` (26.5.1, inside the pinned `>=25.1,<27.0`) already fails on unmodified `maigret/notify.py` and `tests/test_notify.py`, and the reformatting it wants is in code I did not touch. It also wants to restyle the existing `textwrap.dedent(` calls in `tests/test_checking.py`, which is the shape my test copied. Running it would have buried this change in unrelated churn, so I matched the surrounding style instead. Happy to run it if you would rather the branch be formatted with a specific version.

## Other sites of the same class, not touched here

`ai.py:37` uses a braille spinner and `checking.py` uses `→` in verbose messages. Both are behind flags rather than on the startup path, so they are a smaller problem than this one, and folding them in would mean routing several unrelated call sites through the new helper in the same change. Happy to follow up if you want them covered.
