### PR TITLE
Let a site override an engine field instead of losing it

### DIFF
--- a/maigret/sites.py
+++ b/maigret/sites.py
@@ -34,6 +34,7 @@ class MaigretSite:
         "engineObj",
         "stats",
         "urlRegexp",
+        "statedFields",
     ]
 
     # Username known to exist on the site
@@ -111,6 +112,13 @@ class MaigretSite:
 
         for k, v in information.items():
             self.__dict__[CaseConverter.camel_to_snake(k)] = v
+
+        # What the entry stated for itself, as opposed to what this constructor
+        # synthesises (`alexa_rank` below) or an engine supplies later. Used to
+        # decide who wins when both name the same field.
+        self.stated_fields = {
+            CaseConverter.camel_to_snake(k) for k in information
+        }
 
         if (self.alexa_rank is None) or (self.alexa_rank == 0):
             # We do not know the popularity, so make site go to bottom of list.
@@ -291,6 +299,20 @@ class MaigretSite:
                 target.update(v)
             elif isinstance(v, list):
                 self.__dict__[field] = self.__dict__.get(field, []) + v
+            elif (
+                field in getattr(self, "stated_fields", set())
+                and self.__dict__.get(field) != v
+            ):
+                # The site said something different on purpose. An engine is a
+                # template, so the entry wins - otherwise a hand-written
+                # exception is not only ignored at runtime but deleted from
+                # data.json by strip_engine_data on the next save.
+                logger.warning(
+                    "Site %s overrides engine %s field %s",
+                    self.name,
+                    engine.name,
+                    field,
+                )
             else:
                 self.__dict__[field] = v
 
@@ -326,6 +348,10 @@ class MaigretSite:
                         self_copy.__dict__[field].remove(f)
                 continue
             if is_exists:
+                if self_copy.__dict__[field] != engine_data[k]:
+                    # A value the site set for itself is not engine data, and
+                    # stripping it would silently drop it from the database.
+                    continue
                 del self_copy.__dict__[field]
 
         return self_copy

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -115,6 +115,90 @@ def test_saving_site_error():
     assert amperka.strip_engine_data().json['errors'] == {'error1': 'text1'}
 
 
+def test_site_scalar_field_wins_over_engine(caplog):
+    """An engine is a template; a value the entry states itself is an exception.
+
+    Before this, the engine overwrote the site's scalar fields, so a
+    hand-written `urlProbe` was ignored at runtime - and then removed from
+    data.json by strip_engine_data on the next save, without a warning.
+    """
+    site = MaigretSite(
+        'Example',
+        {
+            'urlMain': 'https://example.com',
+            'urlProbe': 'https://example.com/site-specific?u={username}',
+        },
+    )
+    engine = MaigretEngine(
+        'ExampleEngine',
+        {
+            'site': {
+                'url': '{urlMain}/u/{username}',
+                'urlProbe': '{urlMain}/engine-default?u={username}',
+                'checkType': 'message',
+            },
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        site.update_from_engine(engine)
+
+    assert site.url_probe == 'https://example.com/site-specific?u={username}'
+    # fields the site said nothing about still come from the engine
+    assert site.url == '{urlMain}/u/{username}'
+    assert site.check_type == 'message'
+    assert any('overrides engine' in r.getMessage() for r in caplog.records)
+
+
+def test_strip_engine_data_keeps_site_override():
+    """The override has to survive a save, or it disappears from the database."""
+    site = MaigretSite(
+        'Example',
+        {
+            'urlMain': 'https://example.com',
+            'urlProbe': 'https://example.com/site-specific?u={username}',
+        },
+    )
+    engine = MaigretEngine(
+        'ExampleEngine',
+        {
+            'site': {
+                'url': '{urlMain}/u/{username}',
+                'urlProbe': '{urlMain}/engine-default?u={username}',
+                'checkType': 'message',
+            },
+        },
+    )
+    site.update_from_engine(engine)
+
+    stripped = site.strip_engine_data()
+
+    assert stripped.json['urlProbe'] == 'https://example.com/site-specific?u={username}'
+    # what did come from the engine is still stripped
+    assert 'url' not in stripped.json
+    assert 'checkType' not in stripped.json
+
+
+def test_constructor_defaults_do_not_count_as_site_overrides(caplog):
+    """Only what the entry stated counts - not what __init__ filled in.
+
+    `alexa_rank` is set to sys.maxsize for every entry that does not carry one,
+    so keying the rule off the instance dict made seventeen op.gg sites keep
+    that placeholder instead of the rank their engine supplies.
+    """
+    site = MaigretSite('Example', {'urlMain': 'https://example.com'})
+    engine = MaigretEngine(
+        'ExampleEngine',
+        {'site': {'url': '{urlMain}/u/{username}', 'alexaRank': 331}},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        site.update_from_engine(engine)
+
+    assert site.alexa_rank == 331
+    assert not [r for r in caplog.records if 'overrides engine' in r.getMessage()]
+
+
 def test_update_from_engine_warns_on_conflicting_dict_entries(caplog):
     site = MaigretSite(
         'Example',
@@ -401,9 +485,13 @@ def test_get_url_template():
 def test_update_site_replaces_existing_entry():
     """update_site() must replace the list element, not just rebind a loop variable."""
     db = MaigretDatabase()
-    db.update_site(MaigretSite('Example', {'urlMain': 'https://example.com', 'disabled': False}))
+    db.update_site(
+        MaigretSite('Example', {'urlMain': 'https://example.com', 'disabled': False})
+    )
 
-    updated = MaigretSite('Example', {'urlMain': 'https://example.com', 'disabled': True})
+    updated = MaigretSite(
+        'Example', {'urlMain': 'https://example.com', 'disabled': True}
+    )
     db.update_site(updated)
 
     # The database must contain exactly one entry and it must be the updated one


### PR DESCRIPTION
An engine is a template, but `update_from_engine` overwrites a site's scalar
fields with the engine's, and `strip_engine_data` then removes them on save. A
value written into an entry by hand is therefore ignored at runtime **and
deleted from `data.json`** the next time anything calls `save_to_file` — which
`utils/update_site_data.py` does on every regeneration. Nothing is printed: the
dict case already warns about a collision, the scalar case did not.

Found while giving MediaWiki entries a JSON `urlProbe`. The API path is not the
page path — a wiki with articles under `/wiki` keeps `api.php` under `/w` — so
a per-entry probe is the natural way to say it, and it turned out to be
impossible.

Now the entry wins and the override survives the round trip, with the same
warning the dict case prints.

Only fields the entry **stated** count. The constructor synthesises
`alexa_rank` for every site that does not carry one, so keying the rule off the
instance dict made seventeen op.gg sites keep that placeholder instead of the
rank their engine supplies; there is a test for exactly that, next to one for
the override winning and one for it surviving `strip_engine_data`.

The shipped database is unchanged — it round-trips byte for byte through load
and save, and no entry currently sets a field its engine also defines.
