### PR TITLE
Fix infosec.exchange false-positive risk (Mastodon urlProbe)

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -46154,6 +46154,7 @@
             "usernameClaimed": "kevinrothrock",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "url": "https://infosec.exchange/@{username}",
+            "urlProbe": "https://infosec.exchange/api/v1/accounts/lookup?acct={username}",
             "checkType": "status_code"
         },
         "universeodon.com": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-09-09T16:38:26Z",
+    "updated_at": "2026-09-09T18:57:44Z",
     "sites_count": 5373,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "f12e8c8ff0a27b1a7904386ec58411f2b611cdc09e3a1bb99a75db8dc9883c2c",
+    "data_sha256": "68e7c8424611d7ddd30e3175713b8a38ef69066507039979cb6f2a563699aebb",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }


### PR DESCRIPTION
## Summary
- Adds Mastodon `urlProbe` (`/api/v1/accounts/lookup?acct={username}`) for **infosec.exchange**.
- Same pattern as #3111 / #3115.
Hardens status_code check that can false-positive on Mastodon profile routes.

## Test plan
- [x] API returns 404 for missing usernames
- [ ] CI green 3.10–3.14 + minimal-install