### PR TITLE
Percent-encode the username when building a site's probe URL

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -1037,10 +1037,13 @@ def make_site_result(
         else:
             # There is a special URL for probing existence separate
             # from where the user profile normally can be found.
+            # Encode the username here just like the display URL above does:
+            # a raw "#" otherwise turns the rest of it into a fragment and the
+            # probe silently lands on a different account's URL.
             url_probe = url_probe.format(
                 urlMain=site.url_main,
                 urlSubpath=site.url_subpath,
-                username=username,
+                username=quote(username),
             )
 
         for k, v in site.get_params.items():

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 import subprocess
 import sys
 import textwrap
@@ -20,6 +21,7 @@ from maigret.checking import (
     debug_response_logging,
     process_site_result,
     check_site_for_username,
+    make_site_result,
     run_url_mutations,
     _canonical_url,
     _domain_tail,
@@ -1998,3 +2000,96 @@ def test_normalize_proxy_scheme(transport, given, expected):
     from maigret.checking import normalize_proxy_scheme
 
     assert normalize_proxy_scheme(given, transport) == expected
+
+
+class _ProbeRecordingChecker:
+    """Records the URL it was asked to fetch.
+
+    Deliberately not a CheckerMock subclass: make_site_result treats a
+    CheckerMock as "no gateway configured" and marks the site illegal
+    before it ever builds the probe URL.
+    """
+
+    def __init__(self):
+        self.urls_seen = []
+
+    def prepare(self, url, **kwargs):
+        self.urls_seen.append(url)
+        return None
+
+    async def check(self):
+        return '', 200, None
+
+    async def close(self):
+        return
+
+
+def _url_probe_site():
+    return MaigretSite(
+        "ProbeAPI",
+        {
+            "checkType": "status_code",
+            "urlMain": "http://localhost:8989/",
+            "url": "http://localhost:8989/{username}",
+            "urlProbe": "http://localhost:8989/api/users/{username}",
+            "usernameClaimed": "user",
+            "usernameUnclaimed": "nosuchuser",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "username, expected_probe",
+    [
+        # a plain username must come out byte-identical to before
+        ("user", "http://localhost:8989/api/users/user"),
+        # "#" used to end the URL and turn the rest into a fragment
+        ("user#1234", "http://localhost:8989/api/users/user%231234"),
+        # "?" used to start a query string
+        ("user?x=1", "http://localhost:8989/api/users/user%3Fx%3D1"),
+    ],
+)
+def test_url_probe_username_is_percent_encoded(username, expected_probe):
+    """urlProbe has to encode the username the same way the display URL does."""
+    checker = _ProbeRecordingChecker()
+    options = {
+        "id_type": "username",
+        "parsing": False,
+        "timeout": 1,
+        "forced": False,
+        "checkers": {"": lambda: checker},
+    }
+
+    results = make_site_result(_url_probe_site(), username, options, Mock())
+
+    assert results["url_probe"] == expected_probe
+    # and that is really the URL handed to the checker, not just a report field
+    assert checker.urls_seen == [expected_probe]
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_url_probe_fragment_does_not_probe_another_account(httpserver):
+    """A "#" in the username must not make the probe land on another account."""
+    # only the real account "user" exists on this API, everything else is a 404
+    httpserver.expect_request("/api/users/user").respond_with_data("{}", status=200)
+    httpserver.expect_request(re.compile("^/api/users/")).respond_with_data(
+        "{}", status=404
+    )
+
+    results = await search(
+        "user#1234",
+        site_dict={"ProbeAPI": _url_probe_site()},
+        logger=Mock(),
+        timeout=5,
+        no_progressbar=True,
+    )
+
+    requested = [request.path for request, _ in httpserver.log]
+    # the request really happened, so this cannot pass just because the
+    # server was never reached
+    assert len(requested) == 1
+    # the whole username stayed in the path segment; before the fix the server
+    # saw "/api/users/user" and answered 200 for somebody else's account
+    assert requested == ["/api/users/user#1234"]
+    assert results["ProbeAPI"]["status"].is_found() is False


### PR DESCRIPTION
`make_site_result` builds the display URL with `quote(username)`, but builds the probe URL a few lines below with a bare `format()`. So on any site that has a `urlProbe`, a username containing a URL-significant character produces a malformed request.

`#` is the bad one. It ends the URL and turns the rest of the username into a fragment, so the probe goes to a different account and the site comes back claimed.

Local API that only has an account called `user`, searching for `user#1234`:

before
```
probe url  : http://localhost:8989/api/users/user#1234
server got : GET /api/users/user -> 200
verdict    : CLAIMED
```

after
```
probe url  : http://localhost:8989/api/users/user%231234
server got : GET /api/users/user%231234 -> 404
verdict    : available
```

`?` goes the same way, the rest of the username becomes a query string.

Of the 98 enabled sites with a `urlProbe`, 85 accept a username like that: 82 have no `regexCheck` at all (Reddit, Instagram, Medium, Gravatar, Scratch, Calendly, GitLab, Bluesky and others) and 3 more have one that allows `#`, including Discord, where `name#1234` is how the handle gets written in the first place. `is_plausible_username` rejects slashes and whitespace but not `#`, so a username picked up during a recursive search reaches this without anyone typing it.

The fix is the `quote()` the display URL already uses. It can't move any existing check: I ran it over every `usernameClaimed` and `usernameUnclaimed` of those sites and it changes none of them.

Tests are three parametrized cases on the probe URL (plain username unchanged, `#`, `?`) plus one end-to-end through a local server checking the request really carries the whole username. The three that matter fail on main and pass here. Nothing else in the suite moves, the only difference before and after is the four new tests.

I left `requestPayload` alone. It formats the username too, but it's a body value and percent-encoding it there would be wrong.
