### PR TITLE
[LAPOINTE] Add 101 sites

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -50606,6 +50606,1039 @@
                 "wiki"
             ],
             "engine": "MediaWiki"
+        },
+        "filmix.gg": {
+            "urlMain": "https://filmix.gg",
+            "usernameClaimed": "was.lisa",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://filmix.gg/profile/{username}",
+            "checkType": "status_code"
+        },
+        "bg3.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://bg3.wiki",
+            "usernameClaimed": "HiddenDragon",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://bg3.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "emoji.gg": {
+            "urlMain": "https://emoji.gg",
+            "usernameClaimed": "decaydrop",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://emoji.gg/user/{username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "class=\"card profile-about\""
+            ]
+        },
+        "gbf.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://gbf.wiki",
+            "usernameClaimed": "ElGnomo",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://gbf.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "umamusu.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://umamusu.wiki",
+            "usernameClaimed": "Honodera",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://umamusu.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "hollowknight.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://hollowknight.wiki",
+            "usernameClaimed": "Polymeric",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://hollowknight.wiki/w/User:{username}",
+            "checkType": "status_code"
+        },
+        "gem.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://gem.wiki",
+            "usernameClaimed": "Gregorclark",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.gem.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "wavu.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wavu.wiki",
+            "usernameClaimed": "Poolsys",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wavu.wiki/t/User:{username}",
+            "checkType": "status_code"
+        },
+        "wavedream.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wavedream.wiki",
+            "usernameClaimed": "Christian4602",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wavedream.wiki/index.php/User:{username}",
+            "checkType": "status_code"
+        },
+        "hax.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://hax.social",
+            "usernameClaimed": "rallias",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://hax.social/@{username}",
+            "checkType": "status_code"
+        },
+        "screamer.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://screamer.wiki",
+            "usernameClaimed": "Kevin2008",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://screamer.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "consumerrights.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://consumerrights.wiki",
+            "usernameClaimed": "Matt78",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://consumerrights.wiki/w/User:{username}",
+            "checkType": "status_code"
+        },
+        "incremental.social": {
+            "tags": [
+                "discussion",
+                "forum",
+                "social"
+            ],
+            "urlMain": "https://incremental.social",
+            "usernameClaimed": "thepaperpilot",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://incremental.social/u/{username}",
+            "checkType": "status_code"
+        },
+        "idleon.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://idleon.wiki",
+            "usernameClaimed": "BigCoight",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://idleon.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "cooked.wiki": {
+            "urlMain": "https://cooked.wiki",
+            "usernameClaimed": "majesstic",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://cooked.wiki/user/{username}",
+            "checkType": "status_code"
+        },
+        "ylvapedia.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://ylvapedia.wiki",
+            "usernameClaimed": "Maestro2864",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://ylvapedia.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "outof.games": {
+            "urlMain": "https://outof.games",
+            "usernameClaimed": "demonxz95",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://outof.games/members/{username}/",
+            "checkType": "status_code"
+        },
+        "havoc.games": {
+            "tags": [
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://havoc.games",
+            "usernameClaimed": "ArmenTheHeli",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "exedra.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://exedra.wiki",
+            "usernameClaimed": "Boylnwza",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://exedra.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "fallenlondon.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://fallenlondon.wiki",
+            "usernameClaimed": "Pixie",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://fallenlondon.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "mtg.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://mtg.wiki",
+            "usernameClaimed": "Mrsalt05",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://mtg.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "fgo.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://fgo.wiki",
+            "usernameClaimed": "Enko",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://fgo.wiki/w/User:{username}",
+            "checkType": "status_code"
+        },
+        "incels.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://incels.wiki",
+            "usernameClaimed": "Mike",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://incels.wiki/w/User:{username}",
+            "checkType": "status_code"
+        },
+        "awakening.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://awakening.wiki",
+            "usernameClaimed": "-NGC-6302-",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://awakening.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "horizonffxi.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://horizonffxi.wiki",
+            "usernameClaimed": "Thesirenandtheking",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://horizonffxi.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "thefinals.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://thefinals.wiki",
+            "usernameClaimed": "1z1Fr4g",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.thefinals.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "smo.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://smo.wiki",
+            "usernameClaimed": "Grady",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://smo.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "blazblue.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://blazblue.wiki",
+            "usernameClaimed": "SuryadarmaTripalo",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://blazblue.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "haritonov.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://haritonov.wiki",
+            "usernameClaimed": "MaximNasurdinov",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://haritonov.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "atitd.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://atitd.wiki",
+            "usernameClaimed": "Sadvak",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://atitd.wiki/tale11/User:{username}",
+            "checkType": "status_code"
+        },
+        "gta.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://gta.wiki",
+            "usernameClaimed": "FirestarIDN",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://gta.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "hcommons.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://hcommons.social",
+            "usernameClaimed": "esko",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://hcommons.social/@{username}",
+            "checkType": "status_code"
+        },
+        "nin.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://nin.wiki",
+            "usernameClaimed": "Piggy",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.nin.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "siivagunner.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://siivagunner.wiki",
+            "usernameClaimed": "-YourOgrelord-",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://siivagunner.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "neptunia.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://neptunia.wiki",
+            "usernameClaimed": "Sammyrms1",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://neptunia.wiki/User:{username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "class=\"citizen-user-regdate\"",
+                "class=\"citizen-ui-icon mw-ui-icon-userContributions mw-ui-icon-wikimedia-userContributions\""
+            ]
+        },
+        "grapheneos.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://grapheneos.social",
+            "usernameClaimed": "metr0pl3x",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://grapheneos.social/@{username}",
+            "checkType": "status_code"
+        },
+        "bbw.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://bbw.wiki",
+            "usernameClaimed": "Gozoki",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://bbw.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "manson.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://manson.wiki",
+            "usernameClaimed": "MindBoosterNoori",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://manson.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "transfem.social": {
+            "tags": [
+                "social"
+            ],
+            "urlMain": "https://transfem.social",
+            "usernameClaimed": "puppygirlhornypost2",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://transfem.social/@{username}",
+            "urlProbe": "https://transfem.social/.well-known/webfinger?resource=acct:{username}@transfem.social",
+            "checkType": "status_code"
+        },
+        "swgoh.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://swgoh.wiki",
+            "usernameClaimed": "Aceantarctic",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://swgoh.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "trump.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://trump.wiki",
+            "usernameClaimed": "Agthorne",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.trump.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "profe.social": {
+            "urlMain": "https://profe.social",
+            "usernameClaimed": "ana.laura.ponce",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://profe.social/users/{username}/",
+            "checkType": "message",
+            "presenseStrs": [
+                "class=\"box has-text-centered profile\""
+            ]
+        },
+        "fanaticus.social": {
+            "tags": [
+                "discussion",
+                "forum",
+                "lemmy",
+                "social"
+            ],
+            "urlMain": "https://fanaticus.social",
+            "usernameClaimed": "PunkRockSportsFan",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://fanaticus.social/u/{username}",
+            "urlProbe": "https://fanaticus.social/api/v3/user?username={username}",
+            "checkType": "status_code"
+        },
+        "vger.social": {
+            "tags": [
+                "discussion",
+                "forum",
+                "lemmy",
+                "social"
+            ],
+            "urlMain": "https://vger.social",
+            "usernameClaimed": "aeharding",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://vger.social/u/{username}",
+            "urlProbe": "https://vger.social/api/v3/user?username={username}",
+            "checkType": "status_code"
+        },
+        "cymbal.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://cymbal.wiki",
+            "usernameClaimed": "Bluejacketsfan2",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://cymbal.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "arcraiders.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://arcraiders.wiki",
+            "usernameClaimed": "Sandstorm",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://arcraiders.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "wetshaving.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://wetshaving.social",
+            "usernameClaimed": "WegianWarrior",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wetshaving.social/@{username}",
+            "checkType": "status_code"
+        },
+        "safernicotine.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://safernicotine.wiki",
+            "usernameClaimed": "Skip",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://safernicotine.wiki/mediawiki/index.php/User:{username}",
+            "checkType": "message",
+            "presenseStrs": [
+                "class=\"user-section-heading\"",
+                "class=\"user-section-title\""
+            ]
+        },
+        "absurdopedia.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://absurdopedia.wiki",
+            "usernameClaimed": "Тэйтанка-птекила",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://absurdopedia.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "omori.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://omori.wiki",
+            "usernameClaimed": "AAAAAA",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://omori.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "kde.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://kde.social",
+            "usernameClaimed": "halla",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://kde.social/@{username}",
+            "checkType": "status_code"
+        },
+        "brogue.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://brogue.wiki",
+            "usernameClaimed": "Eel",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://brogue.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "blaseball.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://blaseball.wiki",
+            "usernameClaimed": "WayslideCool",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.blaseball.wiki/w/User:{username}",
+            "checkType": "status_code"
+        },
+        "nijimiss.moe": {
+            "tags": [
+                "social"
+            ],
+            "urlMain": "https://nijimiss.moe",
+            "usernameClaimed": "gabyo_cat",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://nijimiss.moe/@{username}",
+            "urlProbe": "https://nijimiss.moe/.well-known/webfinger?resource=acct:{username}@nijimiss.moe",
+            "checkType": "status_code"
+        },
+        "tkohhh.social": {
+            "tags": [
+                "discussion",
+                "forum",
+                "lemmy",
+                "social"
+            ],
+            "urlMain": "https://tkohhh.social",
+            "usernameClaimed": "michellewalters",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://tkohhh.social/u/{username}",
+            "urlProbe": "https://tkohhh.social/api/v3/user?username={username}",
+            "checkType": "status_code"
+        },
+        "gothic.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://gothic.wiki",
+            "usernameClaimed": "Garok",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://gothic.wiki/w/User:{username}",
+            "checkType": "status_code"
+        },
+        "brighteon.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://brighteon.social",
+            "usernameClaimed": "alltheworldsastage",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://brighteon.social/@{username}",
+            "checkType": "status_code"
+        },
+        "plenty.community": {
+            "tags": [
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://plenty.community",
+            "usernameClaimed": "DirkO",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "Discourse"
+        },
+        "amenzb.moe": {
+            "urlMain": "https://amenzb.moe",
+            "usernameClaimed": "Ame",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://amenzb.moe/u/{username}",
+            "checkType": "status_code"
+        },
+        "gametips.gg": {
+            "urlMain": "https://gametips.gg",
+            "usernameClaimed": "Lewis",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://gametips.gg/users/{username}",
+            "checkType": "status_code"
+        },
+        "wingsoffire.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wingsoffire.wiki",
+            "usernameClaimed": "Bog",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wingsoffire.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "milu.moe": {
+            "tags": [
+                "social"
+            ],
+            "urlMain": "https://milu.moe",
+            "usernameClaimed": "ximi",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://milu.moe/@{username}",
+            "urlProbe": "https://milu.moe/.well-known/webfinger?resource=acct:{username}@milu.moe",
+            "checkType": "status_code"
+        },
+        "nucleartech.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://nucleartech.wiki",
+            "usernameClaimed": "Mellow",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://nucleartech.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "wydds.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wydds.wiki",
+            "usernameClaimed": "Feylin33!",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wydds.wiki/info/User:{username}",
+            "checkType": "status_code"
+        },
+        "sustc.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://sustc.wiki",
+            "usernameClaimed": "听说强迫症喜",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://sustc.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "stencil.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://stencil.wiki",
+            "usernameClaimed": "Ranchpressing",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://stencil.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "lostwaves.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://lostwaves.wiki",
+            "usernameClaimed": "KezKaz",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://lostwaves.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "catmaze.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://catmaze.wiki",
+            "usernameClaimed": "MisterPerson",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://catmaze.wiki/w/User:{username}",
+            "checkType": "status_code"
+        },
+        "bisq.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://bisq.wiki",
+            "usernameClaimed": "SuddenWhipVapor",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://bisq.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "wallz.gg": {
+            "urlMain": "https://wallz.gg",
+            "usernameClaimed": "AronZaldyPidlaoan",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.wallz.gg/u/{username}",
+            "checkType": "status_code"
+        },
+        "osfirsttimer.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://osfirsttimer.wiki",
+            "usernameClaimed": "ByteOfMelon",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://osfirsttimer.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "biography.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://biography.wiki",
+            "usernameClaimed": "Finley",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://biography.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "irony.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://irony.wiki",
+            "usernameClaimed": "BearFM",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://irony.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "memory-alpha.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://memory-alpha.wiki",
+            "usernameClaimed": "Alboin",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://memory-alpha.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "indiedev.gg": {
+            "tags": [
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://indiedev.gg",
+            "usernameClaimed": "Cunechan",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "der-echte-nerden.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://der-echte-nerden.social",
+            "usernameClaimed": "Tvluke",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://der-echte-nerden.social/@{username}",
+            "checkType": "status_code"
+        },
+        "kerbal.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://kerbal.wiki",
+            "usernameClaimed": "Foonix",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://kerbal.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "projex.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://projex.wiki",
+            "usernameClaimed": "JasonCarswell",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://projex.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "chaosfurs.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://chaosfurs.social",
+            "usernameClaimed": "cato",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://chaosfurs.social/@{username}",
+            "checkType": "status_code"
+        },
+        "stationery.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://stationery.wiki",
+            "usernameClaimed": "Slivercrows",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://stationery.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "theblockheads.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://theblockheads.wiki",
+            "usernameClaimed": "NovaDev404",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://theblockheads.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "retro.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://retro.social",
+            "usernameClaimed": "LeoKirke",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://retro.social/@{username}",
+            "checkType": "status_code"
+        },
+        "eamon.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://eamon.wiki",
+            "usernameClaimed": "Huwmanbeing",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://eamon.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "solarpunk.moe": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://solarpunk.moe",
+            "usernameClaimed": "stellarskylark",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://solarpunk.moe/@{username}",
+            "checkType": "status_code"
+        },
+        "emergent.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://emergent.wiki",
+            "usernameClaimed": "AbsurdistLog",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://emergent.wiki/wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "polymaths.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://polymaths.social",
+            "usernameClaimed": "rl_dane",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://polymaths.social/@{username}",
+            "checkType": "status_code"
+        },
+        "venera.social": {
+            "tags": [
+                "social"
+            ],
+            "urlMain": "https://venera.social",
+            "usernameClaimed": "rlaimondas",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://venera.social/profile/{username}",
+            "checkType": "status_code"
+        },
+        "religions.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://religions.wiki",
+            "usernameClaimed": "TimSC",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://religions.wiki/index.php/User:{username}",
+            "checkType": "status_code"
+        },
+        "farwalker.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://farwalker.wiki",
+            "usernameClaimed": "The-Dungeon-Master",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://farwalker.wiki/index.php/User:{username}",
+            "checkType": "status_code"
+        },
+        "monte.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://monte.wiki",
+            "usernameClaimed": "Troggy",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://monte.wiki/ru/User:{username}",
+            "checkType": "status_code"
+        },
+        "wub.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://wub.wiki",
+            "usernameClaimed": "Akusukasgriper",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://wub.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "obby.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://obby.wiki",
+            "usernameClaimed": "Wlft",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://obby.wiki/User:{username}",
+            "checkType": "status_code"
+        },
+        "belgae.social": {
+            "tags": [
+                "discussion",
+                "forum",
+                "lemmy",
+                "social"
+            ],
+            "urlMain": "https://belgae.social",
+            "usernameClaimed": "autonomousPunk",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://belgae.social/u/{username}",
+            "urlProbe": "https://belgae.social/api/v3/user?username={username}",
+            "checkType": "status_code"
+        },
+        "over.gg": {
+            "urlMain": "https://over.gg",
+            "usernameClaimed": "9wntr",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://www.over.gg/user/{username}",
+            "checkType": "status_code"
+        },
+        "misskey.gg": {
+            "tags": [
+                "social"
+            ],
+            "urlMain": "https://misskey.gg",
+            "usernameClaimed": "Amane_Shion",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://misskey.gg/@{username}",
+            "urlProbe": "https://misskey.gg/.well-known/webfinger?resource=acct:{username}@misskey.gg",
+            "checkType": "status_code"
+        },
+        "pacificdrive.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://pacificdrive.wiki",
+            "usernameClaimed": "FlannPud",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://pacificdrive.wiki/view/User:{username}",
+            "checkType": "status_code"
+        },
+        "simplesurvival.gg": {
+            "urlMain": "https://simplesurvival.gg",
+            "usernameClaimed": "Jadziaa",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://simplesurvival.gg/profile/{username}/",
+            "checkType": "message",
+            "presenseStrs": [
+                "class=\"profile-header\"",
+                "class=\"profile-header-info\""
+            ]
+        },
+        "systemli.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://systemli.social",
+            "usernameClaimed": "funz",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://systemli.social/@{username}",
+            "checkType": "status_code"
+        },
+        "dronepilots.community": {
+            "tags": [
+                "discussion",
+                "forum"
+            ],
+            "urlMain": "https://dronepilots.community",
+            "usernameClaimed": "LoudThunder",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "engine": "XenForo"
+        },
+        "mainz.social": {
+            "tags": [
+                "mastodon",
+                "social"
+            ],
+            "urlMain": "https://mainz.social",
+            "usernameClaimed": "reutter",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://mainz.social/@{username}",
+            "checkType": "status_code"
+        },
+        "zzzzz.wiki": {
+            "tags": [
+                "wiki"
+            ],
+            "urlMain": "https://zzzzz.wiki",
+            "usernameClaimed": "MaribelMarcello",
+            "usernameUnclaimed": "noonewouldeverusethis7",
+            "url": "https://zzzzz.wiki/User:{username}",
+            "checkType": "status_code"
         }
     },
     "engines": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-09-04T13:28:48Z",
-    "sites_count": 3826,
+    "updated_at": "2026-09-04T17:10:17Z",
+    "sites_count": 3927,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "0161d174a58c0866d810bf2e374dd27b230a215a5eebb7f5f741d2a6355e1d21",
+    "data_sha256": "74a80637d9d1f44f6e83343356c01d62b1b839468f7fe52ad2852827b0b1a9fd",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -1,5 +1,5 @@
 
-## List of supported sites (search methods): total 3826
+## List of supported sites (search methods): total 3927
 
 Rank data fetched from Majestic Million by domains.
 
@@ -3829,52 +3829,153 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://tetris.wiki) [tetris.wiki (https://tetris.wiki)](https://tetris.wiki)*: top 100M, wiki*
 1. ![](https://www.google.com/s2/favicons?domain=https://transit.wiki) [transit.wiki (https://transit.wiki)](https://transit.wiki)*: top 100M, wiki*
 1. ![](https://www.google.com/s2/favicons?domain=https://zapf.wiki) [zapf.wiki (https://zapf.wiki)](https://zapf.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://filmix.gg) [filmix.gg (https://filmix.gg)](https://filmix.gg)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://bg3.wiki) [bg3.wiki (https://bg3.wiki)](https://bg3.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://emoji.gg) [emoji.gg (https://emoji.gg)](https://emoji.gg)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://gbf.wiki) [gbf.wiki (https://gbf.wiki)](https://gbf.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://umamusu.wiki) [umamusu.wiki (https://umamusu.wiki)](https://umamusu.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://hollowknight.wiki) [hollowknight.wiki (https://hollowknight.wiki)](https://hollowknight.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://gem.wiki) [gem.wiki (https://gem.wiki)](https://gem.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wavu.wiki) [wavu.wiki (https://wavu.wiki)](https://wavu.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wavedream.wiki) [wavedream.wiki (https://wavedream.wiki)](https://wavedream.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://hax.social) [hax.social (https://hax.social)](https://hax.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://screamer.wiki) [screamer.wiki (https://screamer.wiki)](https://screamer.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://consumerrights.wiki) [consumerrights.wiki (https://consumerrights.wiki)](https://consumerrights.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://incremental.social) [incremental.social (https://incremental.social)](https://incremental.social)*: top 100M, discussion, forum, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://idleon.wiki) [idleon.wiki (https://idleon.wiki)](https://idleon.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://cooked.wiki) [cooked.wiki (https://cooked.wiki)](https://cooked.wiki)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://ylvapedia.wiki) [ylvapedia.wiki (https://ylvapedia.wiki)](https://ylvapedia.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://outof.games) [outof.games (https://outof.games)](https://outof.games)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://havoc.games) [havoc.games (https://havoc.games)](https://havoc.games)*: top 100M, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://exedra.wiki) [exedra.wiki (https://exedra.wiki)](https://exedra.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fallenlondon.wiki) [fallenlondon.wiki (https://fallenlondon.wiki)](https://fallenlondon.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://mtg.wiki) [mtg.wiki (https://mtg.wiki)](https://mtg.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://fgo.wiki) [fgo.wiki (https://fgo.wiki)](https://fgo.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://incels.wiki) [incels.wiki (https://incels.wiki)](https://incels.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://awakening.wiki) [awakening.wiki (https://awakening.wiki)](https://awakening.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://horizonffxi.wiki) [horizonffxi.wiki (https://horizonffxi.wiki)](https://horizonffxi.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://thefinals.wiki) [thefinals.wiki (https://thefinals.wiki)](https://thefinals.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://smo.wiki) [smo.wiki (https://smo.wiki)](https://smo.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://blazblue.wiki) [blazblue.wiki (https://blazblue.wiki)](https://blazblue.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://haritonov.wiki) [haritonov.wiki (https://haritonov.wiki)](https://haritonov.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://atitd.wiki) [atitd.wiki (https://atitd.wiki)](https://atitd.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://gta.wiki) [gta.wiki (https://gta.wiki)](https://gta.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://hcommons.social) [hcommons.social (https://hcommons.social)](https://hcommons.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://nin.wiki) [nin.wiki (https://nin.wiki)](https://nin.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://siivagunner.wiki) [siivagunner.wiki (https://siivagunner.wiki)](https://siivagunner.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://neptunia.wiki) [neptunia.wiki (https://neptunia.wiki)](https://neptunia.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://grapheneos.social) [grapheneos.social (https://grapheneos.social)](https://grapheneos.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://bbw.wiki) [bbw.wiki (https://bbw.wiki)](https://bbw.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://manson.wiki) [manson.wiki (https://manson.wiki)](https://manson.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://transfem.social) [transfem.social (https://transfem.social)](https://transfem.social)*: top 100M, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://swgoh.wiki) [swgoh.wiki (https://swgoh.wiki)](https://swgoh.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://trump.wiki) [trump.wiki (https://trump.wiki)](https://trump.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://profe.social) [profe.social (https://profe.social)](https://profe.social)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://fanaticus.social) [fanaticus.social (https://fanaticus.social)](https://fanaticus.social)*: top 100M, discussion, forum, lemmy, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://vger.social) [vger.social (https://vger.social)](https://vger.social)*: top 100M, discussion, forum, lemmy, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://cymbal.wiki) [cymbal.wiki (https://cymbal.wiki)](https://cymbal.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://arcraiders.wiki) [arcraiders.wiki (https://arcraiders.wiki)](https://arcraiders.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wetshaving.social) [wetshaving.social (https://wetshaving.social)](https://wetshaving.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://safernicotine.wiki) [safernicotine.wiki (https://safernicotine.wiki)](https://safernicotine.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://absurdopedia.wiki) [absurdopedia.wiki (https://absurdopedia.wiki)](https://absurdopedia.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://omori.wiki) [omori.wiki (https://omori.wiki)](https://omori.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://kde.social) [kde.social (https://kde.social)](https://kde.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://brogue.wiki) [brogue.wiki (https://brogue.wiki)](https://brogue.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://blaseball.wiki) [blaseball.wiki (https://blaseball.wiki)](https://blaseball.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://nijimiss.moe) [nijimiss.moe (https://nijimiss.moe)](https://nijimiss.moe)*: top 100M, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://tkohhh.social) [tkohhh.social (https://tkohhh.social)](https://tkohhh.social)*: top 100M, discussion, forum, lemmy, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://gothic.wiki) [gothic.wiki (https://gothic.wiki)](https://gothic.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://brighteon.social) [brighteon.social (https://brighteon.social)](https://brighteon.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://plenty.community) [plenty.community (https://plenty.community)](https://plenty.community)*: top 100M, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://amenzb.moe) [amenzb.moe (https://amenzb.moe)](https://amenzb.moe)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://gametips.gg) [gametips.gg (https://gametips.gg)](https://gametips.gg)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://wingsoffire.wiki) [wingsoffire.wiki (https://wingsoffire.wiki)](https://wingsoffire.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://milu.moe) [milu.moe (https://milu.moe)](https://milu.moe)*: top 100M, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://nucleartech.wiki) [nucleartech.wiki (https://nucleartech.wiki)](https://nucleartech.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wydds.wiki) [wydds.wiki (https://wydds.wiki)](https://wydds.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://sustc.wiki) [sustc.wiki (https://sustc.wiki)](https://sustc.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://stencil.wiki) [stencil.wiki (https://stencil.wiki)](https://stencil.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://lostwaves.wiki) [lostwaves.wiki (https://lostwaves.wiki)](https://lostwaves.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://catmaze.wiki) [catmaze.wiki (https://catmaze.wiki)](https://catmaze.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://bisq.wiki) [bisq.wiki (https://bisq.wiki)](https://bisq.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wallz.gg) [wallz.gg (https://wallz.gg)](https://wallz.gg)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://osfirsttimer.wiki) [osfirsttimer.wiki (https://osfirsttimer.wiki)](https://osfirsttimer.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://biography.wiki) [biography.wiki (https://biography.wiki)](https://biography.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://irony.wiki) [irony.wiki (https://irony.wiki)](https://irony.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://memory-alpha.wiki) [memory-alpha.wiki (https://memory-alpha.wiki)](https://memory-alpha.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://indiedev.gg) [indiedev.gg (https://indiedev.gg)](https://indiedev.gg)*: top 100M, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://der-echte-nerden.social) [der-echte-nerden.social (https://der-echte-nerden.social)](https://der-echte-nerden.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://kerbal.wiki) [kerbal.wiki (https://kerbal.wiki)](https://kerbal.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://projex.wiki) [projex.wiki (https://projex.wiki)](https://projex.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://chaosfurs.social) [chaosfurs.social (https://chaosfurs.social)](https://chaosfurs.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://stationery.wiki) [stationery.wiki (https://stationery.wiki)](https://stationery.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://theblockheads.wiki) [theblockheads.wiki (https://theblockheads.wiki)](https://theblockheads.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://retro.social) [retro.social (https://retro.social)](https://retro.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://eamon.wiki) [eamon.wiki (https://eamon.wiki)](https://eamon.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://solarpunk.moe) [solarpunk.moe (https://solarpunk.moe)](https://solarpunk.moe)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://emergent.wiki) [emergent.wiki (https://emergent.wiki)](https://emergent.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://polymaths.social) [polymaths.social (https://polymaths.social)](https://polymaths.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://venera.social) [venera.social (https://venera.social)](https://venera.social)*: top 100M, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://religions.wiki) [religions.wiki (https://religions.wiki)](https://religions.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://farwalker.wiki) [farwalker.wiki (https://farwalker.wiki)](https://farwalker.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://monte.wiki) [monte.wiki (https://monte.wiki)](https://monte.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://wub.wiki) [wub.wiki (https://wub.wiki)](https://wub.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://obby.wiki) [obby.wiki (https://obby.wiki)](https://obby.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://belgae.social) [belgae.social (https://belgae.social)](https://belgae.social)*: top 100M, discussion, forum, lemmy, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://over.gg) [over.gg (https://over.gg)](https://over.gg)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://misskey.gg) [misskey.gg (https://misskey.gg)](https://misskey.gg)*: top 100M, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://pacificdrive.wiki) [pacificdrive.wiki (https://pacificdrive.wiki)](https://pacificdrive.wiki)*: top 100M, wiki*
+1. ![](https://www.google.com/s2/favicons?domain=https://simplesurvival.gg) [simplesurvival.gg (https://simplesurvival.gg)](https://simplesurvival.gg)*: top 100M*
+1. ![](https://www.google.com/s2/favicons?domain=https://systemli.social) [systemli.social (https://systemli.social)](https://systemli.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://dronepilots.community) [dronepilots.community (https://dronepilots.community)](https://dronepilots.community)*: top 100M, discussion, forum*
+1. ![](https://www.google.com/s2/favicons?domain=https://mainz.social) [mainz.social (https://mainz.social)](https://mainz.social)*: top 100M, mastodon, social*
+1. ![](https://www.google.com/s2/favicons?domain=https://zzzzz.wiki) [zzzzz.wiki (https://zzzzz.wiki)](https://zzzzz.wiki)*: top 100M, wiki*
 
 The list was updated at (2026-09-04)
 ## Statistics
 
-Enabled/total sites: 3133/3826 = 81.89%
+Enabled/total sites: 3234/3927 = 82.35%
 
-Incomplete message checks: 356/3133 = 11.36% (false positive risks)
+Incomplete message checks: 361/3234 = 11.16% (false positive risks)
 
-Status code checks: 1017/3133 = 32.46% (false positive risks)
+Status code checks: 1109/3234 = 34.29% (false positive risks)
 
-False positive risk (total): 43.82%
+False positive risk (total): 45.45%
 
-Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, ani.social, awful.systems, blob.cat, bolha.forum, capivarinha.club, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, detroitriotcity.com, devs.live, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, discuss.online, discuss.tchncs.de, donotsta.re, eientei.org, en.brickimedia.org, europe.pub, eveningzoo.club, eviltoast.org, fe.disroot.org, feddit.cl, feddit.dk, feddit.it, feddit.nl, feddit.nu, feddit.org, feddit.uk, fedi.absturztau.be, fgc.network, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.guncadindex.com, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, freaksonly.space, freesoftwareextremist.com, genserver.social, gigaohm.bio, habbo.com.br, habbo.com.tr, hexbear.net, hilariouschaos.com, hiveos.farm, iNaturalist, jlai.lu, kazv.moe, kiwifarms.cc, labyrinth.zone, lemdro.id, leminal.space, lemmus.org, lemmy.1095.me, lemmy.blahaj.zone, lemmy.ca, lemmy.cafe, lemmy.dbzer0.com, lemmy.dorfrollenspiel.de, lemmy.ml, lemmy.myserv.one, lemmy.nz, lemmy.radio, lemmy.sdf.org, lemmy.today, lemmy.wtf, lemmy.zip, lemmygrad.ml, lemmynsfw.com, lemy.lol, literature.cafe, mander.xyz, midwest.social, mikuobsession.net, minazukey.uk, miraiverse.xyz, mk.absturztau.be, msk.ilnk.info, mujico.org, nekomiya.net, nicecrew.digital, nightbot, notabug.org, openframeworks, outerheaven.club, pawb.social, plasmatrap.com, pleroma.envs.net, programming.dev, qiwi.me (disabled), rebelbase.site, reddthat.com, retrolemmy.com, scribe.disroot.org, sh.itjust.works, shitpost.cloud, shitposter.world, slrpnk.net, social.net.ua, social.xenofem.me, sopuli.xyz, sourceruns, spinster.xyz, startrek.website, stelpolva.moe, stereophonic.space, support.ilovegrowingmarijuana.com, thelemmy.club, ttrpg.network, varishangout.net
+Sites with probing: 500px, Armchairgm, Bambu Lab Forum, Bilibili, BinarySearch (disabled), BitBucket, BleachFandom, Bluesky, BongaCams, Boosty, Bunpro, BuyMeACoffee, Calendly, Cent, Chess, Code Sandbox (disabled), Code Snippet Wiki, DailyMotion, DataCite, Discord, Diskusjon.no, Disqus, Docker Hub, Dryad, Duolingo, F-droid, Faceit, FandomCommunityCentral, GitHub, GitLab, Golangbridge, Google Plus (archived), Gravatar, HackTheBox (disabled), HackerNews, HackerNoon, Hackerrank, Hashnode, Hey, Holopin, HuggingFace, ITVDN Forum, Imgur, Instagram, Instapaper, Juejin, Keybase, Kick, Kvinneguiden, LeetCode, Lemmy World, Lesswrong, Livejasmin, LocalCryptos (disabled), Mapillary Forum, Matrix, Medium, MetaDiscourse, MicrosoftLearn, Minds, MixCloud, Monkeytype, NPM, NetEase Music, Niftygateway, ORCID, Omg.lol, OnlyFans, OpenAIRE, OpenWrt Forum, Paragraph, Picsart, Polarsteps, QQ, Rarible, Reddit, Reddit Search (Pushshift) (disabled), Revolut.me, RoyalCams, Scratch, Silver-collector, Soop, SportsTracker, Spotify, StackOverflow, Substack, TAP'D, Topcoder, Trello, Twitch, Twitter, Twitter Shadowban (disabled), UnstoppableDomains, Vimeo, Vivino, Warframe Market, Warpcast, Weibo, Wikipedia, Yapisal (disabled), Ybox, YouNow, Zenodo, ani.social, awful.systems, belgae.social, blob.cat, bolha.forum, capivarinha.club, community.endlessos.com, community.getpostman.com, community.icons8.com, community.p2pu.org, detroitriotcity.com, devs.live, discourse.haskell.org, discourse.jupyter.org, discuss.inventables.com, discuss.online, discuss.tchncs.de, donotsta.re, eientei.org, en.brickimedia.org, europe.pub, eveningzoo.club, eviltoast.org, fanaticus.social, fe.disroot.org, feddit.cl, feddit.dk, feddit.it, feddit.nl, feddit.nu, feddit.org, feddit.uk, fedi.absturztau.be, fgc.network, figshare, forum.audacityteam.org, forum.garudalinux.org, forum.ghost.org, forum.guncadindex.com, forum.languagelearningwithnetflix.com, forum.shotcut.org, forum.zorin.com, forums.docker.com, forums.grandstream.com, forums.steinberg.net, freaksonly.space, freesoftwareextremist.com, genserver.social, gigaohm.bio, habbo.com.br, habbo.com.tr, hexbear.net, hilariouschaos.com, hiveos.farm, iNaturalist, jlai.lu, kazv.moe, kiwifarms.cc, labyrinth.zone, lemdro.id, leminal.space, lemmus.org, lemmy.1095.me, lemmy.blahaj.zone, lemmy.ca, lemmy.cafe, lemmy.dbzer0.com, lemmy.dorfrollenspiel.de, lemmy.ml, lemmy.myserv.one, lemmy.nz, lemmy.radio, lemmy.sdf.org, lemmy.today, lemmy.wtf, lemmy.zip, lemmygrad.ml, lemmynsfw.com, lemy.lol, literature.cafe, mander.xyz, midwest.social, mikuobsession.net, milu.moe, minazukey.uk, miraiverse.xyz, misskey.gg, mk.absturztau.be, msk.ilnk.info, mujico.org, nekomiya.net, nicecrew.digital, nightbot, nijimiss.moe, notabug.org, openframeworks, outerheaven.club, pawb.social, plasmatrap.com, pleroma.envs.net, programming.dev, qiwi.me (disabled), rebelbase.site, reddthat.com, retrolemmy.com, scribe.disroot.org, sh.itjust.works, shitpost.cloud, shitposter.world, slrpnk.net, social.net.ua, social.xenofem.me, sopuli.xyz, sourceruns, spinster.xyz, startrek.website, stelpolva.moe, stereophonic.space, support.ilovegrowingmarijuana.com, thelemmy.club, tkohhh.social, transfem.social, ttrpg.network, varishangout.net, vger.social
 
 Sites with activation: OnlyFans, ProtonMail, Twitter, Vimeo, Weibo, WikimapiaSearch
 
 Top 20 profile URLs:
 - (709)	`{urlMain}/index/8-0-{username} (uCoz)`
 - (354)	`/{username}`
-- (286)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
-- (216)	`/user/{username}`
-- (182)	`/u/{username}`
-- (159)	`/profile/{username}`
+- (289)	`{urlMain}{urlSubpath}/members/?username={username} (XenForo)`
+- (219)	`/user/{username}`
+- (189)	`/u/{username}`
+- (162)	`/profile/{username}`
 - (142)	`{urlMain}{urlSubpath}/User:{username} (MediaWiki)`
-- (128)	`/users/{username}`
+- (141)	`/@{username}`
+- (130)	`/users/{username}`
 - (127)	`{urlMain}{urlSubpath}/member.php?username={username} (vBulletin)`
 - (126)	`{urlMain}{urlSubpath}/search.php?author={username} (phpBB/Search)`
-- (124)	`/@{username}`
-- (89)	`{urlMain}/u/{username}/summary (Discourse)`
+- (90)	`{urlMain}/u/{username}/summary (Discourse)`
+- (84)	`/wiki/User:{username}`
 - (84)	`/a/{username}`
-- (62)	`/wiki/User:{username}`
 - (48)	`SUBDOMAIN`
 - (44)	`/members/?username={username}`
+- (40)	`/User:{username}`
 - (32)	`/author/{username}`
-- (30)	`/members/{username}`
+- (31)	`/members/{username}`
 - (29)	`{urlMain}{urlSubpath}/memberlist.php?username={username} (phpBB)`
-- (26)	`{urlMain}/u/{username} (DiscourseJson)`
 
 
 Sites by engine:
 - `uCoz`: 633/709 (89.3%)
-- `XenForo`: 236/286 (82.5%)
+- `XenForo`: 239/289 (82.7%)
 - `MediaWiki`: 142/142 (100.0%)
 - `vBulletin`: 34/127 (26.8%)
 - `phpBB/Search`: 117/126 (92.9%)
-- `Discourse`: 81/89 (91.0%)
+- `Discourse`: 82/90 (91.1%)
 - `phpBB`: 23/29 (79.3%)
 - `DiscourseJson`: 26/26 (100.0%)
 - `engine404`: 18/23 (78.3%)
@@ -3888,12 +3989,12 @@ Sites by engine:
 
 
 Top 20 tags:
-- (1452)	`forum`
-- (614)	`social`
-- (466)	`discussion`
+- (1461)	`forum`
+- (637)	`social`
+- (475)	`discussion`
 - (397)	`gaming`
 - (328)	`tech`
-- (225)	`wiki`
+- (289)	`wiki`
 - (216)	`education`
 - (213)	`coding`
 - (208)	`business`


### PR DESCRIPTION
Adds 101 sites.

| site | engine | tags |
|---|---|---|
| filmix.gg | — | — |
| bg3.wiki | — | wiki |
| emoji.gg | — | — |
| gbf.wiki | — | wiki |
| umamusu.wiki | — | wiki |
| hollowknight.wiki | — | wiki |
| gem.wiki | — | wiki |
| wavu.wiki | — | wiki |
| wavedream.wiki | — | wiki |
| hax.social | — | social, mastodon |
| screamer.wiki | — | wiki |
| consumerrights.wiki | — | wiki |
| incremental.social | — | social, forum, discussion |
| idleon.wiki | — | wiki |
| cooked.wiki | — | — |
| ylvapedia.wiki | — | wiki |
| outof.games | — | — |
| havoc.games | XenForo | forum, discussion |
| exedra.wiki | — | wiki |
| fallenlondon.wiki | — | wiki |
| mtg.wiki | — | wiki |
| fgo.wiki | — | wiki |
| incels.wiki | — | wiki |
| awakening.wiki | — | wiki |
| horizonffxi.wiki | — | wiki |
| thefinals.wiki | — | wiki |
| smo.wiki | — | wiki |
| blazblue.wiki | — | wiki |
| haritonov.wiki | — | wiki |
| atitd.wiki | — | wiki |
| gta.wiki | — | wiki |
| hcommons.social | — | social, mastodon |
| nin.wiki | — | wiki |
| siivagunner.wiki | — | wiki |
| neptunia.wiki | — | wiki |
| grapheneos.social | — | social, mastodon |
| bbw.wiki | — | wiki |
| manson.wiki | — | wiki |
| transfem.social | — | social |
| swgoh.wiki | — | wiki |
| trump.wiki | — | wiki |
| profe.social | — | — |
| fanaticus.social | — | social, lemmy, forum, discussion |
| vger.social | — | social, lemmy, forum, discussion |
| cymbal.wiki | — | wiki |
| arcraiders.wiki | — | wiki |
| wetshaving.social | — | social, mastodon |
| safernicotine.wiki | — | wiki |
| absurdopedia.wiki | — | wiki |
| omori.wiki | — | wiki |
| kde.social | — | social, mastodon |
| brogue.wiki | — | wiki |
| blaseball.wiki | — | wiki |
| nijimiss.moe | — | social |
| tkohhh.social | — | social, lemmy, forum, discussion |
| gothic.wiki | — | wiki |
| brighteon.social | — | social, mastodon |
| plenty.community | Discourse | forum, discussion |
| amenzb.moe | — | — |
| gametips.gg | — | — |
| wingsoffire.wiki | — | wiki |
| milu.moe | — | social |
| nucleartech.wiki | — | wiki |
| wydds.wiki | — | wiki |
| sustc.wiki | — | wiki |
| stencil.wiki | — | wiki |
| lostwaves.wiki | — | wiki |
| catmaze.wiki | — | wiki |
| bisq.wiki | — | wiki |
| wallz.gg | — | — |
| osfirsttimer.wiki | — | wiki |
| biography.wiki | — | wiki |
| irony.wiki | — | wiki |
| memory-alpha.wiki | — | wiki |
| indiedev.gg | XenForo | forum, discussion |
| der-echte-nerden.social | — | social, mastodon |
| kerbal.wiki | — | wiki |
| projex.wiki | — | wiki |
| chaosfurs.social | — | social, mastodon |
| stationery.wiki | — | wiki |
| theblockheads.wiki | — | wiki |
| retro.social | — | social, mastodon |
| eamon.wiki | — | wiki |
| solarpunk.moe | — | social, mastodon |
| emergent.wiki | — | wiki |
| polymaths.social | — | social, mastodon |
| venera.social | — | social |
| religions.wiki | — | wiki |
| farwalker.wiki | — | wiki |
| monte.wiki | — | wiki |
| wub.wiki | — | wiki |
| obby.wiki | — | wiki |
| belgae.social | — | social, lemmy, forum, discussion |
| over.gg | — | — |
| misskey.gg | — | social |
| pacificdrive.wiki | — | wiki |
| simplesurvival.gg | — | — |
| systemli.social | — | social, mastodon |
| dronepilots.community | XenForo | forum, discussion |
| mainz.social | — | social, mastodon |
| zzzzz.wiki | — | wiki |
