### PR TITLE
Fix hachyderm.io false-positive risk (Mastodon urlProbe)

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -46254,6 +46254,7 @@
             "usernameClaimed": "SnoopJ",
             "usernameUnclaimed": "noonewouldeverusethis7",
             "url": "https://hachyderm.io/@{username}",
+            "urlProbe": "https://hachyderm.io/api/v1/accounts/lookup?acct={username}",
             "checkType": "status_code"
         },
         "mstdn.party": {

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-09-09T16:38:26Z",
+    "updated_at": "2026-09-09T18:57:49Z",
     "sites_count": 5373,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "f12e8c8ff0a27b1a7904386ec58411f2b611cdc09e3a1bb99a75db8dc9883c2c",
+    "data_sha256": "37823f1985c2cd8c50c417da7993adde4c01cf7a489757849b0a029292ab706b",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }


### PR DESCRIPTION
## Summary
- Adds Mastodon `urlProbe` (`/api/v1/accounts/lookup?acct={username}`) for **hachyderm.io**.
- Same pattern as #3111 / #3115.
Hardens status_code check that can false-positive on Mastodon profile routes.

## Test plan
- [x] API returns 404 for missing usernames
- [ ] CI green 3.10–3.14 + minimal-install