### PR TITLE
fix(db): route the database auto-update through --proxy

### DIFF
--- a/maigret/db_updater.py
+++ b/maigret/db_updater.py
@@ -24,6 +24,27 @@ logger = logging.getLogger("maigret")
 _use_color = True
 
 
+def _proxies_for(proxy: Optional[str]) -> Optional[dict]:
+    """Build the ``proxies`` mapping for the update requests.
+
+    Returns None when no proxy was given, so ``requests`` keeps honouring
+    HTTP_PROXY / HTTPS_PROXY as it does today.
+
+    The scheme is normalised for this transport first. ``requests`` resolves
+    hostnames locally for ``socks5://`` and through the proxy for
+    ``socks5h://`` (urllib3's SOCKSProxyManager sets ``rdns`` off the scheme),
+    so passing the user's value through unchanged would still leak the DNS
+    lookup for the update host outside the tunnel.
+    """
+    if not proxy:
+        return None
+
+    from .checking import LIBCURL_TRANSPORT, normalize_proxy_scheme
+
+    normalized = normalize_proxy_scheme(proxy, LIBCURL_TRANSPORT)
+    return {"http": normalized, "https": normalized}
+
+
 def _print(prefix: str, color: str, msg: str) -> None:
     text = f"[{prefix}] {msg}"
     print(Style.BRIGHT + color + text + Style.RESET_ALL if _use_color else text)
@@ -97,9 +118,11 @@ def _needs_check(state: dict, interval_hours: int) -> bool:
         return True
 
 
-def _fetch_meta(meta_url: str, timeout: int = 10) -> Optional[dict]:
+def _fetch_meta(
+    meta_url: str, timeout: int = 10, proxy: Optional[str] = None
+) -> Optional[dict]:
     try:
-        response = requests.get(meta_url, timeout=timeout)
+        response = requests.get(meta_url, timeout=timeout, proxies=_proxies_for(proxy))
         if response.status_code == 200:
             return response.json()
     except Exception:
@@ -120,11 +143,16 @@ def _is_update_available(meta: dict, state: dict) -> bool:
     return remote_date > cached_date
 
 
-def _download_and_verify(data_url: str, expected_sha256: str, timeout: int = 60) -> Optional[str]:
+def _download_and_verify(
+    data_url: str,
+    expected_sha256: str,
+    timeout: int = 60,
+    proxy: Optional[str] = None,
+) -> Optional[str]:
     _ensure_maigret_home()
     tmp_fd, tmp_path = tempfile.mkstemp(dir=MAIGRET_HOME, suffix=".json")
     try:
-        response = requests.get(data_url, timeout=timeout)
+        response = requests.get(data_url, timeout=timeout, proxies=_proxies_for(proxy))
         if response.status_code != 200:
             return None
 
@@ -179,6 +207,7 @@ def resolve_db_path(
     meta_url: str = DEFAULT_META_URL,
     check_interval_hours: int = DEFAULT_CHECK_INTERVAL_HOURS,
     color: bool = True,
+    proxy: Optional[str] = None,
 ) -> str:
     """
     Determine which database file to use, potentially downloading an update.
@@ -222,7 +251,7 @@ def resolve_db_path(
 
     # Time to check
     _print_info("DB auto-update: checking for updates...")
-    meta = _fetch_meta(meta_url)
+    meta = _fetch_meta(meta_url, proxy=proxy)
     if meta is None:
         _print_warning("DB auto-update: could not reach update server, using local database")
         state["last_check_at"] = _now_iso()
@@ -259,7 +288,7 @@ def resolve_db_path(
 
     data_url = meta.get("data_url", "")
     expected_sha = meta.get("data_sha256", "")
-    result = _download_and_verify(data_url, expected_sha)
+    result = _download_and_verify(data_url, expected_sha, proxy=proxy)
 
     if result is None:
         _print_warning("DB auto-update: download failed, using local database")
@@ -278,6 +307,7 @@ def resolve_db_path(
 def force_update(
     meta_url: str = DEFAULT_META_URL,
     color: bool = True,
+    proxy: Optional[str] = None,
 ) -> bool:
     """
     Force check for database updates and download if available.
@@ -290,7 +320,7 @@ def force_update(
     _ensure_maigret_home()
 
     _print_info("DB update: checking for updates...")
-    meta = _fetch_meta(meta_url)
+    meta = _fetch_meta(meta_url, proxy=proxy)
     if meta is None:
         _print_warning("DB update: could not reach update server")
         return False
@@ -321,7 +351,7 @@ def force_update(
 
     data_url = meta.get("data_url", "")
     expected_sha = meta.get("data_sha256", "")
-    result = _download_and_verify(data_url, expected_sha)
+    result = _download_and_verify(data_url, expected_sha, proxy=proxy)
 
     if result is None:
         _print_warning("DB update: download failed")

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -690,6 +690,7 @@ async def main():
         force_update(
             meta_url=settings.db_update_meta_url,
             color=not args.no_color,
+            proxy=args.proxy,
         )
 
     try:
@@ -699,6 +700,7 @@ async def main():
             meta_url=settings.db_update_meta_url,
             check_interval_hours=settings.autoupdate_check_interval_hours,
             color=not args.no_color,
+            proxy=args.proxy,
         )
     except FileNotFoundError as e:
         logger.error(str(e))

--- a/tests/test_db_updater.py
+++ b/tests/test_db_updater.py
@@ -234,3 +234,94 @@ def test_force_update_download_fails(mock_fetch, mock_download, tmp_path):
         with patch("maigret.db_updater.STATE_PATH", str(tmp_path / "state.json")):
             with patch("maigret.db_updater.CACHED_DB_PATH", str(tmp_path / "missing.json")):
                 assert force_update() is False
+
+
+class TestUpdateProxy:
+    """The auto-update must go through --proxy (#3108).
+
+    resolve_db_path() runs before the first site check and, until this was
+    fixed, fetched db_meta.json and data.json over the direct connection. A
+    user following TROUBLESHOOTING.md's `--proxy socks5://127.0.0.1:9050`
+    advice believed the whole run was tunnelled; the leak happened before any
+    result was printed, so nothing in the output revealed it.
+    """
+
+    def test_no_proxy_leaves_requests_alone(self):
+        """Without --proxy, requests keeps reading HTTP_PROXY / HTTPS_PROXY."""
+        from maigret.db_updater import _proxies_for
+
+        assert _proxies_for(None) is None
+        assert _proxies_for("") is None
+
+    def test_proxy_is_applied_to_both_schemes(self):
+        from maigret.db_updater import _proxies_for
+
+        assert _proxies_for("http://127.0.0.1:8080") == {
+            "http": "http://127.0.0.1:8080",
+            "https": "http://127.0.0.1:8080",
+        }
+
+    def test_socks5_is_upgraded_to_socks5h(self):
+        """Otherwise the DNS lookup for the update host still leaks.
+
+        urllib3's SOCKSProxyManager sets rdns from the scheme: socks5 resolves
+        hostnames locally, socks5h resolves them through the proxy. Passing the
+        user's value through unchanged would tunnel the connection but not the
+        name lookup that precedes it.
+        """
+        from maigret.db_updater import _proxies_for
+
+        proxies = _proxies_for("socks5://127.0.0.1:9050")
+        assert proxies == {
+            "http": "socks5h://127.0.0.1:9050",
+            "https": "socks5h://127.0.0.1:9050",
+        }
+
+    def test_socks5h_is_left_as_is(self):
+        from maigret.db_updater import _proxies_for
+
+        proxies = _proxies_for("socks5h://127.0.0.1:9050")
+        assert proxies["https"] == "socks5h://127.0.0.1:9050"
+
+    def test_fetch_meta_passes_the_proxy(self):
+        from maigret.db_updater import _fetch_meta
+
+        with patch("maigret.db_updater.requests.get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=200, json=lambda: {})
+            _fetch_meta("https://example.com/db_meta.json", proxy="socks5://127.0.0.1:9050")
+
+        assert mock_get.call_args.kwargs["proxies"] == {
+            "http": "socks5h://127.0.0.1:9050",
+            "https": "socks5h://127.0.0.1:9050",
+        }
+
+    def test_download_passes_the_proxy(self, tmp_path):
+        from maigret.db_updater import _download_and_verify
+
+        payload = json.dumps({"sites": {}, "engines": {}, "tags": {}}).encode()
+        digest = hashlib.sha256(payload).hexdigest()
+
+        with patch("maigret.db_updater.requests.get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=200, content=payload)
+            _download_and_verify(
+                "https://example.com/data.json", digest, proxy="socks5://127.0.0.1:9050"
+            )
+
+        assert mock_get.call_args.kwargs["proxies"] == {
+            "http": "socks5h://127.0.0.1:9050",
+            "https": "socks5h://127.0.0.1:9050",
+        }
+
+    def test_a_dead_proxy_does_not_fall_back_to_a_direct_request(self):
+        """Failing the update is correct; retrying without the proxy is not.
+
+        A fallback would reintroduce the very leak this guards against, on the
+        one path where the user is most likely to be relying on the tunnel.
+        """
+        from maigret.db_updater import _fetch_meta
+
+        with patch("maigret.db_updater.requests.get") as mock_get:
+            mock_get.side_effect = Exception("proxy refused")
+            assert _fetch_meta("https://example.com/db_meta.json", proxy="socks5://x:1") is None
+
+        assert mock_get.call_count == 1


### PR DESCRIPTION
Closes #3108.

The auto-update ran before the first site check and fetched `db_meta.json` and `data.json` with plain `requests.get()` calls that never received the proxy. It is on by default and fires once every 24 hours, so a user passing `--proxy` sent one request a day to `raw.githubusercontent.com` from their real address — and `TROUBLESHOOTING.md` recommends that exact flag for anonymising a run, so the expectation was that the whole run is tunnelled.

## Two things beyond what the issue described

**`--force-update` leaked the same way.** `force_update()` reaches the same two helpers, so it is fixed here too rather than left for a follow-up.

**`socks5://` alone would still leak the DNS lookup.** The issue suggests `proxies={"http": proxy, "https": proxy}`. Passing the user's value through unchanged is not enough: urllib3's `SOCKSProxyManager` derives `rdns` from the scheme —

```python
if parsed.scheme == "socks5":
    rdns = False
elif parsed.scheme == "socks5h":
    rdns = True
```

— so `socks5://127.0.0.1:9050`, the spelling `TROUBLESHOOTING.md` prints, tunnels the connection while still resolving `raw.githubusercontent.com` locally. The name lookup the tunnel was meant to cover would leak. `normalize_proxy_scheme()` from #2966 already knows this rewrite, so the fix reuses it rather than adding a second spelling rule.

## Behaviour preserved

- No proxy given means no `proxies` argument at all, so `HTTP_PROXY` / `HTTPS_PROXY` keep being honoured by `requests` exactly as before.
- A failing proxy fails the update and keeps the local database. There is deliberately no direct-connection retry: that would reintroduce the leak on the one path where the user is most likely relying on the tunnel. Covered by a test.

## Tests

Seven new cases in `tests/test_db_updater.py`: no-proxy stays untouched, both schemes get the proxy, `socks5` is upgraded, `socks5h` is left alone, both `_fetch_meta` and `_download_and_verify` actually receive it, and a dead proxy makes exactly one attempt with no fallback.

`tests/test_db_updater.py` passes in full (32 tests). `tests/test_checking.py` and `tests/test_cli.py` show 35 failures in my environment, but they are identical on a clean `main` — unrelated to this change, and I could not get those optional dependencies installed locally.

## Not addressed here

The other call sites the issue lists — `activation.py`, `ai.py:149`, `sites.py:562` — are untouched. They are a different shape of problem (aiohttp sessions and `--db <url>` loading) and worth their own change; happy to follow up if you want them.
