### PR TITLE
Fix social.tchncs.de false-positive check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -14283,6 +14283,7 @@
             "regexCheck": "^[a-zA-Z0-9_]+$",
             "urlMain": "https://social.tchncs.de/",
             "url": "https://social.tchncs.de/@{username}",
+            "urlProbe": "https://social.tchncs.de/api/v1/accounts/lookup?acct={username}",
             "usernameClaimed": "Milan",
             "usernameUnclaimed": "noonewouldeverusethis7"
         },

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-09-09T06:17:17Z",
+    "updated_at": "2026-09-09T08:05:35Z",
     "sites_count": 5369,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "e534b34f48b4ef9d391a1766b4bef0d6ffc133f106b22174763266228a8a5f69",
+    "data_sha256": "2318273fdbe0ee7ddd6829758885eb66e4abd4f5e7882644b86d3114c6fe07dc",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }


### PR DESCRIPTION
## Summary
- social.tchncs.de HTML is behind Anubis: every username probe returns HTTP 200 → false positives with `checkType: status_code` on the profile URL.
- Add Mastodon `urlProbe` to `/api/v1/accounts/lookup?acct={username}` so claimed accounts stay 200 and missing accounts return 404.
- Regenerate `db_meta.json` / `sites.md` via repo hooks.

Closes #3080.

Same pattern as Substack `urlProbe` and prior site FP fixes (#2929, #3100).

## Validation
- Live lookup `Milan` → 200
- Live lookup fake username → 404