### PR TITLE
File every site under its tag in the XMind report

### DIFF
--- a/maigret/report.py
+++ b/maigret/report.py
@@ -977,11 +977,13 @@ def design_xmind_sheet(sheet, username, results):
 
         category = None
         for tag in normalized_tags:
-            if tag in alltags.keys():
-                continue
-            tagsection = root_topic1.addSubTopic()
-            tagsection.setTitle(tag)
-            alltags[tag] = tagsection
+            if tag not in alltags:
+                tagsection = root_topic1.addSubTopic()
+                tagsection.setTitle(tag)
+                alltags[tag] = tagsection
+            # A section created for an earlier site is still this site's section.
+            # Setting the category only when a section was created filed every
+            # site after the first one for a tag under "Undefined".
             category = tag
 
         section = alltags[category] if category else undefinedsection

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -503,6 +503,41 @@ def test_save_xmind_report():
     )
 
 
+def test_save_xmind_report_groups_every_site_under_a_shared_tag(tmp_path):
+    # EXAMPLE_RESULTS has a single site, so it cannot tell "filed under its tag"
+    # apart from "filed under its tag only if it was the first site to use it".
+    def claimed(site, url):
+        return {
+            'username': 'test',
+            'parsing_enabled': True,
+            'url_main': url,
+            'url_user': url + 'test',
+            'status': MaigretCheckResult(
+                'test', site, url + 'test', MaigretCheckStatus.CLAIMED, tags=['dev']
+            ),
+            'http_status': 200,
+            'is_similar': False,
+            'rank': 1,
+            'site': MaigretSite(site, {}),
+        }
+
+    results = {
+        'GitHub': claimed('GitHub', 'https://github.com/'),
+        'GitLab': claimed('GitLab', 'https://gitlab.com/'),
+    }
+    filename = str(tmp_path / 'shared_tag.xmind')
+    save_xmind_report(filename, 'test', results)
+
+    topics = xmind.load(filename).getPrimarySheet().getData()['topic']['topics']
+    by_title = {t['title']: t.get('topics') or [] for t in topics}
+
+    assert [t['label'] for t in by_title['dev']] == [
+        'https://github.com/test',
+        'https://gitlab.com/test',
+    ]
+    assert by_title['Undefined'] == []
+
+
 def test_xmind_report_has_complete_manifest_and_valid_zip(tmp_path):
     filename = tmp_path / 'unicode-report.xmind'
 


### PR DESCRIPTION
## The bug

In the XMind report (`maigret user -X`), only the **first** claimed site for each tag is
filed under that tag. Every later site carrying the same tag goes to **"Undefined"**.

`save_xmind_report` (`maigret/report.py`):

```python
category = None
for tag in normalized_tags:
    if tag in alltags.keys():
        continue            # section already exists -> category is never set
    tagsection = root_topic1.addSubTopic()
    tagsection.setTitle(tag)
    alltags[tag] = tagsection
    category = tag

section = alltags[category] if category else undefinedsection
```

`category` is only assigned when a section is *created*. Once a tag has a section, the
`continue` skips the assignment, `category` stays `None`, and the site falls back to
`undefinedsection` — with `alltags[tag]` sitting right there.

Two claimed sites, both tagged `dev`:

```
before                          after
  Undefined                       Undefined
    https://gitlab.com/test         (empty)
  dev                             dev
    https://github.com/test         https://github.com/test
                                    https://gitlab.com/test
```

A real scan puts dozens of sites under tags like `social`, `coding` or `forum`, so in
practice nearly every account lands in "Undefined" and each tag section holds exactly one
entry — which is the opposite of what the grouping is for.

## The change

Assign the category for an existing section too. When all of a site's tags are new the
behaviour is unchanged — the last tag still wins — so this only affects the case that was
broken. I left the choice of *which* tag wins alone; "last" looks arbitrary, but changing
it is a separate decision.

## Why the tests did not catch it

`test_save_xmind_report` uses `EXAMPLE_RESULTS`, which has a single site. With one site
there is no "second site for the same tag", so it cannot tell "filed under its tag" apart
from "filed under its tag only if it was first". The new test uses two sites sharing a tag
and checks both land under it and "Undefined" stays empty.

## Verification

On Windows every XMind test currently fails with `OSError: [Errno 9] Bad file descriptor`
at `report.py:913` — the issue #3143 addresses — including all 7 existing ones on an
unmodified `main`. So I verified in a scratch worktree with #3143's patch applied **only
to make the suite runnable**; it is not part of this PR, and the two changes do not touch
the same lines.

```
#3143 + this change:           9 passed
#3143 only (this reverted):    1 failed (the new test), 8 passed
tests/test_report.py in full:  51 passed, 2 skipped
```

`flake8` with the Makefile's blocking selection (`E9,F63,F7,F82`) is clean. `black
--skip-string-normalization --check` reports both files as needing reformatting, but it
does the same on an unmodified `main` and its diff does not touch the lines changed here.
