### PR TITLE
Add OSDev Website

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -46074,6 +46074,24 @@
                 "data-template=\"login\""
             ],
             "ignore403": true
+        },
+        "OSDev": {
+            "tags": [
+                "coding",
+                "tech"
+            ],
+            "urlMain": "https://wiki.osdev.org",
+            "usernameClaimed": "Admin",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wiki.osdev.org/User:{username}",
+            "urlProbe": "https://wiki.osdev.org/api.php?action=query&list=users&ususers={username}&format=json",
+            "checkType": "message",
+            "presenceStrs": [
+                "\"userid\":"
+            ],
+            "absenceStrs": [
+                "\"missing\":"
+            ]
         }
     },
     "engines": {


### PR DESCRIPTION
# Summary
Adds wiki.osdev.org as a supported wesbite

# Testing
I tested the website using this data:

Claimed Username: ```Admin```
Unclaimed Username: ```noonewouldeverusethis7```


urlProbe: ```https://wiki.osdev.org/api.php?action=query&list=users&ususers={username}&format=json```
presenceStrs: ```"\"userid\":"```
absenceStrs: ```"\"missing\":"```


Tags: ```coding, tech```