### PR TITLE
fix: keep the AI analysis from crashing on a non-UTF-8 stdout

### DIFF
--- a/maigret/ai.py
+++ b/maigret/ai.py
@@ -31,14 +31,31 @@ def resolve_api_key(settings) -> str | None:
     return os.environ.get("OPENAI_API_KEY")
 
 
+def _write_encodable(stream, text: str) -> None:
+    """Write text the stream's encoding may not be able to represent.
+
+    Same shape as notify._print_encodable, for a stream write rather than a
+    print. On Windows, Python takes stdout's encoding from the process ANSI
+    codepage, cp1252 on a default install. stdout's error handler is
+    surrogateescape, which rescues lone surrogates only -- an ordinary
+    unencodable character still raises. PYTHONIOENCODING cannot rescue the
+    PyInstaller build, which ignores PYTHON* environment variables.
+    """
+    try:
+        stream.write(text)
+    except UnicodeEncodeError:
+        encoding = getattr(stream, "encoding", None) or "ascii"
+        stream.write(text.encode(encoding, errors="replace").decode(encoding, errors="replace"))
+
+
 def _frames_for(stream, frames, fallback):
     """Pick a frame set the stream can actually render.
 
     The braille frames are not in cp1252, the ANSI codepage of a stock Windows
-    install, so writing one raised UnicodeEncodeError inside the spinner's
-    daemon thread: the thread died with a traceback over the output and the
-    animation stopped for the rest of the run. Encoding with replacement would
-    only leave a row of '?' spinning, so fall back to frames that carry.
+    install. Unlike stdout, stderr's error handler is backslashreplace, so
+    writing one never raised: it printed the escape, and the animation became a
+    column of literal ⠋. Encoding with replacement would only leave a row
+    of '?' spinning, so fall back to frames that carry.
     """
     encoding = getattr(stream, "encoding", None) or "ascii"
     try:
@@ -127,7 +144,11 @@ async def _stream_response(resp, spinner, first_token):
             spinner.stop()
             print()
             first_token = False
-        sys.stdout.write(content)
+        # The model's reply is arbitrary text: an OSINT run on an international
+        # username routinely comes back with Cyrillic or CJK. Writing it straight
+        # raised UnicodeEncodeError out of this coroutine and ended the analysis
+        # mid-sentence, with the tokens already printed left on screen.
+        _write_encodable(sys.stdout, content)
         sys.stdout.flush()
         full_response.append(content)
     return first_token, "".join(full_response)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,8 +1,13 @@
 """Tests for maigret.ai terminal output."""
 
+import io
 import os
 import subprocess
 import sys
+
+import pytest
+
+from maigret.ai import _stream_response, _write_encodable
 
 
 def _run_probe(tmp_path, name, lines, encoding):
@@ -78,3 +83,100 @@ def test_spinner_keeps_its_braille_when_the_stream_can_encode_it(tmp_path):
     assert result.returncode == 0, f"stderr={result.stderr!r}"
     braille = "".join(["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
     assert f"FRAMES={braille}" in result.stdout, f"stdout={result.stdout!r}"
+
+
+# --- the analysis itself, which goes to stdout --------------------------------
+
+CYRILLIC = "Привет"
+
+
+def cp1252(errors):
+    """A real cp1252 text stream, so the codec decides rather than a mock."""
+    return io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors=errors)
+
+
+def read_back(stream):
+    stream.flush()
+    return stream.buffer.getvalue().decode("cp1252")
+
+
+def test_raw_write_to_a_cp1252_stdout_is_what_fails():
+    """Pin the defect itself, so these tests fail if the platform changes.
+
+    surrogateescape is what sys.stdout actually carries here, and it is not a
+    guard against this: it rescues lone surrogates only, so an ordinary
+    unencodable character still raises.
+    """
+    stream = cp1252("surrogateescape")
+
+    with pytest.raises(UnicodeEncodeError):
+        stream.write(CYRILLIC)
+        stream.flush()
+
+
+@pytest.mark.parametrize("errors", ["strict", "surrogateescape"])
+def test_a_reply_outside_the_codepage_does_not_raise(errors):
+    stream = cp1252(errors)
+
+    _write_encodable(stream, CYRILLIC)
+
+    assert read_back(stream) == "?" * len(CYRILLIC)
+
+
+def test_a_reply_the_codepage_can_carry_is_written_unchanged():
+    """The replacement is a fallback, not the normal path."""
+    stream = cp1252("strict")
+
+    _write_encodable(stream, "Ana Gómez, née Muñoz")
+
+    assert read_back(stream) == "Ana Gómez, née Muñoz"
+
+
+def test_a_stream_that_does_not_raise_is_left_to_its_own_handler():
+    """The straight write comes first; replacement is only the recovery path.
+
+    A backslashreplace stream -- which is what sys.stderr carries -- encodes
+    without raising, so the helper must not reach for its fallback and flatten
+    the escapes to '?'. Without this case, always replacing passes every other
+    test here: the strings the codepage can carry round-trip unchanged, and the
+    ones it cannot raise either way.
+    """
+    stream = cp1252("backslashreplace")
+
+    _write_encodable(stream, CYRILLIC)
+
+    assert read_back(stream) == CYRILLIC.encode("cp1252", "backslashreplace").decode("cp1252")
+    assert "?" not in read_back(stream)
+
+
+def test_streaming_an_international_reply_finishes(monkeypatch):
+    """The end-to-end path. The exception propagated out of the coroutine and
+    ended the analysis mid-sentence, with the earlier tokens left on screen.
+    """
+    import asyncio
+
+    class FakeContent:
+        def __aiter__(self):
+            return self._lines()
+
+        async def _lines(self):
+            for token in ("Найден ", "профиль", " 完了"):
+                yield b'data: {"choices":[{"delta":{"content":"' + token.encode() + b'"}}]}'
+            yield b"data: [DONE]"
+
+    class FakeResp:
+        content = FakeContent()
+
+    class FakeSpinner:
+        def stop(self):
+            pass
+
+    stream = cp1252("surrogateescape")
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    _, analysis = asyncio.run(_stream_response(FakeResp(), FakeSpinner(), first_token=True))
+
+    # The value handed back to the caller is the real text; only the terminal
+    # copy is degraded to what the codepage can show.
+    assert analysis == "Найден профиль 完了"
+    assert "?" in read_back(stream)


### PR DESCRIPTION
Third of the same shape as #3050 (startup banners) and #3056 (result lines, and the spinner). The one terminal write in the AI module that was not covered is the analysis itself.

## The defect

`_stream_response()` writes each token of the model's reply straight to stdout:

```python
sys.stdout.write(content)
sys.stdout.flush()
```

The reply is arbitrary text. An OSINT run on an international username routinely comes back with Cyrillic or CJK. On Windows, Python takes stdout's encoding from the process ANSI codepage — cp1252 on a default install — so that write raises `UnicodeEncodeError`, the exception leaves the coroutine, and the analysis ends mid-sentence with the tokens already printed left on screen. `PYTHONIOENCODING` cannot rescue the PyInstaller build, which ignores `PYTHON*` variables.

**`surrogateescape` is not a guard here**, which is the part worth pinning. It is what `sys.stdout` actually carries, and it rescues lone surrogates only — an ordinary unencodable character still raises:

```
>>> "Привет".encode("cp1252", "surrogateescape")
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-5
```

`test_raw_write_to_a_cp1252_stdout_is_what_fails` asserts that, so the suite notices if the platform ever changes underneath the fix. The fix itself reuses the shape from the two merged PRs — `notify._print_encodable` — as a stream write rather than a print.

## A correction to something I wrote

The `_frames_for` docstring, which I added in #3056, says the braille frames *"raised UnicodeEncodeError inside the spinner's daemon thread: the thread died with a traceback over the output"*.

**They did not.** I only found this while probing upstream `main` for this PR. Unlike stdout, `sys.stderr`'s error handler is `backslashreplace`, and `PYTHONIOENCODING` does not change it:

| stream | encoding | errors | a braille frame |
|---|---|---|---|
| `sys.stdout` | cp1252 | `surrogateescape` | **raises** |
| `sys.stderr` | cp1252 | `backslashreplace` | prints `⠋` |

So the spinner never crashed — the animation just became a column of literal escapes. The fix was right; the reason I gave for it was not, and the difference between the two streams is exactly what this change turns on. The docstring now says what actually happens.

## Left alone

`print_streaming()` writes to stdout the same way and has the same defect, but it has no callers anywhere in the tree. I would rather not change code there is no way to exercise; happy to include it if you would prefer.

## Verification

6 tests added to `tests/test_ai.py`, driven by real `cp1252` `TextIOWrapper` streams rather than mocks, so the codec decides. Checked by breaking it:

| reverted | killed |
|---|---|
| stream the reply with a raw write again | `test_streaming_an_international_reply_finishes` |
| drop the helper's fallback, keep the call site | both `..._does_not_raise` cases + the end-to-end one |
| always replace, never write straight through | `test_a_stream_that_does_not_raise_is_left_to_its_own_handler` |

The last test exists because that third mutation **survived** my first draft: every other case here uses text cp1252 either carries unchanged or cannot carry at all, and both paths give the same bytes for those. A `backslashreplace` stream is the one that separates them.

Full suite on Windows: the set of failing test names is identical before and after (35 pre-existing, plus `tests/test_maigret.py`, which cannot be collected on Windows at all — `os.geteuid` does not exist there). `flake8` clean.
