### PR TITLE
Route the database auto-update through --proxy

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -59,7 +59,7 @@ def _is_dns_error(exc: Exception) -> bool:
     return any(m in text for m in _DNS_ERROR_MARKERS)
 
 
-# The two HTTP transports disagree about what a SOCKS5 proxy URL means.
+# The HTTP transports disagree about what a SOCKS5 proxy URL means.
 #
 #   python_socks (via aiohttp_socks, used by SimpleAiohttpChecker)
 #     accepts exactly socks5/socks4/http and raises
@@ -73,6 +73,9 @@ def _is_dns_error(exc: Exception) -> bool:
 #     client and passes an address to the proxy, socks5h:// passes the
 #     hostname and lets the proxy resolve it.
 #
+#   requests (via PySocks, used by the database auto-update in db_updater)
+#     draws the same distinction as libcurl.
+#
 # So a single `--proxy socks5://...` resolves most of the database at the
 # proxy but the tls_fingerprint sites locally: their hostnames leak to the
 # local resolver, and geo-balanced hosts get resolved for the wrong network.
@@ -84,10 +87,12 @@ def _is_dns_error(exc: Exception) -> bool:
 # so rewriting socks4 would change behavior instead of aligning it.
 PYTHON_SOCKS_TRANSPORT = 'python_socks'
 LIBCURL_TRANSPORT = 'libcurl'
+REQUESTS_TRANSPORT = 'requests'
 
 _PROXY_SCHEME_ALIASES = {
     PYTHON_SOCKS_TRANSPORT: {'socks5h': 'socks5'},
     LIBCURL_TRANSPORT: {'socks5': 'socks5h'},
+    REQUESTS_TRANSPORT: {'socks5': 'socks5h'},
 }
 
 

--- a/maigret/db_updater.py
+++ b/maigret/db_updater.py
@@ -97,9 +97,32 @@ def _needs_check(state: dict, interval_hours: int) -> bool:
         return True
 
 
-def _fetch_meta(meta_url: str, timeout: int = 10) -> Optional[dict]:
+def _proxies(proxy: Optional[str]) -> Optional[dict]:
+    """Build the requests proxy mapping for --proxy, or None when it is unset.
+
+    None keeps the previous behavior of letting requests read HTTP_PROXY /
+    HTTPS_PROXY from the environment. A mapping always wins over those, so an
+    explicit --proxy cannot be bypassed by NO_PROXY.
+
+    When the proxy is unreachable requests raises, the caller reports the
+    update as failed and keeps the local database. There is deliberately no
+    fallback to a direct request: that would leak the real IP on exactly the
+    path the proxy was meant to cover.
+    """
+    if not proxy:
+        return None
+
+    # Imported here, not at module level: checking imports activation, which
+    # imports this module, so a top-level import would close the cycle.
+    from .checking import REQUESTS_TRANSPORT, normalize_proxy_scheme
+
+    normalized = normalize_proxy_scheme(proxy, REQUESTS_TRANSPORT)
+    return {"http": normalized, "https": normalized}
+
+
+def _fetch_meta(meta_url: str, timeout: int = 10, proxy: Optional[str] = None) -> Optional[dict]:
     try:
-        response = requests.get(meta_url, timeout=timeout)
+        response = requests.get(meta_url, timeout=timeout, proxies=_proxies(proxy))
         if response.status_code == 200:
             return response.json()
     except Exception:
@@ -120,11 +143,16 @@ def _is_update_available(meta: dict, state: dict) -> bool:
     return remote_date > cached_date
 
 
-def _download_and_verify(data_url: str, expected_sha256: str, timeout: int = 60) -> Optional[str]:
+def _download_and_verify(
+    data_url: str,
+    expected_sha256: str,
+    timeout: int = 60,
+    proxy: Optional[str] = None,
+) -> Optional[str]:
     _ensure_maigret_home()
     tmp_fd, tmp_path = tempfile.mkstemp(dir=MAIGRET_HOME, suffix=".json")
     try:
-        response = requests.get(data_url, timeout=timeout)
+        response = requests.get(data_url, timeout=timeout, proxies=_proxies(proxy))
         if response.status_code != 200:
             return None
 
@@ -179,6 +207,7 @@ def resolve_db_path(
     meta_url: str = DEFAULT_META_URL,
     check_interval_hours: int = DEFAULT_CHECK_INTERVAL_HOURS,
     color: bool = True,
+    proxy: Optional[str] = None,
 ) -> str:
     """
     Determine which database file to use, potentially downloading an update.
@@ -222,7 +251,7 @@ def resolve_db_path(
 
     # Time to check
     _print_info("DB auto-update: checking for updates...")
-    meta = _fetch_meta(meta_url)
+    meta = _fetch_meta(meta_url, proxy=proxy)
     if meta is None:
         _print_warning("DB auto-update: could not reach update server, using local database")
         state["last_check_at"] = _now_iso()
@@ -259,7 +288,7 @@ def resolve_db_path(
 
     data_url = meta.get("data_url", "")
     expected_sha = meta.get("data_sha256", "")
-    result = _download_and_verify(data_url, expected_sha)
+    result = _download_and_verify(data_url, expected_sha, proxy=proxy)
 
     if result is None:
         _print_warning("DB auto-update: download failed, using local database")
@@ -278,6 +307,7 @@ def resolve_db_path(
 def force_update(
     meta_url: str = DEFAULT_META_URL,
     color: bool = True,
+    proxy: Optional[str] = None,
 ) -> bool:
     """
     Force check for database updates and download if available.
@@ -290,7 +320,7 @@ def force_update(
     _ensure_maigret_home()
 
     _print_info("DB update: checking for updates...")
-    meta = _fetch_meta(meta_url)
+    meta = _fetch_meta(meta_url, proxy=proxy)
     if meta is None:
         _print_warning("DB update: could not reach update server")
         return False
@@ -321,7 +351,7 @@ def force_update(
 
     data_url = meta.get("data_url", "")
     expected_sha = meta.get("data_sha256", "")
-    result = _download_and_verify(data_url, expected_sha)
+    result = _download_and_verify(data_url, expected_sha, proxy=proxy)
 
     if result is None:
         _print_warning("DB update: download failed")

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -690,6 +690,7 @@ async def main():
         force_update(
             meta_url=settings.db_update_meta_url,
             color=not args.no_color,
+            proxy=args.proxy,
         )
 
     try:
@@ -699,6 +700,7 @@ async def main():
             meta_url=settings.db_update_meta_url,
             check_interval_hours=settings.autoupdate_check_interval_hours,
             color=not args.no_color,
+            proxy=args.proxy,
         )
     except FileNotFoundError as e:
         logger.error(str(e))

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -1981,6 +1981,11 @@ def test_both_checkers_agree_on_proxy_side_dns():
             'socks5://user:p%40ss@[::1]:1080',
             'socks5h://user:p%40ss@[::1]:1080',
         ),
+        (
+            'requests',
+            'socks5://user:p%40ss@[::1]:1080',
+            'socks5h://user:p%40ss@[::1]:1080',
+        ),
         # the scheme match is case-insensitive, like every other URL scheme
         ('python_socks', 'SOCKS5H://127.0.0.1:1080', 'socks5://127.0.0.1:1080'),
         ('libcurl', 'Socks5://127.0.0.1:1080', 'socks5h://127.0.0.1:1080'),

--- a/tests/test_db_updater.py
+++ b/tests/test_db_updater.py
@@ -7,10 +7,12 @@ from datetime import datetime, timezone, timedelta
 from unittest.mock import patch, MagicMock
 
 import pytest
+import requests
 
 from maigret.db_updater import (
     _parse_version,
     _needs_check,
+    _fetch_meta,
     _is_version_compatible,
     _is_update_available,
     _load_state,
@@ -234,3 +236,81 @@ def test_force_update_download_fails(mock_fetch, mock_download, tmp_path):
         with patch("maigret.db_updater.STATE_PATH", str(tmp_path / "state.json")):
             with patch("maigret.db_updater.CACHED_DB_PATH", str(tmp_path / "missing.json")):
                 assert force_update() is False
+
+
+# --- proxy plumbing (issue #3108) ---
+
+PROXY = "socks5://127.0.0.1:9050"
+# PySocks, like libcurl, needs socks5h:// to resolve hostnames at the proxy.
+PROXIED = {"http": "socks5h://127.0.0.1:9050", "https": "socks5h://127.0.0.1:9050"}
+
+
+def _response(payload: bytes):
+    response = MagicMock()
+    response.status_code = 200
+    response.content = payload
+    response.json.return_value = json.loads(payload)
+    return response
+
+
+@patch("maigret.db_updater.requests.get")
+def test_fetch_meta_without_proxy_keeps_environment_in_charge(mock_get):
+    mock_get.return_value = _response(b'{"sites_count": 1}')
+    assert _fetch_meta("https://example.com/db_meta.json") == {"sites_count": 1}
+    # HTTP_PROXY / HTTPS_PROXY must still be honoured when --proxy is unset
+    assert mock_get.call_args.kwargs["proxies"] is None
+
+
+@patch("maigret.db_updater.requests.get")
+def test_resolve_db_path_sends_every_request_through_the_proxy(mock_get, tmp_path):
+    payload = json.dumps({"sites": {}, "engines": {}, "tags": []}).encode()
+    meta = {
+        "min_maigret_version": "0.1.0",
+        "sites_count": 3200,
+        "updated_at": "2099-01-01T00:00:00Z",
+        "data_url": "https://example.com/data.json",
+        "data_sha256": hashlib.sha256(payload).hexdigest(),
+    }
+    mock_get.side_effect = [_response(json.dumps(meta).encode()), _response(payload)]
+    cached = tmp_path / "data.json"
+    with patch("maigret.db_updater.MAIGRET_HOME", str(tmp_path)):
+        with patch("maigret.db_updater.STATE_PATH", str(tmp_path / "state.json")):
+            with patch("maigret.db_updater.CACHED_DB_PATH", str(cached)):
+                assert resolve_db_path("resources/data.json", proxy=PROXY) == str(cached)
+
+    # the meta check and the database download both leave through the proxy
+    assert len(mock_get.call_args_list) == 2
+    assert [call.kwargs["proxies"] for call in mock_get.call_args_list] == [PROXIED, PROXIED]
+
+
+@patch("maigret.db_updater.requests.get")
+def test_resolve_db_path_keeps_local_db_when_the_proxy_is_down(mock_get, tmp_path):
+    mock_get.side_effect = requests.exceptions.ConnectionError("proxy refused")
+    with patch("maigret.db_updater.MAIGRET_HOME", str(tmp_path)):
+        with patch("maigret.db_updater.STATE_PATH", str(tmp_path / "state.json")):
+            with patch("maigret.db_updater.CACHED_DB_PATH", str(tmp_path / "missing.json")):
+                assert resolve_db_path("resources/data.json", proxy=PROXY) == BUNDLED_DB_PATH
+
+    # exactly one attempt, through the proxy: a direct retry would leak the IP
+    assert mock_get.call_count == 1
+    assert mock_get.call_args.kwargs["proxies"] == PROXIED
+
+
+@patch("maigret.db_updater._download_and_verify")
+@patch("maigret.db_updater._fetch_meta")
+def test_force_update_passes_proxy_down(mock_fetch, mock_download, tmp_path):
+    mock_fetch.return_value = {
+        "min_maigret_version": "0.1.0",
+        "sites_count": 3200,
+        "updated_at": "2099-01-01T00:00:00Z",
+        "data_url": "https://example.com/data.json",
+        "data_sha256": "abc123",
+    }
+    mock_download.return_value = str(tmp_path / "data.json")
+    with patch("maigret.db_updater.MAIGRET_HOME", str(tmp_path)):
+        with patch("maigret.db_updater.STATE_PATH", str(tmp_path / "state.json")):
+            with patch("maigret.db_updater.CACHED_DB_PATH", str(tmp_path / "missing.json")):
+                assert force_update(proxy=PROXY) is True
+
+    assert mock_fetch.call_args.kwargs["proxy"] == PROXY
+    assert mock_download.call_args.kwargs["proxy"] == PROXY


### PR DESCRIPTION
Fixes #3108

`resolve_db_path()` runs from `maigret.py` before any site check, and both of its HTTP calls were bare `requests.get()`: `_fetch_meta()` for `db_meta.json` and `_download_and_verify()` for `data.json`. Auto-update is on by default, so a run started with `--proxy` still reached `raw.githubusercontent.com` from the real address once every 24 hours. Only `HTTP_PROXY` / `HTTPS_PROXY` worked, by accident of `requests` reading them on its own.

## Changes

- `db_updater`: new `_proxies()` helper, threaded through `_fetch_meta()`, `_download_and_verify()`, `resolve_db_path()` and `force_update()`. `--proxy` now covers `--force-update` too, not just the automatic 24-hour check.
- `checking`: added `REQUESTS_TRANSPORT` to the `normalize_proxy_scheme()` table from #2966. PySocks draws the same `socks5://` vs `socks5h://` distinction as libcurl, so `--proxy socks5://...` resolves DNS at the proxy here as well.
- `maigret.py`: passes `args.proxy` to both entry points.

## Behaviour on failure

No fallback to a direct request. When the proxy is down `requests` raises, the existing handler prints "could not reach update server" and keeps the local database — as suggested in the issue, since a direct retry would put the leak back on exactly the path the proxy was meant to cover. Verified against a dead SOCKS5 proxy:

```
no proxy   -> reached update server
dead proxy -> blocked, update fails quietly
```

Passing `proxies` explicitly also beats the environment, so a stray `NO_PROXY` cannot bypass `--proxy` (checked against the pinned requests 2.34.2: env proxies are only `setdefault` into the mapping, and `NO_PROXY` only suppresses *adding* them).

With `--proxy` unset, `_proxies()` returns `None` and the environment stays in charge, so nothing changes for people relying on `HTTP_PROXY`.

## Tests

Four tests in `tests/test_db_updater.py` (all four fail on `main`, pass here), plus a `requests` row in the existing `normalize_proxy_scheme` parametrize. Offline suite: 458 passed.

The `activation` → `db_updater` import chain makes a module-level `from .checking import ...` circular, so that one import sits inside `_proxies()` with a comment saying why.

The other paths listed at the bottom of the issue (`activation.py`, `ai.py`, `sites.py`) are untouched — happy to follow up on them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
