### PR TITLE
Fix Framapiaf false-positive check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -17197,6 +17197,7 @@
             "checkType": "status_code",
             "urlMain": "https://framapiaf.org",
             "url": "https://framapiaf.org/@{username}",
+            "urlProbe": "https://framapiaf.org/api/v1/accounts/lookup?acct={username}",
             "usernameClaimed": "pylapp",
             "usernameUnclaimed": "noonewouldeverusethis42",
             "alexaRank": 46767

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-09-09T16:38:26Z",
+    "updated_at": "2026-09-09T18:57:41Z",
     "sites_count": 5373,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "f12e8c8ff0a27b1a7904386ec58411f2b611cdc09e3a1bb99a75db8dc9883c2c",
+    "data_sha256": "82752e83c066ef3a828df06fae9a31ef756889a0884ecb23a5f55daa03836658",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }


### PR DESCRIPTION
## Summary
- Adds `urlProbe` to the Mastodon accounts lookup API for `Framapiaf` (`framapiaf.org`) so missing accounts correctly 404.
- Same pattern as #3111 (social.tchncs.de). Closes #3114.

## Test plan
- [x] Claimed `pylapp` → API 200
- [x] Unclaimed usernames → API 404 `Record not found`
- [ ] CI green on 3.10–3.14 + minimal-install