### PR TITLE
Keep result lines from crashing on a non-UTF-8 stdout

### DIFF
--- a/maigret/ai.py
+++ b/maigret/ai.py
@@ -31,15 +31,34 @@ def resolve_api_key(settings) -> str | None:
     return os.environ.get("OPENAI_API_KEY")
 
 
+def _frames_for(stream, frames, fallback):
+    """Pick a frame set the stream can actually render.
+
+    The braille frames are not in cp1252, the ANSI codepage of a stock Windows
+    install, so writing one raised UnicodeEncodeError inside the spinner's
+    daemon thread: the thread died with a traceback over the output and the
+    animation stopped for the rest of the run. Encoding with replacement would
+    only leave a row of '?' spinning, so fall back to frames that carry.
+    """
+    encoding = getattr(stream, "encoding", None) or "ascii"
+    try:
+        "".join(frames).encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return fallback
+    return frames
+
+
 class _Spinner:
     """Simple animated spinner for terminal output."""
 
     FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    ASCII_FRAMES = ["|", "/", "-", "\\"]
 
     def __init__(self, text=""):
         self.text = text
         self._stop = threading.Event()
         self._thread = None
+        self._frames = _frames_for(sys.stderr, self.FRAMES, self.ASCII_FRAMES)
 
     def start(self):
         self._thread = threading.Thread(target=self._spin, daemon=True)
@@ -48,7 +67,7 @@ class _Spinner:
     def _spin(self):
         i = 0
         while not self._stop.is_set():
-            frame = self.FRAMES[i % len(self.FRAMES)]
+            frame = self._frames[i % len(self._frames)]
             sys.stderr.write(f"\r{frame} {self.text}")
             sys.stderr.flush()
             i += 1

--- a/maigret/notify.py
+++ b/maigret/notify.py
@@ -95,7 +95,7 @@ class QueryNotifyPrint:
 
         title = f"Checking {id_type}"
         if self.color:
-            print(
+            _print_encodable(
                 Style.BRIGHT
                 + Fore.GREEN
                 + "["
@@ -109,7 +109,7 @@ class QueryNotifyPrint:
                 + " on:"
             )
         else:
-            print(f"[*] {title} {message} on:")
+            _print_encodable(f"[*] {title} {message} on:")
 
     def finish(self, message=None):
         # Hook called at the end of a run. Currently a no-op; kept on the
@@ -118,9 +118,9 @@ class QueryNotifyPrint:
 
     def _colored_print(self, fore_color, msg):
         if self.color:
-            print(Style.BRIGHT + fore_color + msg)
+            _print_encodable(Style.BRIGHT + fore_color + msg)
         else:
-            print(msg)
+            _print_encodable(msg)
 
     def success(self, message, symbol="+"):
         msg = f"[{symbol}] {message}"
@@ -134,7 +134,7 @@ class QueryNotifyPrint:
         if advice and self.color:
             # Bold + yellow for the count line; turn off bold for the advice
             # but keep the yellow until the line is reset at the end.
-            print(
+            _print_encodable(
                 Style.BRIGHT + Fore.YELLOW + msg
                 + Style.NORMAL + ". " + advice
                 + Style.RESET_ALL
@@ -142,7 +142,7 @@ class QueryNotifyPrint:
         elif advice:
             # No-colour mode: dot separator is enough to distinguish the
             # parts, no ANSI codes leak into the output.
-            print(f"{msg}. {advice}")
+            _print_encodable(f"{msg}. {advice}")
         else:
             self._colored_print(Fore.YELLOW, msg)
 
@@ -249,7 +249,7 @@ class QueryNotifyPrint:
 
         if notify:
             sys.stdout.write("\x1b[1K\r")
-            print(notify)
+            _print_encodable(notify)
 
         return notify
 
@@ -280,6 +280,12 @@ def _print_encodable(text: str) -> None:
     before a single site was checked, and --no-color did not help because
     the character sits in that branch too. PYTHONIOENCODING cannot rescue
     the PyInstaller build, which ignores PYTHON* environment variables.
+
+    Every line this module writes goes through here for the same reason.
+    A run reaches text the codepage cannot hold in two ordinary ways: the
+    --enrich notifications built in checking.py carry U+2192, and extracted
+    profile fields carry whatever script the page was written in. Both
+    arrive mid-scan, so the crash discarded work already done.
 
     Catching the write rather than reconfiguring the stream is deliberate:
     colorama's init() replaces sys.stdout with a wrapper that has no

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,80 @@
+"""Tests for maigret.ai terminal output."""
+
+import os
+import subprocess
+import sys
+
+
+def _run_probe(tmp_path, name, lines, encoding):
+    """Run a probe in a child process whose streams really use `encoding`.
+
+    Forcing the encoding rather than mocking the failure is deliberate: this then
+    fails on any machine if the guard goes, the same way the banner test does.
+    """
+    probe = tmp_path / name
+    probe.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = encoding
+    return subprocess.run(
+        [sys.executable, str(probe)],
+        capture_output=True,
+        encoding=encoding,
+        errors="replace",
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+
+def test_spinner_renders_on_a_stderr_that_cannot_encode_braille(tmp_path):
+    """The spinner frames are braille, which cp1252 -- the ANSI codepage of a
+    stock Windows install -- cannot encode. Writing one raised UnicodeEncodeError
+    inside the spinner's daemon thread: the thread died with a traceback printed
+    over the output, and the animation stopped for the rest of the run.
+    """
+    result = _run_probe(
+        tmp_path,
+        "spinner_probe.py",
+        [
+            "import sys, time",
+            "from maigret.ai import _Spinner",
+            "",
+            "spinner = _Spinner('probe')",
+            "spinner.start()",
+            "time.sleep(0.3)",
+            "spinner.stop()",
+            "sys.stdout.write('FRAMES=' + ''.join(spinner._frames) + chr(10))",
+            "sys.stdout.write('STILL_RUNNING=' + str(spinner._thread.is_alive()) + chr(10))",
+            "sys.stdout.write('REACHED_END' + chr(10))",
+        ],
+        "cp1252",
+    )
+
+    assert result.returncode == 0, f"the spinner must not crash the run: stderr={result.stderr!r}"
+    assert "REACHED_END" in result.stdout, f"stdout={result.stdout!r}"
+    # The daemon thread swallows nothing: an encode failure surfaces as a
+    # traceback on stderr and leaves the spinner dead for the rest of the run.
+    assert "UnicodeEncodeError" not in result.stderr, f"stderr={result.stderr!r}"
+    assert "Exception in thread" not in result.stderr, f"stderr={result.stderr!r}"
+    # It still animates, using frames the stream can carry.
+    assert "FRAMES=|/-\\" in result.stdout, f"stdout={result.stdout!r}"
+
+
+def test_spinner_keeps_its_braille_when_the_stream_can_encode_it(tmp_path):
+    """The frame set is chosen from the stream, not swapped unconditionally: a
+    UTF-8 terminal must still get the original animation."""
+    result = _run_probe(
+        tmp_path,
+        "spinner_utf8_probe.py",
+        [
+            "import sys",
+            "from maigret.ai import _Spinner",
+            "",
+            "sys.stdout.write('FRAMES=' + ''.join(_Spinner('probe')._frames) + chr(10))",
+        ],
+        "utf-8",
+    )
+
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+    braille = "".join(["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
+    assert f"FRAMES={braille}" in result.stdout, f"stdout={result.stdout!r}"

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -253,3 +253,69 @@ def test_banners_survive_a_stdout_that_cannot_encode_them(tmp_path):
     assert "Support Maigret" in result.stdout, (
         f"the banner must still be printed: stdout={result.stdout!r}"
     )
+
+
+def test_result_lines_survive_a_stdout_that_cannot_encode_them(tmp_path):
+    """The banner was not the only line the Windows ANSI codepage can break.
+
+    Two ordinary things a run prints carry characters cp1252 has no slot for:
+    the --enrich notifications built in checking.py contain U+2192, and any
+    profile field extracted from a page carries the script that page is
+    written in. Both arrive mid-scan, so the crash threw away work already
+    done rather than failing at startup.
+
+    Run them in a child process whose stdout really is cp1252, the same way
+    the banner test does, so this fails on any machine if the guard goes.
+    """
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    probe = tmp_path / "result_probe.py"
+    probe.write_text(
+        textwrap.dedent(
+            """
+            from maigret.notify import QueryNotifyPrint
+            from maigret.result import MaigretCheckStatus, MaigretCheckResult
+
+            for color in (False, True):
+                n = QueryNotifyPrint(color=color)
+                n.enrich("VK: https://vk.com/x → status=404, empty body")
+                n.update(
+                    MaigretCheckResult(
+                        username="tester",
+                        status=MaigretCheckStatus.CLAIMED,
+                        site_name="VK",
+                        site_url_user="https://vk.com/tester",
+                        ids_data={"fullname": "Иван", "city": "東京"},
+                    )
+                )
+                n.warning("2 sites failed", advice="rerun with → --retries 3")
+                n.info("done")
+            print("REACHED_END")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"
+    result = subprocess.run(
+        [sys.executable, str(probe)],
+        capture_output=True,
+        encoding="cp1252",
+        errors="replace",
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, (
+        f"a result line must not crash the run: stderr={result.stderr!r}"
+    )
+    assert "REACHED_END" in result.stdout, (
+        f"the run must reach the end: stdout={result.stdout!r}"
+    )
+    assert "vk.com/tester" in result.stdout, (
+        f"the result itself must still be printed: stdout={result.stdout!r}"
+    )


### PR DESCRIPTION
Follow-up to #3050. That PR stopped the startup banners from crashing on a Windows console, but the banner was not the only line the ANSI codepage can break — and the remaining ones are worse, because they arrive **mid-scan**, after the network work is done, so the crash throws away results the run already collected.

## What still crashed

I probed each realistic trigger against a real cp1252 stdout rather than guessing:

| printed thing | before |
|---|---|
| `enrich()` message containing `→` | **UnicodeEncodeError** `'→'` |
| result line carrying an extracted profile field (`fullname`, `city`) | **UnicodeEncodeError** |
| a username in a non-Latin script | fine — the claimed-status line does not include it |
| plain ASCII result | fine |

The arrow is not user data, it is in the source: `checking.py` lines 1847, 1851, 1859 and 1899 all build `f"{site.name}: {mut_url} → …"`. The extracted fields are the whole point of `--enrich` — a Russian or Japanese profile produces them by design.

One thing I checked and it is *not* the trigger: site names. Of the 3404 sites in the shipped database only 2 have a non-ASCII name, and cp1252 can encode both. I had assumed otherwise until I counted.

## The fix

Every write in `notify.py` now goes through the `_print_encodable` helper #3050 already added — the seven remaining bare `print()` calls, including `_colored_print`, which is what `success` / `warning` / `info` / `enrich` all funnel into.

## Test

`test_result_lines_survive_a_stdout_that_cannot_encode_them` runs the enrich line, an extracted-field result, a warning and an info line in a child process whose stdout really is cp1252 — same shape as the banner test from #3050, so it fails on any machine if the guard goes, in both colour and `--no-color` mode.

Putting a bare `print()` back on either path fails it:

| mutation | result |
|---|---|
| `print(notify)` on the result path | 1 failed |
| `print(...)` in `_colored_print` | 1 failed |

```
pytest tests/test_notify.py                        16 passed
pytest tests/ --ignore=tests/test_maigret.py       360 passed, 259 pre-existing failures
```

Those 259 are identical before and after this branch — I diffed the failing test names against a clean tree, and the set matches exactly. They are Windows-environment failures (`tests/test_maigret.py` cannot even be collected here: `os.geteuid` does not exist on Windows). CI runs `pytest` on Linux, where I expect them not to appear.

`flake8` reports the same four findings before and after, none in the changed lines. My local `black` is newer than the repo's style and wants to reformat the `textwrap.dedent` block in *both* this test and the already-merged banner test from #3050 the same way, so I matched the merged code rather than diverging from it.


---

## Update — this now closes #3055 in full

Thanks for filing #3055 and for the review on #3050. This PR already covered the first half of it (the `→` in `checking.py`, which travels `notify` → `enrich` → `_colored_print` → a bare `print()`); the spinner is now in too.

**`ai.py`, the spinner frames.** Encoding with replacement would leave a row of `?` spinning, which is no better than a dead spinner, so the frame set is chosen from what the stream can carry:

```python
self._frames = _frames_for(sys.stderr, self.FRAMES, self.ASCII_FRAMES)
```

A UTF-8 terminal keeps the braille; cp1252 gets `|/-\` and still animates. Measured in a child process on a real cp1252 stderr:

```
cp1252  frames=|/-\        thread alive, no traceback
utf-8   frames=⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏  unchanged
```

Two tests in a new `tests/test_ai.py`, both driving a real child process rather than mocking the encoder. Reverting either direction fails one:

| mutation | result |
|---|---|
| always use the braille frames | 1 failed (cp1252 case) |
| always use the ASCII frames | 1 failed (utf-8 case) |

**One place I did not touch.** `print_streaming()` in the same module writes model output to stdout word by word and would raise on any non-Latin reply — same class, third instance. It has **no callers anywhere in the tree**, so I left it: fixing dead code adds diff without fixing a user's run. Happy to include it if you would rather it be safe before something wires it up.

```
pytest tests/test_ai.py tests/test_notify.py        18 passed
pytest tests/ --ignore=tests/test_maigret.py       259 pre-existing failures, unchanged
flake8 maigret/ai.py tests/test_ai.py              clean
```

The 259 are the Windows-environment failures noted above — identical set before and after this branch. `tests/test_maigret.py` still cannot be collected here (`os.geteuid` does not exist on Windows).

Closes #3055.
