### PR TITLE
Fix --xmind crashing on Windows with a bad file descriptor

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -907,10 +907,14 @@ def _normalize_xmind_archive(filename):
                 manifest_info.external_attr = 0o100644 << 16
                 target.writestr(manifest_info, manifest)
 
+        # Flush through a writable handle, and before the chmod: Windows
+        # implements fsync as FlushFileBuffers, which needs write access and
+        # raises EBADF on a read-only handle. Doing it after the chmod would
+        # also fail to reopen the file at all when archive_mode is read-only.
+        with open(temporary_path, 'rb+') as temporary_file:
+            os.fsync(temporary_file.fileno())
         os.chmod(temporary_path, archive_mode)
         _validate_xmind_archive(temporary_path, expected_names)
-        with open(temporary_path, 'rb') as temporary_file:
-            os.fsync(temporary_file.fileno())
         os.replace(temporary_path, archive_path)
     except BaseException:
         try:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -622,6 +622,37 @@ def test_xmind_normalization_failure_is_atomic(tmp_path, monkeypatch):
     assert list(tmp_path.iterdir()) == [filename]
 
 
+def test_xmind_normalization_flushes_through_a_writable_handle(tmp_path, monkeypatch):
+    """The finished archive must be flushed through a writable handle.
+
+    Windows implements os.fsync as FlushFileBuffers, which needs write access
+    and raises EBADF on a handle opened read-only, so flushing through 'rb'
+    made every XMind report fail there. POSIX permits it, so the Linux CI
+    never saw it; asserting on the handle keeps this catchable there too.
+    """
+    filename = tmp_path / 'report.xmind'
+    save_xmind_report(filename, 'test', EXAMPLE_RESULTS)
+
+    real_open = open
+    writable = []
+
+    def recording_open(file, mode='r', *args, **kwargs):
+        handle = real_open(file, mode, *args, **kwargs)
+        writable.append(handle.writable())
+        return handle
+
+    # zipfile reaches for io.open, so this only intercepts the explicit
+    # open() that report.py uses for the flush.
+    monkeypatch.setattr('maigret.report.open', recording_open, raising=False)
+
+    _normalize_xmind_archive(filename)
+
+    assert writable == [True]
+    with zipfile.ZipFile(filename) as archive:
+        assert archive.testzip() is None
+        assert archive.namelist().count('META-INF/manifest.xml') == 1
+
+
 def test_save_xmind_report_broken():
     filename = 'report_test.xmind'
     save_xmind_report(filename, 'test', BROKEN_RESULTS)


### PR DESCRIPTION
--xmind crashes on Windows and takes the rest of the run's reports with it.

_normalize_xmind_archive flushes the rewritten archive with
open(temporary_path, 'rb') then os.fsync(). On Windows fsync is
FlushFileBuffers, which needs write access, so a read-only handle raises
OSError: [Errno 9] Bad file descriptor. POSIX allows it, and every workflow
runs on ubuntu-latest, so CI never saw it. Present since #2930.

The call is unguarded in the reporting loop and XMind is written first, so the
traceback also costs the CSV, TXT and JSON reports asked for in the same run,
and the HTML/PDF stage never runs. A Windows standalone .exe ships on every
push, so that build is affected too.

Repro, on Windows:

    maigret testuser --db tests/db.json --xmind --csv --json simple

Before: traceback, and only a manifest-less report_testuser.xmind left behind.
After: all three reports written, archive valid.

Flushing through 'rb+' fixes it. I moved it above the chmod as well, because
reopening the file for writing after archive_mode has been applied would fail
whenever that mode has no write bits, which would just swap one failure for
another.

The test asserts that the flush handle is writable rather than asserting the
outcome, since the outcome only differs on Windows. It fails on main on both
platforms: EBADF on Windows, writable False on POSIX.

Windows, Python 3.12: the 7 failing xmind tests now pass, tests/test_report.py
is 51 passed and 1 skipped, and the 4 unrelated failures elsewhere in the suite
are unchanged from before the patch.

Separately, and not touched here: tests/test_maigret.py calls os.geteuid() at
import, so the suite cannot be collected on Windows at all.
