### PR TITLE
Fix scan statistics leaking between sites

### DIFF
--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -108,6 +108,7 @@ class MaigretSite:
     def __init__(self, name, information):
         self.name = name
         self.url_subpath = ""
+        self.stats = {}
 
         for k, v in information.items():
             self.__dict__[CaseConverter.camel_to_snake(k)] = v

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -77,6 +77,16 @@ def test_site_correct_initialization():
     assert amperka.check_type == 'message'
 
 
+def test_site_stats_are_instance_local():
+    first = MaigretSite('First', {})
+    second = MaigretSite('Second', {})
+
+    first.stats['presense_flag'] = 'profile marker'
+
+    assert first.stats is not second.stats
+    assert 'presense_flag' not in second.stats
+
+
 def test_site_strip_engine_data():
     db = MaigretDatabase()
     db.load_from_json(EXAMPLE_DB)


### PR DESCRIPTION
## Summary
- initialize a fresh statistics dictionary for every MaigretSite instance
- prevent a presence marker recorded for one site from appearing in another site's statistics
- add regression coverage proving instance isolation

## Why
MaigretSite.stats was only a mutable class attribute. The checker mutates this dictionary while identifying presence markers, so sites without an instance value shared scan state and could report another site's marker.

## Testing
- python -m pytest tests/test_sites.py -q
- 25 passed

The broader checking test file requires optional async/server test dependencies not installed in this environment; its failures were environment-related and the focused site suite passes.