### PR TITLE
[LAPOINTE] Add 11 sites

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -45923,6 +45923,157 @@
             "usernameUnclaimed": "noonewouldeverusethis7",
             "url": "https://skeptikon.fr/a/{username}",
             "checkType": "status_code"
+        },
+        "f1-forum.fi": {
+            "tags": [
+                "discussion",
+                "fi",
+                "forum",
+                "sport"
+            ],
+            "urlMain": "https://f1-forum.fi",
+            "usernameClaimed": "Mosse",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "ffhl.kld.im": {
+            "tags": [
+                "discussion",
+                "fi",
+                "forum",
+                "sport"
+            ],
+            "urlMain": "https://ffhl.kld.im",
+            "usernameClaimed": "hyllevi",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "forum.elektrolab.eu": {
+            "tags": [
+                "discussion",
+                "forum",
+                "sk",
+                "tech"
+            ],
+            "urlMain": "https://forum.elektrolab.eu",
+            "usernameClaimed": "oneeeeee",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "forum.konsolifin.net": {
+            "tags": [
+                "discussion",
+                "fi",
+                "forum",
+                "gaming"
+            ],
+            "urlMain": "https://forum.konsolifin.net",
+            "usernameClaimed": "Nisupulla",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "gennisi.gr": {
+            "tags": [
+                "discussion",
+                "forum",
+                "gr",
+                "news"
+            ],
+            "urlMain": "https://gennisi.gr",
+            "usernameClaimed": "Apostolos",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://gennisi.gr/memberlist.php?mode=viewprofile&un={username}",
+            "checkType": "status_code"
+        },
+        "kellofoorumi.fi": {
+            "tags": [
+                "discussion",
+                "fi",
+                "forum",
+                "hobby"
+            ],
+            "urlMain": "https://kellofoorumi.fi",
+            "usernameClaimed": "JakubL",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "keskustelu.jatkoaika.com": {
+            "tags": [
+                "discussion",
+                "fi",
+                "forum",
+                "sport"
+            ],
+            "urlMain": "https://keskustelu.jatkoaika.com",
+            "usernameClaimed": "GellynKuti",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "tech247.fi": {
+            "tags": [
+                "discussion",
+                "fi",
+                "forum",
+                "tech"
+            ],
+            "urlMain": "https://tech247.fi",
+            "usernameClaimed": "Tsaari",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "xn--lnforum-exa.se": {
+            "tags": [
+                "discussion",
+                "finance",
+                "forum",
+                "se"
+            ],
+            "urlMain": "https://xn--lnforum-exa.se",
+            "usernameClaimed": "Terry_",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "klocksnack.se": {
+            "tags": [
+                "discussion",
+                "forum",
+                "hobby",
+                "se"
+            ],
+            "urlMain": "https://klocksnack.se",
+            "usernameClaimed": "jabla",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://klocksnack.se/members/?username={username}",
+            "checkType": "message",
+            "absenceStrs": [
+                "Nämnvärda medlemmar"
+            ],
+            "presenseStrs": [
+                "data-template=\"login\"",
+                "memberHeader-content"
+            ],
+            "ignore403": true
+        },
+        "ilvesfoorumi.com": {
+            "tags": [
+                "discussion",
+                "fi",
+                "forum",
+                "sport"
+            ],
+            "urlMain": "https://ilvesfoorumi.com",
+            "usernameClaimed": "Toutain",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://ilvesfoorumi.com/members/?username={username}",
+            "checkType": "message",
+            "absenceStrs": [
+                "Merkittävät jäsenet"
+            ],
+            "presenseStrs": [
+                "memberHeader-content",
+                "data-template=\"login\""
+            ],
+            "ignore403": true
         }
     },
     "engines": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-08-31T05:25:34Z",
-    "sites_count": 3404,
+    "updated_at": "2026-08-31T15:37:20Z",
+    "sites_count": 3415,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "87207de6d9e281d4cd28cbef3b8d32570b052ce12918c59617b2b0d26fb9a10d",
+    "data_sha256": "45810129f54a07e0ca21398951644b83d861688e46825873811dae8ac8f59aae",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3404
+## List of supported sites (search methods): total 3415
 
 Rank data fetched from Majestic Million by domains.
 
@@ -3407,17 +3407,28 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://pari.cafe) [pari.cafe (https://pari.cafe)](https://pari.cafe)*: top 100M, anime, social, tw*
 1. ![](https://www.google.com/s2/favicons?domain=https://pawoo.net) [pawoo.net (https://pawoo.net)](https://pawoo.net)*: top 100M, art, jp, mastodon, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://skeptikon.fr) [skeptikon.fr (https://skeptikon.fr)](https://skeptikon.fr)*: top 100M, fr, science, video*
+1. ![](https://www.google.com/s2/favicons?domain=https://f1-forum.fi) [f1-forum.fi (https://f1-forum.fi)](https://f1-forum.fi)*: top 100M, discussion, fi, forum, sport*
+1. ![](https://www.google.com/s2/favicons?domain=https://ffhl.kld.im) [ffhl.kld.im (https://ffhl.kld.im)](https://ffhl.kld.im)*: top 100M, discussion, fi, forum, sport*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.elektrolab.eu) [forum.elektrolab.eu (https://forum.elektrolab.eu)](https://forum.elektrolab.eu)*: top 100M, discussion, forum, sk, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://forum.konsolifin.net) [forum.konsolifin.net (https://forum.konsolifin.net)](https://forum.konsolifin.net)*: top 100M, discussion, fi, forum, gaming*
+1. ![](https://www.google.com/s2/favicons?domain=https://gennisi.gr) [gennisi.gr (https://gennisi.gr)](https://gennisi.gr)*: top 100M, discussion, forum, gr, news*
+1. ![](https://www.google.com/s2/favicons?domain=https://kellofoorumi.fi) [kellofoorumi.fi (https://kellofoorumi.fi)](https://kellofoorumi.fi)*: top 100M, discussion, fi, forum, hobby*
+1. ![](https://www.google.com/s2/favicons?domain=https://keskustelu.jatkoaika.com) [keskustelu.jatkoaika.com (https://keskustelu.jatkoaika.com)](https://keskustelu.jatkoaika.com)*: top 100M, discussion, fi, forum, sport*
+1. ![](https://www.google.com/s2/favicons?domain=https://tech247.fi) [tech247.fi (https://tech247.fi)](https://tech247.fi)*: top 100M, discussion, fi, forum, tech*
+1. ![](https://www.google.com/s2/favicons?domain=https://xn--lnforum-exa.se) [xn--lnforum-exa.se (https://xn--lnforum-exa.se)](https://xn--lnforum-exa.se)*: top 100M, discussion, finance, forum, se*
+1. ![](https://www.google.com/s2/favicons?domain=https://klocksnack.se) [klocksnack.se (https://klocksnack.se)](https://klocksnack.se)*: top 100M, discussion, forum, hobby, se*
+1. ![](https://www.google.com/s2/favicons?domain=https://ilvesfoorumi.com) [ilvesfoorumi.com (https://ilvesfoorumi.com)](https://ilvesfoorumi.com)*: top 100M, discussion, fi, forum, sport*
 
 The list was updated at (2026-08-31)
 ## Statistics
 
-Enabled/total sites: 2711/3404 = 79.64%
+Enabled/total sites: 2722/3415 = 79.71%
 
-Incomplete message checks: 352/2711 = 12.98% (false positive risks)
+Incomplete message checks: 352/2722 = 12.93% (false positive risks)
 
-Status code checks: 761/2711 = 28.07% (false positive risks)
+Status code checks: 762/2722 = 27.99% (false positive risks)
 
-False positive risk (total): 41.05%
+False positive risk (total): 40.92%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, en.brickimedia.org, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, habbo.com.br, habbo.com.tr, hiveos.farm, iNaturalist, nightbot, notabug.org, openframeworks, programming.dev, qiwi.me (disabled), sourceruns, support.ilovegrowingmarijuana.com
 
@@ -3426,7 +3437,7 @@ Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSea
 Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
 - (337)	`/{username}`
-- (272)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
+- (280)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
 - (206)	`/user/{username}`
 - (149)	`/profile/{username}`
 - (127)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
@@ -3437,7 +3448,7 @@ Top 20 profile URLs:
 - (81)	`/@{username}`
 - (60)	`/wiki/User:{username}`
 - (48)	`SUBDOMAIN`
-- (42)	`/members/?username={username}`
+- (44)	`/members/?username={username}`
 - (32)	`/author/{username}`
 - (29)	`/members/{username}`
 - (29)	`{urlMain}{urlSubpath}/memberlist.php?username={username} (phpBB)`
@@ -3448,7 +3459,7 @@ Top 20 profile URLs:
 
 Sites by engine:
 - `uCoz`: 633/709 (89.3%)
-- `XenForo`: 222/272 (81.6%)
+- `XenForo`: 230/280 (82.1%)
 - `vBulletin`: 34/127 (26.8%)
 - `phpBB/Search`: 117/126 (92.9%)
 - `Discourse`: 77/85 (90.6%)
@@ -3465,19 +3476,19 @@ Sites by engine:
 
 
 Top 20 tags:
-- (1377)	`forum`
+- (1388)	`forum`
 - (463)	`social`
-- (396)	`gaming`
-- (390)	`discussion`
-- (326)	`tech`
+- (401)	`discussion`
+- (397)	`gaming`
+- (328)	`tech`
 - (215)	`education`
 - (212)	`coding`
 - (208)	`business`
-- (186)	`hobby`
+- (188)	`hobby`
 - (137)	`apps`
 - (131)	`music`
 - (123)	`blog`
-- (110)	`news`
+- (111)	`news`
 - (106)	`art`
 - (92)	`sharing`
 - (87)	`auto`


### PR DESCRIPTION
Adds 11 sites.

| site | engine | tags |
|---|---|---|
| f1-forum.fi | XenForo | forum, discussion, fi, sport |
| ffhl.kld.im | XenForo | forum, discussion, fi, sport |
| forum.elektrolab.eu | XenForo | forum, discussion, sk, tech |
| forum.konsolifin.net | XenForo | forum, discussion, fi, gaming |
| gennisi.gr | — | forum, discussion, gr, news |
| kellofoorumi.fi | XenForo | forum, discussion, fi, hobby |
| keskustelu.jatkoaika.com | XenForo | forum, discussion, fi, sport |
| tech247.fi | XenForo | forum, discussion, fi, tech |
| xn--lnforum-exa.se | XenForo | forum, discussion, se, finance |
| klocksnack.se | — | forum, discussion, se, hobby |
| ilvesfoorumi.com | — | forum, discussion, fi, sport |
