### PR TITLE
[LAPOINTE] Add 140 sites and a MediaWiki engine

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -48892,6 +48892,1405 @@
             "url": "https://kiwifarms.cc/users/{username}",
             "urlProbe": "https://kiwifarms.cc/.well-known/webfinger?resource=acct:{username}@kiwifarms.cc",
             "checkType": "status_code"
+        },
+        "en.wiki.aktivix.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://en.wiki.aktivix.org",
+            "usernameClaimed": "XavierU30",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.openstreetmap.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.openstreetmap.org",
+            "usernameClaimed": "Leijurv",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "imslp.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://imslp.org",
+            "usernameClaimed": "Hfredrich416hk",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "mariowiki.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://mariowiki.com",
+            "usernameClaimed": "Mari0fan100",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.ead.pucv.cl": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.ead.pucv.cl",
+            "usernameClaimed": "Consuelo.arce.c",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "jarviwiki.fi": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "fi",
+                "wiki"
+            ],
+            "urlMain": "https://jarviwiki.fi",
+            "usernameClaimed": "Kuikkaranta",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "tfwiki.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://tfwiki.net",
+            "usernameClaimed": "Arktffan",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.guildwars2.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.guildwars2.com",
+            "usernameClaimed": "Tery3065",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "drinkiwiki.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://drinkiwiki.com",
+            "usernameClaimed": "Mothical",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "fr.wikimini.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://fr.wikimini.org",
+            "usernameClaimed": "Ananas35",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "yugipedia.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://yugipedia.com",
+            "usernameClaimed": "Ascriptmaster",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.ubc.ca": {
+            "tags": [
+                "ca",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.ubc.ca",
+            "usernameClaimed": "EstherRoorda",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "dustloop.com": {
+            "urlSubpath": "/w",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://dustloop.com",
+            "usernameClaimed": "Quash",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.guildwars.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.guildwars.com",
+            "usernameClaimed": "Litework",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "pzwiki.net": {
+            "urlSubpath": "/wiki/Special:MyLanguage",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://pzwiki.net",
+            "usernameClaimed": "SomethingLikeMe",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "aw-wiki.de": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://aw-wiki.de",
+            "usernameClaimed": "Spurzem",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "imfdb.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://imfdb.org",
+            "usernameClaimed": "XSlayer300",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "pokewiki.de": {
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://pokewiki.de",
+            "usernameClaimed": "Flyfunner",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "coasterpedia.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://coasterpedia.net",
+            "usernameClaimed": "Time93",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "mkwiiki.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://mkwiiki.org",
+            "usernameClaimed": "KantoEpic",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "esolangs.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://esolangs.org",
+            "usernameClaimed": "Miui",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "chakuwiki.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://chakuwiki.org",
+            "usernameClaimed": "Pakaru",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wikidex.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wikidex.net",
+            "usernameClaimed": "Sebasgallo",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "generasia.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://generasia.com",
+            "usernameClaimed": "Emmaxtrbl",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.generasia.com/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "wiki.gentoo.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.gentoo.org",
+            "usernameClaimed": "Winterheart",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "halopedia.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://halopedia.org",
+            "usernameClaimed": "XScruffyDaSasquatchx",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "tmbw.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://tmbw.net",
+            "usernameClaimed": "Zondry",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.starbase118.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.starbase118.net",
+            "usernameClaimed": "Thegilmoreguy80",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.eveuniversity.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.eveuniversity.org",
+            "usernameClaimed": "PilotRep",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "lokalhistoriewiki.no": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "no",
+                "wiki"
+            ],
+            "urlMain": "https://lokalhistoriewiki.no",
+            "usernameClaimed": "Rool",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "pokepedia.fr": {
+            "tags": [
+                "fr",
+                "wiki"
+            ],
+            "urlMain": "https://pokepedia.fr",
+            "usernameClaimed": "Matt.",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "sarna.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://sarna.net",
+            "usernameClaimed": "Nolimitation781",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "sgwiki.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://sgwiki.com",
+            "usernameClaimed": "8549H",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "appropedia.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://appropedia.org",
+            "usernameClaimed": "J.M.Pearce",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "libreplanet.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://libreplanet.org",
+            "usernameClaimed": "Ekokao",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "starbounder.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://starbounder.org",
+            "usernameClaimed": "AlienAgent",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "coppermind.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://coppermind.net",
+            "usernameClaimed": "King of Herdaz",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "de.wiki-aventurica.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://de.wiki-aventurica.de",
+            "usernameClaimed": "StipenTreublatt",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "srw.wiki.cre.jp": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "jp",
+                "wiki"
+            ],
+            "urlMain": "https://srw.wiki.cre.jp",
+            "usernameClaimed": "30XTWY",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "unterrichten.zum.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://unterrichten.zum.de",
+            "usernameClaimed": "Ukalina",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.sn.at": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.sn.at",
+            "usernameClaimed": "Remora",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.ovinnederland.nl": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "nl",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.ovinnederland.nl",
+            "usernameClaimed": "Stationsbordjes",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.osgeo.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.osgeo.org",
+            "usernameClaimed": "Mazingaro",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "tolkiengateway.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://tolkiengateway.net",
+            "usernameClaimed": "Luotiansha",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "khwiki.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://khwiki.com",
+            "usernameClaimed": "NinjaSheik",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "nethackwiki.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://nethackwiki.com",
+            "usernameClaimed": "JohnRDelaney",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.dolibarr.org": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.dolibarr.org",
+            "usernameClaimed": "Eldy",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "fuerthwiki.de": {
+            "urlSubpath": "/wiki/index.php",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://fuerthwiki.de",
+            "usernameClaimed": "Aquilex",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "tibiawiki.com.br": {
+            "tags": [
+                "br",
+                "wiki"
+            ],
+            "urlMain": "https://tibiawiki.com.br",
+            "usernameClaimed": "Ewertoncolombo",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.linuxformat.ru": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "ru",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.linuxformat.ru",
+            "usernameClaimed": "Kededuni",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wikimon.net": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wikimon.net",
+            "usernameClaimed": "Pluvia",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.pumpingstationone.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.pumpingstationone.org",
+            "usernameClaimed": "Jleonardson",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.postgresql.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.postgresql.org",
+            "usernameClaimed": "Law",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "projektwiki.zum.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://projektwiki.zum.de",
+            "usernameClaimed": "LMT0204",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "simpsonswiki.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://simpsonswiki.com",
+            "usernameClaimed": "Wehaveabrownshoe",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "nnov.ec": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://nnov.ec",
+            "usernameClaimed": "Невесомость1",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "fuksiwiki.tko-aly.fi": {
+            "tags": [
+                "fi",
+                "wiki"
+            ],
+            "urlMain": "https://fuksiwiki.tko-aly.fi",
+            "usernameClaimed": "Averio",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "pikminwiki.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://pikminwiki.com",
+            "usernameClaimed": "LoveDoctor",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "revspace.nl": {
+            "tags": [
+                "nl",
+                "wiki"
+            ],
+            "urlMain": "https://revspace.nl",
+            "usernameClaimed": "Ries",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.d-addicts.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.d-addicts.com",
+            "usernameClaimed": "Panwink",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "semantic-mediawiki.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://semantic-mediawiki.org",
+            "usernameClaimed": "Kghbln",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "c64-wiki.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://c64-wiki.de",
+            "usernameClaimed": "Jodigi",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "s4wiki.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://s4wiki.com",
+            "usernameClaimed": "Advancedautomotion",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "ka.stadtwiki.net": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ka.stadtwiki.net",
+            "usernameClaimed": "Suggs",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.darkjedibrotherhood.com": {
+            "urlSubpath": "/view",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.darkjedibrotherhood.com",
+            "usernameClaimed": "Strix",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.hope.net": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.hope.net",
+            "usernameClaimed": "Steveb",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "nl.wikisage.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://nl.wikisage.org",
+            "usernameClaimed": "Mendelo",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "perrypedia.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://perrypedia.de",
+            "usernameClaimed": "Cuore",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "aiowiki.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://aiowiki.com",
+            "usernameClaimed": "Whittaker",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "speedsolving.com": {
+            "tags": [
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://speedsolving.com",
+            "usernameClaimed": "abunickabhi",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "ringofbrodgar.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ringofbrodgar.com",
+            "usernameClaimed": "MvGulik",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "theaterencyclopedie.nl": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "nl",
+                "wiki"
+            ],
+            "urlMain": "https://theaterencyclopedie.nl",
+            "usernameClaimed": "Gewild",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wikimanche.fr": {
+            "tags": [
+                "fr",
+                "wiki"
+            ],
+            "urlMain": "https://wikimanche.fr",
+            "usernameClaimed": "Tesson",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wikiskripta.eu": {
+            "urlSubpath": "/w",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wikiskripta.eu",
+            "usernameClaimed": "JanKozinski",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.multitheftauto.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.multitheftauto.com",
+            "usernameClaimed": "FileEX",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "ethw.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ethw.org",
+            "usernameClaimed": "Prosodico",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wikijournalclub.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wikijournalclub.org",
+            "usernameClaimed": "Tbplante",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "itgamal.app.uib.no": {
+            "tags": [
+                "no",
+                "wiki"
+            ],
+            "urlMain": "https://itgamal.app.uib.no",
+            "usernameClaimed": "Mihho",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.shardsofdalaya.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.shardsofdalaya.com",
+            "usernameClaimed": "Corbenmv1",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "roguebasin.com": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://roguebasin.com",
+            "usernameClaimed": "Rickton",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "fr.nvcwiki.com": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://fr.nvcwiki.com",
+            "usernameClaimed": "Anzieu",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "openei.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://openei.org",
+            "usernameClaimed": "Nikgiovine",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.erepublik.com": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.erepublik.com",
+            "usernameClaimed": "00AngryMobMan00",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "jvflux.fr": {
+            "tags": [
+                "fr",
+                "wiki"
+            ],
+            "urlMain": "https://jvflux.fr",
+            "usernameClaimed": "Orleans",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "marefa.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://marefa.org",
+            "usernameClaimed": "Shafei",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "stampsoftheworld.co.uk": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "gb",
+                "wiki"
+            ],
+            "urlMain": "https://stampsoftheworld.co.uk",
+            "usernameClaimed": "Rayinclover",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "seriewikin.serieframjandet.se": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "se",
+                "wiki"
+            ],
+            "urlMain": "https://seriewikin.serieframjandet.se",
+            "usernameClaimed": "E.G.",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.urbandead.com": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.urbandead.com",
+            "usernameClaimed": "Spiderzed",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.rc-network.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.rc-network.de",
+            "usernameClaimed": "Waltair",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "jedipedia.net": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://jedipedia.net",
+            "usernameClaimed": "Moddi",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "ennstalwiki.at": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ennstalwiki.at",
+            "usernameClaimed": "Ewaldgabardi",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.ennstalwiki.at/wiki/index.php/User:{username}",
+            "checkType": "status_code"
+        },
+        "de.duckipedia.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://de.duckipedia.org",
+            "usernameClaimed": "Mattes",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.antamar.eu": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.antamar.eu",
+            "usernameClaimed": "Camael",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiibrew.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiibrew.org",
+            "usernameClaimed": "Xale00",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.sotahuuto.fi": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "fi",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.sotahuuto.fi",
+            "usernameClaimed": "-TET-",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki-brest.net": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki-brest.net",
+            "usernameClaimed": "Kérébel",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "http://www.wiki-brest.net/index.php/User:{username}",
+            "checkType": "status_code"
+        },
+        "ardapedia.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ardapedia.org",
+            "usernameClaimed": "Alboin",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "middlewiki.midrealm.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://middlewiki.midrealm.org",
+            "usernameClaimed": "Milesent",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "http://middlewiki.midrealm.org/index.php/User:{username}",
+            "checkType": "status_code"
+        },
+        "wiki.armagetronad.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.armagetronad.org",
+            "usernameClaimed": "Goose",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "vanipedia.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://vanipedia.org",
+            "usernameClaimed": "Caitanyadeva",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "ja.yourpedia.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ja.yourpedia.org",
+            "usernameClaimed": "まるまいん",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "dwarffortresswiki.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://dwarffortresswiki.org",
+            "usernameClaimed": "Zippy",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.halo.fr": {
+            "tags": [
+                "fr",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.halo.fr",
+            "usernameClaimed": "VoitureJb",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.ihe.net": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.ihe.net",
+            "usernameClaimed": "Kelliason",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wurmpedia.com": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wurmpedia.com",
+            "usernameClaimed": "Coventina",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.hackmanhattan.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.hackmanhattan.com",
+            "usernameClaimed": "Spaghevin",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wikiindex.org": {
+            "urlSubpath": "/w",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wikiindex.org",
+            "usernameClaimed": "TeraS",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.oroboros.at": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.oroboros.at",
+            "usernameClaimed": "Spoettl Martina",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "fwwiki.de": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://fwwiki.de",
+            "usernameClaimed": "KarlGP",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "nanowiki.no": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "no",
+                "wiki"
+            ],
+            "urlMain": "https://nanowiki.no",
+            "usernameClaimed": "Mettewi",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "csdms.colorado.edu": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://csdms.colorado.edu",
+            "usernameClaimed": "Albert",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "dragon-quest.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://dragon-quest.org",
+            "usernameClaimed": "Follower of Light",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "tuepedia.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://tuepedia.de",
+            "usernameClaimed": "HubertQ",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "hurraki.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://hurraki.de",
+            "usernameClaimed": "Valentin",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "mhwiki.hitgrab.com": {
+            "urlSubpath": "/wiki/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://mhwiki.hitgrab.com",
+            "usernameClaimed": "Xellis",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "theportalwiki.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://theportalwiki.com",
+            "usernameClaimed": "Ritbulau",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "irowiki.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://irowiki.org",
+            "usernameClaimed": "Dewfield",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki-fr.guildwars2.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki-fr.guildwars2.com",
+            "usernameClaimed": "Hved",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "openwaterpedia.com": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://openwaterpedia.com",
+            "usernameClaimed": "Munatones",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "zeldapendium.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://zeldapendium.de",
+            "usernameClaimed": "TwilightPincer",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "moneypedia.de": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://moneypedia.de",
+            "usernameClaimed": "Monique",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.kolmisoft.com": {
+            "urlSubpath": "/index.php",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.kolmisoft.com",
+            "usernameClaimed": "Zinger-AI",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.london.hackspace.org.uk": {
+            "urlSubpath": "/view",
+            "tags": [
+                "gb",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.london.hackspace.org.uk",
+            "usernameClaimed": "Chris-c",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "labviewwiki.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://labviewwiki.org",
+            "usernameClaimed": "MrJim",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.web.ru": {
+            "tags": [
+                "ru",
+                "wiki"
+            ],
+            "urlMain": "https://wiki.web.ru",
+            "usernameClaimed": "Mineralog",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wiki.web.ru/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "theinfosphere.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://theinfosphere.org",
+            "usernameClaimed": "BenderFan",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.selfhtml.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.selfhtml.org",
+            "usernameClaimed": "Bertie",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.avlis.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.avlis.org",
+            "usernameClaimed": "Gorgon",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "libregamewiki.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://libregamewiki.org",
+            "usernameClaimed": "Wuzzy",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "dpbwiki.digitalfreaks.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://dpbwiki.digitalfreaks.org",
+            "usernameClaimed": "Chaos",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "http://dpbwiki.digitalfreaks.org/index.php/User:{username}",
+            "checkType": "status_code"
+        },
+        "hammwiki.info": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://hammwiki.info",
+            "usernameClaimed": "Berntzen",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "muenchenwiki.de": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "de",
+                "wiki"
+            ],
+            "urlMain": "https://muenchenwiki.de",
+            "usernameClaimed": "Wuschel",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "cvillepedia.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://cvillepedia.org",
+            "usernameClaimed": "Punker99",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "ufopaedia.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ufopaedia.org",
+            "usernameClaimed": "PuporonGOD",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "fansub.d-addicts.com": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://fansub.d-addicts.com",
+            "usernameClaimed": "Subie06",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.happylab.at": {
+            "urlSubpath": "/w",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.happylab.at",
+            "usernameClaimed": "Karim",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.apertium.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.apertium.org",
+            "usernameClaimed": "Firespeaker",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "fileformats.archiveteam.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://fileformats.archiveteam.org",
+            "usernameClaimed": "Thorsted",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wikem.org": {
+            "urlSubpath": "/wiki",
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wikem.org",
+            "usernameClaimed": "3amrbadawy",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
+        },
+        "wiki.the-reincarnation.org": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wiki.the-reincarnation.org",
+            "usernameClaimed": "-zipper-",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "MediaWiki"
         }
     },
     "engines": {
@@ -49136,6 +50535,24 @@
             },
             "presenseStrs": [
                 "gdn.meta"
+            ]
+        },
+        "MediaWiki": {
+            "name": "MediaWiki",
+            "site": {
+                "url": "{urlMain}{urlSubpath}/User:{username}",
+                "checkType": "message",
+                "presenseStrs": [
+                    "ns-2",
+                    "mw-body-content"
+                ],
+                "absenceStrs": [
+                    "mw-userpage-userdoesnotexist"
+                ]
+            },
+            "presenseStrs": [
+                "wgCanonicalNamespace",
+                "mw-body-content"
             ]
         }
     },

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-09-01T20:44:22Z",
-    "sites_count": 3653,
+    "updated_at": "2026-09-02T09:09:30Z",
+    "sites_count": 3793,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "2a78ccb8035df464951b662fa49fd25b3123585806d317bf2b644ab3494f5ac0",
+    "data_sha256": "cc8fb35f8d888319a6478b966ccb1c3dca86b2f05ed8f3f9cec9b5d2d121059e",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3653
+## List of supported sites (search methods): total 3793
 
 Rank data fetched from Majestic Million by domains.
 
@@ -3656,17 +3656,157 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://detroitriotcity.com) [detroitriotcity.com (https://detroitriotcity.com)](https://detroitriotcity.com)*: top 100M, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://devs.live) [devs.live (https://devs.live)](https://devs.live)*: top 100M, social*
 1. ![](https://www.google.com/s2/favicons?domain=https://kiwifarms.cc) [kiwifarms.cc (https://kiwifarms.cc)](https://kiwifarms.cc)*: top 100M, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://en.wiki.aktivix.org) [en.wiki.aktivix.org (https://en.wiki.aktivix.org)](https://en.wiki.aktivix.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.openstreetmap.org) [wiki.openstreetmap.org (https://wiki.openstreetmap.org)](https://wiki.openstreetmap.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://imslp.org) [imslp.org (https://imslp.org)](https://imslp.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://mariowiki.com) [mariowiki.com (https://mariowiki.com)](https://mariowiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.ead.pucv.cl) [wiki.ead.pucv.cl (https://wiki.ead.pucv.cl)](https://wiki.ead.pucv.cl)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://jarviwiki.fi) [jarviwiki.fi (https://jarviwiki.fi)](https://jarviwiki.fi)*: top 100M, fi, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://tfwiki.net) [tfwiki.net (https://tfwiki.net)](https://tfwiki.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.guildwars2.com) [wiki.guildwars2.com (https://wiki.guildwars2.com)](https://wiki.guildwars2.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://drinkiwiki.com) [drinkiwiki.com (https://drinkiwiki.com)](https://drinkiwiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fr.wikimini.org) [fr.wikimini.org (https://fr.wikimini.org)](https://fr.wikimini.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://yugipedia.com) [yugipedia.com (https://yugipedia.com)](https://yugipedia.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.ubc.ca) [wiki.ubc.ca (https://wiki.ubc.ca)](https://wiki.ubc.ca)*: top 100M, ca, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://dustloop.com) [dustloop.com (https://dustloop.com)](https://dustloop.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.guildwars.com) [wiki.guildwars.com (https://wiki.guildwars.com)](https://wiki.guildwars.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://pzwiki.net) [pzwiki.net (https://pzwiki.net)](https://pzwiki.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://aw-wiki.de) [aw-wiki.de (https://aw-wiki.de)](https://aw-wiki.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://imfdb.org) [imfdb.org (https://imfdb.org)](https://imfdb.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://pokewiki.de) [pokewiki.de (https://pokewiki.de)](https://pokewiki.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://coasterpedia.net) [coasterpedia.net (https://coasterpedia.net)](https://coasterpedia.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://mkwiiki.org) [mkwiiki.org (https://mkwiiki.org)](https://mkwiiki.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://esolangs.org) [esolangs.org (https://esolangs.org)](https://esolangs.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://chakuwiki.org) [chakuwiki.org (https://chakuwiki.org)](https://chakuwiki.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wikidex.net) [wikidex.net (https://wikidex.net)](https://wikidex.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://generasia.com) [generasia.com (https://generasia.com)](https://generasia.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.gentoo.org) [wiki.gentoo.org (https://wiki.gentoo.org)](https://wiki.gentoo.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://halopedia.org) [halopedia.org (https://halopedia.org)](https://halopedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://tmbw.net) [tmbw.net (https://tmbw.net)](https://tmbw.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.starbase118.net) [wiki.starbase118.net (https://wiki.starbase118.net)](https://wiki.starbase118.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.eveuniversity.org) [wiki.eveuniversity.org (https://wiki.eveuniversity.org)](https://wiki.eveuniversity.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://lokalhistoriewiki.no) [lokalhistoriewiki.no (https://lokalhistoriewiki.no)](https://lokalhistoriewiki.no)*: top 100M, no, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://pokepedia.fr) [pokepedia.fr (https://pokepedia.fr)](https://pokepedia.fr)*: top 100M, fr, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://sarna.net) [sarna.net (https://sarna.net)](https://sarna.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://sgwiki.com) [sgwiki.com (https://sgwiki.com)](https://sgwiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://appropedia.org) [appropedia.org (https://appropedia.org)](https://appropedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://libreplanet.org) [libreplanet.org (https://libreplanet.org)](https://libreplanet.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://starbounder.org) [starbounder.org (https://starbounder.org)](https://starbounder.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://coppermind.net) [coppermind.net (https://coppermind.net)](https://coppermind.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://de.wiki-aventurica.de) [de.wiki-aventurica.de (https://de.wiki-aventurica.de)](https://de.wiki-aventurica.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://srw.wiki.cre.jp) [srw.wiki.cre.jp (https://srw.wiki.cre.jp)](https://srw.wiki.cre.jp)*: top 100M, jp, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://unterrichten.zum.de) [unterrichten.zum.de (https://unterrichten.zum.de)](https://unterrichten.zum.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.sn.at) [wiki.sn.at (https://wiki.sn.at)](https://wiki.sn.at)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.ovinnederland.nl) [wiki.ovinnederland.nl (https://wiki.ovinnederland.nl)](https://wiki.ovinnederland.nl)*: top 100M, nl, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.osgeo.org) [wiki.osgeo.org (https://wiki.osgeo.org)](https://wiki.osgeo.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://tolkiengateway.net) [tolkiengateway.net (https://tolkiengateway.net)](https://tolkiengateway.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://khwiki.com) [khwiki.com (https://khwiki.com)](https://khwiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://nethackwiki.com) [nethackwiki.com (https://nethackwiki.com)](https://nethackwiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.dolibarr.org) [wiki.dolibarr.org (https://wiki.dolibarr.org)](https://wiki.dolibarr.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fuerthwiki.de) [fuerthwiki.de (https://fuerthwiki.de)](https://fuerthwiki.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://tibiawiki.com.br) [tibiawiki.com.br (https://tibiawiki.com.br)](https://tibiawiki.com.br)*: top 100M, br, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.linuxformat.ru) [wiki.linuxformat.ru (https://wiki.linuxformat.ru)](https://wiki.linuxformat.ru)*: top 100M, ru, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wikimon.net) [wikimon.net (https://wikimon.net)](https://wikimon.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.pumpingstationone.org) [wiki.pumpingstationone.org (https://wiki.pumpingstationone.org)](https://wiki.pumpingstationone.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.postgresql.org) [wiki.postgresql.org (https://wiki.postgresql.org)](https://wiki.postgresql.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://projektwiki.zum.de) [projektwiki.zum.de (https://projektwiki.zum.de)](https://projektwiki.zum.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://simpsonswiki.com) [simpsonswiki.com (https://simpsonswiki.com)](https://simpsonswiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://nnov.ec) [nnov.ec (https://nnov.ec)](https://nnov.ec)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fuksiwiki.tko-aly.fi) [fuksiwiki.tko-aly.fi (https://fuksiwiki.tko-aly.fi)](https://fuksiwiki.tko-aly.fi)*: top 100M, fi, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://pikminwiki.com) [pikminwiki.com (https://pikminwiki.com)](https://pikminwiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://revspace.nl) [revspace.nl (https://revspace.nl)](https://revspace.nl)*: top 100M, nl, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.d-addicts.com) [wiki.d-addicts.com (https://wiki.d-addicts.com)](https://wiki.d-addicts.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://semantic-mediawiki.org) [semantic-mediawiki.org (https://semantic-mediawiki.org)](https://semantic-mediawiki.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://c64-wiki.de) [c64-wiki.de (https://c64-wiki.de)](https://c64-wiki.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://s4wiki.com) [s4wiki.com (https://s4wiki.com)](https://s4wiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://ka.stadtwiki.net) [ka.stadtwiki.net (https://ka.stadtwiki.net)](https://ka.stadtwiki.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.darkjedibrotherhood.com) [wiki.darkjedibrotherhood.com (https://wiki.darkjedibrotherhood.com)](https://wiki.darkjedibrotherhood.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.hope.net) [wiki.hope.net (https://wiki.hope.net)](https://wiki.hope.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://nl.wikisage.org) [nl.wikisage.org (https://nl.wikisage.org)](https://nl.wikisage.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://perrypedia.de) [perrypedia.de (https://perrypedia.de)](https://perrypedia.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://aiowiki.com) [aiowiki.com (https://aiowiki.com)](https://aiowiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://speedsolving.com) [speedsolving.com (https://speedsolving.com)](https://speedsolving.com)*: top 100M, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://ringofbrodgar.com) [ringofbrodgar.com (https://ringofbrodgar.com)](https://ringofbrodgar.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://theaterencyclopedie.nl) [theaterencyclopedie.nl (https://theaterencyclopedie.nl)](https://theaterencyclopedie.nl)*: top 100M, nl, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wikimanche.fr) [wikimanche.fr (https://wikimanche.fr)](https://wikimanche.fr)*: top 100M, fr, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wikiskripta.eu) [wikiskripta.eu (https://wikiskripta.eu)](https://wikiskripta.eu)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.multitheftauto.com) [wiki.multitheftauto.com (https://wiki.multitheftauto.com)](https://wiki.multitheftauto.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://ethw.org) [ethw.org (https://ethw.org)](https://ethw.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wikijournalclub.org) [wikijournalclub.org (https://wikijournalclub.org)](https://wikijournalclub.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://itgamal.app.uib.no) [itgamal.app.uib.no (https://itgamal.app.uib.no)](https://itgamal.app.uib.no)*: top 100M, no, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.shardsofdalaya.com) [wiki.shardsofdalaya.com (https://wiki.shardsofdalaya.com)](https://wiki.shardsofdalaya.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://roguebasin.com) [roguebasin.com (https://roguebasin.com)](https://roguebasin.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fr.nvcwiki.com) [fr.nvcwiki.com (https://fr.nvcwiki.com)](https://fr.nvcwiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://openei.org) [openei.org (https://openei.org)](https://openei.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.erepublik.com) [wiki.erepublik.com (https://wiki.erepublik.com)](https://wiki.erepublik.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://jvflux.fr) [jvflux.fr (https://jvflux.fr)](https://jvflux.fr)*: top 100M, fr, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://marefa.org) [marefa.org (https://marefa.org)](https://marefa.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://stampsoftheworld.co.uk) [stampsoftheworld.co.uk (https://stampsoftheworld.co.uk)](https://stampsoftheworld.co.uk)*: top 100M, gb, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://seriewikin.serieframjandet.se) [seriewikin.serieframjandet.se (https://seriewikin.serieframjandet.se)](https://seriewikin.serieframjandet.se)*: top 100M, se, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.urbandead.com) [wiki.urbandead.com (https://wiki.urbandead.com)](https://wiki.urbandead.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.rc-network.de) [wiki.rc-network.de (https://wiki.rc-network.de)](https://wiki.rc-network.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://jedipedia.net) [jedipedia.net (https://jedipedia.net)](https://jedipedia.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://ennstalwiki.at) [ennstalwiki.at (https://ennstalwiki.at)](https://ennstalwiki.at)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://de.duckipedia.org) [de.duckipedia.org (https://de.duckipedia.org)](https://de.duckipedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.antamar.eu) [wiki.antamar.eu (https://wiki.antamar.eu)](https://wiki.antamar.eu)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiibrew.org) [wiibrew.org (https://wiibrew.org)](https://wiibrew.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.sotahuuto.fi) [wiki.sotahuuto.fi (https://wiki.sotahuuto.fi)](https://wiki.sotahuuto.fi)*: top 100M, fi, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki-brest.net) [wiki-brest.net (https://wiki-brest.net)](https://wiki-brest.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://ardapedia.org) [ardapedia.org (https://ardapedia.org)](https://ardapedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://middlewiki.midrealm.org) [middlewiki.midrealm.org (https://middlewiki.midrealm.org)](https://middlewiki.midrealm.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.armagetronad.org) [wiki.armagetronad.org (https://wiki.armagetronad.org)](https://wiki.armagetronad.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://vanipedia.org) [vanipedia.org (https://vanipedia.org)](https://vanipedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://ja.yourpedia.org) [ja.yourpedia.org (https://ja.yourpedia.org)](https://ja.yourpedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://dwarffortresswiki.org) [dwarffortresswiki.org (https://dwarffortresswiki.org)](https://dwarffortresswiki.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.halo.fr) [wiki.halo.fr (https://wiki.halo.fr)](https://wiki.halo.fr)*: top 100M, fr, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.ihe.net) [wiki.ihe.net (https://wiki.ihe.net)](https://wiki.ihe.net)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wurmpedia.com) [wurmpedia.com (https://wurmpedia.com)](https://wurmpedia.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.hackmanhattan.com) [wiki.hackmanhattan.com (https://wiki.hackmanhattan.com)](https://wiki.hackmanhattan.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wikiindex.org) [wikiindex.org (https://wikiindex.org)](https://wikiindex.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.oroboros.at) [wiki.oroboros.at (https://wiki.oroboros.at)](https://wiki.oroboros.at)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fwwiki.de) [fwwiki.de (https://fwwiki.de)](https://fwwiki.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://nanowiki.no) [nanowiki.no (https://nanowiki.no)](https://nanowiki.no)*: top 100M, no, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://csdms.colorado.edu) [csdms.colorado.edu (https://csdms.colorado.edu)](https://csdms.colorado.edu)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://dragon-quest.org) [dragon-quest.org (https://dragon-quest.org)](https://dragon-quest.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://tuepedia.de) [tuepedia.de (https://tuepedia.de)](https://tuepedia.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://hurraki.de) [hurraki.de (https://hurraki.de)](https://hurraki.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://mhwiki.hitgrab.com) [mhwiki.hitgrab.com (https://mhwiki.hitgrab.com)](https://mhwiki.hitgrab.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://theportalwiki.com) [theportalwiki.com (https://theportalwiki.com)](https://theportalwiki.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://irowiki.org) [irowiki.org (https://irowiki.org)](https://irowiki.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki-fr.guildwars2.com) [wiki-fr.guildwars2.com (https://wiki-fr.guildwars2.com)](https://wiki-fr.guildwars2.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://openwaterpedia.com) [openwaterpedia.com (https://openwaterpedia.com)](https://openwaterpedia.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://zeldapendium.de) [zeldapendium.de (https://zeldapendium.de)](https://zeldapendium.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://moneypedia.de) [moneypedia.de (https://moneypedia.de)](https://moneypedia.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.kolmisoft.com) [wiki.kolmisoft.com (https://wiki.kolmisoft.com)](https://wiki.kolmisoft.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.london.hackspace.org.uk) [wiki.london.hackspace.org.uk (https://wiki.london.hackspace.org.uk)](https://wiki.london.hackspace.org.uk)*: top 100M, gb, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://labviewwiki.org) [labviewwiki.org (https://labviewwiki.org)](https://labviewwiki.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.web.ru) [wiki.web.ru (https://wiki.web.ru)](https://wiki.web.ru)*: top 100M, ru, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://theinfosphere.org) [theinfosphere.org (https://theinfosphere.org)](https://theinfosphere.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.selfhtml.org) [wiki.selfhtml.org (https://wiki.selfhtml.org)](https://wiki.selfhtml.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.avlis.org) [wiki.avlis.org (https://wiki.avlis.org)](https://wiki.avlis.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://libregamewiki.org) [libregamewiki.org (https://libregamewiki.org)](https://libregamewiki.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://dpbwiki.digitalfreaks.org) [dpbwiki.digitalfreaks.org (https://dpbwiki.digitalfreaks.org)](https://dpbwiki.digitalfreaks.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://hammwiki.info) [hammwiki.info (https://hammwiki.info)](https://hammwiki.info)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://muenchenwiki.de) [muenchenwiki.de (https://muenchenwiki.de)](https://muenchenwiki.de)*: top 100M, de, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://cvillepedia.org) [cvillepedia.org (https://cvillepedia.org)](https://cvillepedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://ufopaedia.org) [ufopaedia.org (https://ufopaedia.org)](https://ufopaedia.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fansub.d-addicts.com) [fansub.d-addicts.com (https://fansub.d-addicts.com)](https://fansub.d-addicts.com)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.happylab.at) [wiki.happylab.at (https://wiki.happylab.at)](https://wiki.happylab.at)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.apertium.org) [wiki.apertium.org (https://wiki.apertium.org)](https://wiki.apertium.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fileformats.archiveteam.org) [fileformats.archiveteam.org (https://fileformats.archiveteam.org)](https://fileformats.archiveteam.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wikem.org) [wikem.org (https://wikem.org)](https://wikem.org)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wiki.the-reincarnation.org) [wiki.the-reincarnation.org (https://wiki.the-reincarnation.org)](https://wiki.the-reincarnation.org)*: top 100M, wiki*
 
-The list was updated at (2026-09-01)
+The list was updated at (2026-09-02)
 ## Statistics
 
-Enabled/total sites: 2960/3653 = 81.03%
+Enabled/total sites: 3100/3793 = 81.73%
 
-Incomplete message checks: 352/2960 = 11.89% (false positive risks)
+Incomplete message checks: 352/3100 = 11.35% (false positive risks)
 
-Status code checks: 999/2960 = 33.75% (false positive risks)
+Status code checks: 1005/3100 = 32.42% (false positive risks)
 
-False positive risk (total): 45.64%
+False positive risk (total): 43.77%
 
 Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, ani.social, awful.systems, blob.cat, capivarinha.club, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, detroitriotcity.com, devs.live, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, discuss.online, discuss.tchncs.de, donotsta.re, eientei.org, en.brickimedia.org, europe.pub, eveningzoo.club, eviltoast.org, fe.disroot.org, feddit.cl, feddit.dk, feddit.it, feddit.nl, feddit.nu, feddit.org, feddit.uk, fedi.absturztau.be, fgc.network, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.guncadindex.com, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, freaksonly.space, freesoftwareextremist.com, genserver.social, gigaohm.bio, habbo.com.br, habbo.com.tr, hexbear.net, hilariouschaos.com, hiveos.farm, iNaturalist, jlai.lu, kazv.moe, kiwifarms.cc, labyrinth.zone, lemdro.id, leminal.space, lemmus.org, lemmy.1095.me, lemmy.blahaj.zone, lemmy.ca, lemmy.cafe, lemmy.dbzer0.com, lemmy.dorfrollenspiel.de, lemmy.ml, lemmy.myserv.one, lemmy.nz, lemmy.radio, lemmy.sdf.org, lemmy.today, lemmy.wtf, lemmy.zip, lemmygrad.ml, lemmynsfw.com, lemy.lol, literature.cafe, mander.xyz, midwest.social, mikuobsession.net, minazukey.uk, miraiverse.xyz, mk.absturztau.be, msk.ilnk.info, mujico.org, nekomiya.net, nicecrew.digital, nightbot, notabug.org, openframeworks, outerheaven.club, pawb.social, plasmatrap.com, pleroma.envs.net, programming.dev, qiwi.me (disabled), rebelbase.site, reddthat.com, retrolemmy.com, scribe.disroot.org, sh.itjust.works, shitpost.cloud, shitposter.world, slrpnk.net, social.net.ua, social.xenofem.me, sopuli.xyz, sourceruns, spinster.xyz, startrek.website, stelpolva.moe, stereophonic.space, support.ilovegrowingmarijuana.com, thelemmy.club, ttrpg.network, varishangout.net
 
@@ -3675,29 +3815,30 @@ Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSea
 Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
 - (354)	`/{username}`
-- (281)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
+- (282)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
 - (209)	`/user/{username}`
 - (179)	`/u/{username}`
 - (157)	`/profile/{username}`
+- (133)	`{urlMain}{urlSubpath}/User:{username} (MediaWiki)`
 - (127)	`/users/{username}`
 - (127)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
 - (126)	`{urlMain}{urlSubpath}/search.php?author={username} (phpBB/Search)`
 - (123)	`/@{username}`
 - (85)	`{urlMain}/u/{username}/summary (Discourse)`
 - (84)	`/a/{username}`
-- (60)	`/wiki/User:{username}`
+- (62)	`/wiki/User:{username}`
 - (48)	`SUBDOMAIN`
 - (44)	`/members/?username={username}`
 - (32)	`/author/{username}`
 - (29)	`/members/{username}`
 - (29)	`{urlMain}{urlSubpath}/memberlist.php?username={username} (phpBB)`
 - (26)	`{urlMain}/u/{username} (DiscourseJson)`
-- (18)	`/people/{username}`
 
 
 Sites by engine:
 - `uCoz`: 633/709 (89.3%)
-- `XenForo`: 231/281 (82.2%)
+- `XenForo`: 232/282 (82.3%)
+- `MediaWiki`: 133/133 (100.0%)
 - `vBulletin`: 34/127 (26.8%)
 - `phpBB/Search`: 117/126 (92.9%)
 - `Discourse`: 77/85 (90.6%)
@@ -3714,12 +3855,13 @@ Sites by engine:
 
 
 Top 20 tags:
-- (1442)	`forum`
+- (1443)	`forum`
 - (612)	`social`
-- (455)	`discussion`
+- (456)	`discussion`
 - (397)	`gaming`
 - (328)	`tech`
 - (216)	`education`
+- (216)	`wiki`
 - (213)	`coding`
 - (208)	`business`
 - (188)	`hobby`
@@ -3733,4 +3875,3 @@ Top 20 tags:
 - (92)	`sharing`
 - (88)	`auto`
 - (81)	`photo`
-- (77)	`wiki`


### PR DESCRIPTION
Adds 140 sites. 133 of them run MediaWiki, so this also adds a MediaWiki engine template.

| site | engine | tags |
|---|---|---|
| en.wiki.aktivix.org | MediaWiki | wiki |
| wiki.openstreetmap.org | MediaWiki | wiki |
| imslp.org | MediaWiki | wiki |
| mariowiki.com | MediaWiki | wiki |
| wiki.ead.pucv.cl | MediaWiki | wiki |
| jarviwiki.fi | MediaWiki | wiki, fi |
| tfwiki.net | MediaWiki | wiki |
| wiki.guildwars2.com | MediaWiki | wiki |
| drinkiwiki.com | MediaWiki | wiki |
| fr.wikimini.org | MediaWiki | wiki |
| yugipedia.com | MediaWiki | wiki |
| wiki.ubc.ca | MediaWiki | wiki, ca |
| dustloop.com | MediaWiki | wiki |
| wiki.guildwars.com | MediaWiki | wiki |
| pzwiki.net | MediaWiki | wiki |
| aw-wiki.de | MediaWiki | wiki, de |
| imfdb.org | MediaWiki | wiki |
| pokewiki.de | MediaWiki | wiki, de |
| coasterpedia.net | MediaWiki | wiki |
| mkwiiki.org | MediaWiki | wiki |
| esolangs.org | MediaWiki | wiki |
| chakuwiki.org | MediaWiki | wiki |
| wikidex.net | MediaWiki | wiki |
| generasia.com | — | wiki |
| wiki.gentoo.org | MediaWiki | wiki |
| halopedia.org | MediaWiki | wiki |
| tmbw.net | MediaWiki | wiki |
| wiki.starbase118.net | MediaWiki | wiki |
| wiki.eveuniversity.org | MediaWiki | wiki |
| lokalhistoriewiki.no | MediaWiki | wiki, no |
| pokepedia.fr | MediaWiki | wiki, fr |
| sarna.net | MediaWiki | wiki |
| sgwiki.com | MediaWiki | wiki |
| appropedia.org | MediaWiki | wiki |
| libreplanet.org | MediaWiki | wiki |
| starbounder.org | MediaWiki | wiki |
| coppermind.net | MediaWiki | wiki |
| de.wiki-aventurica.de | MediaWiki | wiki, de |
| srw.wiki.cre.jp | MediaWiki | wiki, jp |
| unterrichten.zum.de | MediaWiki | wiki, de |
| wiki.sn.at | MediaWiki | wiki |
| wiki.ovinnederland.nl | MediaWiki | wiki, nl |
| wiki.osgeo.org | MediaWiki | wiki |
| tolkiengateway.net | MediaWiki | wiki |
| khwiki.com | MediaWiki | wiki |
| nethackwiki.com | MediaWiki | wiki |
| wiki.dolibarr.org | MediaWiki | wiki |
| fuerthwiki.de | MediaWiki | wiki, de |
| tibiawiki.com.br | MediaWiki | wiki, br |
| wiki.linuxformat.ru | MediaWiki | wiki, ru |
| wikimon.net | MediaWiki | wiki |
| wiki.pumpingstationone.org | MediaWiki | wiki |
| wiki.postgresql.org | MediaWiki | wiki |
| projektwiki.zum.de | MediaWiki | wiki, de |
| simpsonswiki.com | MediaWiki | wiki |
| nnov.ec | MediaWiki | wiki |
| fuksiwiki.tko-aly.fi | MediaWiki | wiki, fi |
| pikminwiki.com | MediaWiki | wiki |
| revspace.nl | MediaWiki | wiki, nl |
| wiki.d-addicts.com | MediaWiki | wiki |
| semantic-mediawiki.org | MediaWiki | wiki |
| c64-wiki.de | MediaWiki | wiki, de |
| s4wiki.com | MediaWiki | wiki |
| ka.stadtwiki.net | MediaWiki | wiki |
| wiki.darkjedibrotherhood.com | MediaWiki | wiki |
| wiki.hope.net | MediaWiki | wiki |
| nl.wikisage.org | MediaWiki | wiki |
| perrypedia.de | MediaWiki | wiki, de |
| aiowiki.com | MediaWiki | wiki |
| speedsolving.com | XenForo | forum, discussion |
| ringofbrodgar.com | MediaWiki | wiki |
| theaterencyclopedie.nl | MediaWiki | wiki, nl |
| wikimanche.fr | MediaWiki | wiki, fr |
| wikiskripta.eu | MediaWiki | wiki |
| wiki.multitheftauto.com | MediaWiki | wiki |
| ethw.org | MediaWiki | wiki |
| wikijournalclub.org | MediaWiki | wiki |
| itgamal.app.uib.no | MediaWiki | wiki, no |
| wiki.shardsofdalaya.com | MediaWiki | wiki |
| roguebasin.com | MediaWiki | wiki |
| fr.nvcwiki.com | MediaWiki | wiki |
| openei.org | MediaWiki | wiki |
| wiki.erepublik.com | MediaWiki | wiki |
| jvflux.fr | MediaWiki | wiki, fr |
| marefa.org | MediaWiki | wiki |
| stampsoftheworld.co.uk | MediaWiki | wiki, gb |
| seriewikin.serieframjandet.se | MediaWiki | wiki, se |
| wiki.urbandead.com | MediaWiki | wiki |
| wiki.rc-network.de | MediaWiki | wiki, de |
| jedipedia.net | MediaWiki | wiki |
| ennstalwiki.at | — | wiki |
| de.duckipedia.org | MediaWiki | wiki |
| wiki.antamar.eu | MediaWiki | wiki |
| wiibrew.org | MediaWiki | wiki |
| wiki.sotahuuto.fi | MediaWiki | wiki, fi |
| wiki-brest.net | — | wiki |
| ardapedia.org | MediaWiki | wiki |
| middlewiki.midrealm.org | — | wiki |
| wiki.armagetronad.org | MediaWiki | wiki |
| vanipedia.org | MediaWiki | wiki |
| ja.yourpedia.org | MediaWiki | wiki |
| dwarffortresswiki.org | MediaWiki | wiki |
| wiki.halo.fr | MediaWiki | wiki, fr |
| wiki.ihe.net | MediaWiki | wiki |
| wurmpedia.com | MediaWiki | wiki |
| wiki.hackmanhattan.com | MediaWiki | wiki |
| wikiindex.org | MediaWiki | wiki |
| wiki.oroboros.at | MediaWiki | wiki |
| fwwiki.de | MediaWiki | wiki, de |
| nanowiki.no | MediaWiki | wiki, no |
| csdms.colorado.edu | MediaWiki | wiki |
| dragon-quest.org | MediaWiki | wiki |
| tuepedia.de | MediaWiki | wiki, de |
| hurraki.de | MediaWiki | wiki, de |
| mhwiki.hitgrab.com | MediaWiki | wiki |
| theportalwiki.com | MediaWiki | wiki |
| irowiki.org | MediaWiki | wiki |
| wiki-fr.guildwars2.com | MediaWiki | wiki |
| openwaterpedia.com | MediaWiki | wiki |
| zeldapendium.de | MediaWiki | wiki, de |
| moneypedia.de | MediaWiki | wiki, de |
| wiki.kolmisoft.com | MediaWiki | wiki |
| wiki.london.hackspace.org.uk | MediaWiki | wiki, gb |
| labviewwiki.org | MediaWiki | wiki |
| wiki.web.ru | — | wiki, ru |
| theinfosphere.org | MediaWiki | wiki |
| wiki.selfhtml.org | MediaWiki | wiki |
| wiki.avlis.org | MediaWiki | wiki |
| libregamewiki.org | MediaWiki | wiki |
| dpbwiki.digitalfreaks.org | — | wiki |
| hammwiki.info | MediaWiki | wiki |
| muenchenwiki.de | MediaWiki | wiki, de |
| cvillepedia.org | MediaWiki | wiki |
| ufopaedia.org | MediaWiki | wiki |
| fansub.d-addicts.com | MediaWiki | wiki |
| wiki.happylab.at | MediaWiki | wiki |
| wiki.apertium.org | MediaWiki | wiki |
| fileformats.archiveteam.org | MediaWiki | wiki |
| wikem.org | MediaWiki | wiki |
| wiki.the-reincarnation.org | MediaWiki | wiki |