### PR TITLE
Drop the duplicate DB save that crashed --submit --db

### DIFF
--- a/maigret/submit.py
+++ b/maigret/submit.py
@@ -660,11 +660,4 @@ class Submitter:
         final_site = old_site if old_site else stripped_site
         self.db.update_site(final_site)
 
-        # save the db in file
-        if self.args.db_file != self.settings.sites_db_path:
-            print(
-                f"{Fore.GREEN}[+] Maigret DB is saved to {self.args.db}.{Style.RESET_ALL}"
-            )
-            self.db.save_to_file(self.args.db)
-
         return True

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -209,6 +209,41 @@ async def test_dialog_selects_status_code_check(settings):
 
 
 @pytest.mark.asyncio
+async def test_dialog_completes_with_parser_built_args(settings, tmp_path):
+    # The dialog tests above hand Submitter a MagicMock, which answers to any
+    # attribute name -- a reference to an attribute argparse never builds stays
+    # invisible there. At runtime Submitter gets the namespace below, where --db
+    # lands on `db_file`.
+    from maigret.maigret import setup_arguments_parser
+
+    args = setup_arguments_parser(settings).parse_args(
+        [
+            "--db",
+            str(tmp_path / "custom_db.json"),
+            "--submit",
+            "https://example.com/claimed",
+        ]
+    )
+    assert args.db_file == str(tmp_path / "custom_db.json")
+    assert not hasattr(args, "db")
+
+    db = MaigretDatabase()
+    submitter = Submitter(db, settings, logging.getLogger("test_logger"), args)
+    submitter.detect_known_engine = AsyncMock(return_value=([], ""))
+    submitter.extract_username_dialog = MagicMock(return_value="claimed")
+    submitter.check_features_manually = AsyncMock(
+        return_value=(None, None, "Found", "unclaimed", 200, 404)
+    )
+    submitter.site_self_check = AsyncMock(return_value={"disabled": False})
+
+    with patch('builtins.input', side_effect=['y', '', '']):
+        result = await submitter.dialog("https://example.com/claimed", None)
+
+    assert result is True
+    assert len(db.sites) == 1
+
+
+@pytest.mark.asyncio
 async def test_dialog_keeps_message_check_for_redirect(settings):
     db = MaigretDatabase()
     args = MagicMock(


### PR DESCRIPTION
## The bug

`maigret --submit <url> --db custom.json` runs the entire interactive dialog, then
raises on the last step:

```
AttributeError: 'Namespace' object has no attribute 'db'
```

`Submitter.dialog` ends with (`maigret/submit.py:663-668`):

```python
# save the db in file
if self.args.db_file != self.settings.sites_db_path:
    print(
        f"{Fore.GREEN}[+] Maigret DB is saved to {self.args.db}.{Style.RESET_ALL}"
    )
    self.db.save_to_file(self.args.db)
```

`self.args.db` does not exist. `maigret.py:234` declares the option with
`dest="db_file"`, and the guard on the line directly above reads `self.args.db_file` —
the correct name is quoted two lines up from the one that crashes. `args.db` appears
nowhere else in the tree.

Confirmed against the real parser:

```
>>> ns = setup_arguments_parser(settings).parse_args(['--db', 'mydb.json', 'user'])
>>> hasattr(ns, 'db_file'), hasattr(ns, 'db')
(True, False)
```

The exception propagates out of `main()` — the `--submit` call at `maigret.py:759` is
unguarded and `run()` catches only `KeyboardInterrupt` — so `dialog()` never returns
`True`, `save_db_safely()` at `maigret.py:761` never runs either, and **the submitted
site is lost after every question has been answered**. The default database path is
unaffected, since the block is guarded by `db_file != settings.sites_db_path`.

## Why remove the block rather than rename the attribute

`main()` already persists the database after a successful submit:

```python
if is_submitted and not save_db_safely(db, db_file, logger):
```

Two things make that the better save, so restoring this one would be a step back:

- `db_file` there comes from `resolve_db_path()`, which for a custom `--db` returns
  `path.abspath(...)` or a module-relative fallback. `self.args.db_file` is the raw
  argument, so the removed line could write to a different file than the one the rest
  of the run loaded from.
- `save_db_safely()` returns `False` instead of raising on a read-only installation —
  its docstring covers exactly the distro/snap/nix case — while `db.save_to_file()`
  raises.

The success message is the one thing lost. I left it out rather than move it, to keep
this to a single change; happy to add a line to `main()` if you would like it back.

## Why the tests did not catch it

`tests/test_submit.py` hands `Submitter` a `MagicMock`, and a `MagicMock` answers to
any attribute name — `args.db` returns a fresh mock instead of raising. The block is
reached in those tests (`db_file="test_db.json"` differs from
`settings.sites_db_path == "resources/data.json"`), it just cannot fail there.

The added test builds its namespace with the real parser instead, and asserts the
contract directly (`args.db_file == ...`, `not hasattr(args, "db")`) before running the
dialog.

## Verification

```
with the fix:     1 passed
without the fix:  AttributeError: 'Namespace' object has no attribute 'db'
                  maigret\submit.py:666
```

Reverting `maigret/submit.py` alone makes only the new test fail, and on exactly the
predicted line. `tests/test_submit.py` goes from 12 passed to 13 passed; the 6 failures
in that file are present on an unmodified `main` as well (they need network —
`Could not contact DNS servers`).
