### PR TITLE
Fix Cash App URL matching in recursive search

### DIFF
--- a/maigret/utils.py
+++ b/maigret/utils.py
@@ -50,7 +50,7 @@ def enrich_link_str(link: str) -> str:
 class URLMatcher:
     _HTTP_URL_RE_STR = r"^https?://(www\.|m\.)?(.+)$"
     HTTP_URL_RE = re.compile(_HTTP_URL_RE_STR)
-    UNSAFE_SYMBOLS = ".?"
+    UNSAFE_SYMBOLS = ".?$"
 
     @classmethod
     def extract_main_part(self, url: str) -> str:

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -184,6 +184,21 @@ def test_extract_id_from_url_skips_none_groups():
     )
 
 
+def test_extract_id_from_url_handles_literal_dollar_prefix():
+    site = MaigretSite(
+        "Cash App",
+        {
+            "urlMain": "https://cash.app",
+            "url": "https://cash.app/${username}",
+        },
+    )
+
+    assert site.extract_id_from_url("https://cash.app/$alice") == (
+        "alice",
+        "username",
+    )
+
+
 def test_ranked_sites_dict():
     db = MaigretDatabase()
     db.update_site(MaigretSite('3', {'alexaRank': 1000, 'engine': 'ucoz'}))


### PR DESCRIPTION
## Summary
- escape the literal dollar sign when compiling profile URL templates
- restore username extraction from Cash App links such as `https://cash.app/$alice`
- add a focused regression test for dollar-prefixed profile paths

## Testing
- `python -m pytest tests/test_utils.py tests/test_sites.py -q` (48 passed)
- verified extraction against the bundled site database