### PR TITLE
Remove redundant direct asgiref dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3585,4 +3585,4 @@ pdf = ["arabic-reshaper", "python-bidi", "xhtml2pdf"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e7b9cd449caefc90258a234331797c6b6993e0beb209a41653863e0e04121ffe"
+content-hash = "afaaeb8c6816a3b4ce2dfab0821b71f42f09a8441987e7dbb3e4cf5d2b06e5c4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ networkx = "^2.6.3"
 pyvis = "^0.3.2"
 reportlab = "^4.4.3"
 flask = {extras = ["async"], version = "^3.1.1"}
-asgiref = "^3.9.1"
 platformdirs = "^4.3.8"
 curl-cffi = ">=0.14,<1.0"
 


### PR DESCRIPTION
## Summary
- remove the direct `asgiref` dependency constraint
- continue receiving `asgiref` transitively through Flask's `async` extra
- allow downstream resolvers to select older compatible releases, including environments that cap `asgiref` at 3.8.x

## Testing
- `poetry check --lock`
- `poetry show asgiref --why --tree` confirms Flask is the remaining dependency path

Closes #3060
