### PR TITLE
Fix SeoClerks false-positive check

### DIFF
--- a/maigret/resources/data.json
+++ b/maigret/resources/data.json
@@ -19625,7 +19625,7 @@
             "tags": [
                 "jp"
             ],
-            "checkType": "response_url",
+            "checkType": "status_code",
             "alexaRank": 106199,
             "urlMain": "https://www.seoclerks.com",
             "url": "https://www.seoclerks.com/user/{username}",

--- a/maigret/resources/db_meta.json
+++ b/maigret/resources/db_meta.json
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "updated_at": "2026-09-09T16:38:26Z",
+    "updated_at": "2026-09-10T07:04:35Z",
     "sites_count": 5373,
     "min_maigret_version": "0.5.0",
-    "data_sha256": "f12e8c8ff0a27b1a7904386ec58411f2b611cdc09e3a1bb99a75db8dc9883c2c",
+    "data_sha256": "9ac1480fd7125e593f1cd72f027ec8aa9a531c391c919d36c159a4e516aa2711",
     "data_url": "https://raw.githubusercontent.com/soxoj/maigret/main/maigret/resources/data.json"
 }

--- a/sites.md
+++ b/sites.md
@@ -5377,7 +5377,7 @@ Rank data fetched from Majestic Million by domains.
 1. ![](https://www.google.com/s2/favicons?domain=https://dewrito.net) [Dewrito (Matrix) (https://dewrito.net)](https://dewrito.net)*: top 100M, messaging*
 1. ![](https://www.google.com/s2/favicons?domain=https://tchncs.de) [tchncs.de (Matrix) (https://tchncs.de)](https://tchncs.de)*: top 100M, messaging*
 
-The list was updated at (2026-09-09)
+The list was updated at (2026-09-10)
 ## Statistics
 
 Enabled/total sites: 4680/5373 = 87.1%


### PR DESCRIPTION
## Summary
- SeoClerks missing usernames return **302 → /** while claimed return **200**.
- `checkType: response_url` treated the redirect as available → false positives (bot #3035).
- Switch to `status_code` so only HTTP 200 counts as claimed.

## Verification
- claimed `adam` → 200
- unclaimed `noonewouldeverusethis7` → 302 Location `/`

Closes #3035