### PR TITLE
Respect --cookies-jar-file in --self-check

### DIFF
--- a/maigret/checking.py
+++ b/maigret/checking.py
@@ -1632,6 +1632,7 @@ async def self_check(
     proxy=None,
     tor_proxy=None,
     i2p_proxy=None,
+    cookies=None,
     auto_disable=False,
     diagnose=False,
     no_progressbar=False,
@@ -1665,7 +1666,8 @@ async def self_check(
     for _, site in all_sites.items():
         check_coro = site_self_check(
             site, logger, sem, db, silent, proxy, tor_proxy, i2p_proxy,
-            skip_errors=True, auto_disable=auto_disable, diagnose=diagnose,
+            skip_errors=True, cookies=cookies, auto_disable=auto_disable,
+            diagnose=diagnose,
             cloudflare_bypass=cloudflare_bypass,
             dns_resolver=dns_resolver,
         )

--- a/maigret/maigret.py
+++ b/maigret/maigret.py
@@ -783,6 +783,7 @@ async def main():
             max_connections=args.connections,
             tor_proxy=args.tor_proxy,
             i2p_proxy=args.i2p_proxy,
+            cookies=args.cookie_file,
             auto_disable=args.auto_disable,
             diagnose=args.diagnose,
             no_progressbar=args.no_progressbar,

--- a/tests/test_checking.py
+++ b/tests/test_checking.py
@@ -5,7 +5,7 @@ import sys
 import textwrap
 from argparse import ArgumentTypeError
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from aiohttp.client_exceptions import ServerDisconnectedError
 from curl_cffi import CurlError
@@ -27,6 +27,7 @@ from maigret.checking import (
     _domain_tail,
     MAX_MUTATIONS_PER_SITE,
     CheckerMock,
+    self_check,
 )
 from maigret.error_detection import detect_error_page
 from maigret.errors import CheckError
@@ -2093,3 +2094,48 @@ async def test_url_probe_fragment_does_not_probe_another_account(httpserver):
     # saw "/api/users/user" and answered 200 for somebody else's account
     assert requested == ["/api/users/user#1234"]
     assert results["ProbeAPI"]["status"].is_found() is False
+
+
+@pytest.mark.asyncio
+async def test_self_check_forwards_cookies_jar_file():
+    """--cookies-jar-file must reach the site checks, as it does for --submit."""
+    site = MaigretSite('Test', {'tags': [], 'disabled': False})
+
+    with patch(
+        'maigret.checking.site_self_check', new_callable=AsyncMock
+    ) as mock_site_self_check:
+        mock_site_self_check.return_value = {
+            'disabled': False,
+            'issues': [],
+            'recommendations': [],
+        }
+        await self_check(
+            Mock(),
+            {'Test': site},
+            Mock(),
+            silent=True,
+            no_progressbar=True,
+            cookies='my_cookies.txt',
+        )
+
+    mock_site_self_check.assert_awaited_once()
+    assert mock_site_self_check.call_args.kwargs.get('cookies') == 'my_cookies.txt'
+
+
+@pytest.mark.asyncio
+async def test_self_check_without_cookies_jar_file():
+    site = MaigretSite('Test', {'tags': [], 'disabled': False})
+
+    with patch(
+        'maigret.checking.site_self_check', new_callable=AsyncMock
+    ) as mock_site_self_check:
+        mock_site_self_check.return_value = {
+            'disabled': False,
+            'issues': [],
+            'recommendations': [],
+        }
+        await self_check(
+            Mock(), {'Test': site}, Mock(), silent=True, no_progressbar=True
+        )
+
+    assert mock_site_self_check.call_args.kwargs.get('cookies') is None


### PR DESCRIPTION
## The bug

`self_check()` (`maigret/checking.py:1626`) has no `cookies` parameter, so the CLI cannot forward `args.cookie_file` and every site check inside `--self-check` runs without the cookie jar.

The layer underneath already takes it and plumbs it through: `site_self_check(..., cookies=None, ...)` at `checking.py:1464` passes `cookies=cookies` into `maigret()` at `checking.py:1508`, which turns it into a real jar (`checking.py:1280-1282`). That parameter is simply unreachable from the CLI today.

Two of the three callers of `site_self_check` do pass it:

| caller | cookies |
| --- | --- |
| `submit.py:74` (`--submit`) | `cookies=self.args.cookie_file` |
| `maigret.py:983` (a normal search) | `cookies=args.cookie_file` |
| `checking.py:1666` (`--self-check`) | not passed |

Verified with the real parser and `self_check()`, with the inner `maigret()` stubbed:

```
$ maigret --self-check --cookies-jar-file my_cookies.txt
CLI parsed args.cookie_file = 'my_cookies.txt'
inner maigret() received cookies=None for all site checks
self_check() parameters      -> no 'cookies'
site_self_check() parameters -> has 'cookies'
```

## Why it matters more than a missing flag

`errors.py:99` maps `'Login required'` to the advice *"Add authorization cookies through `--cookies-jar-file`"*. Those are exactly the sites a maintainer would self-check with a jar. Without it the site answers as if logged out, so the claimed profile is reported as not detected — and with `--auto-disable` that writes `site.disabled = True` into the sites database (`checking.py:1551`). `CONTRIBUTING.md:65` tells contributors to run `maigret --self-check --site "SiteName" --diagnose`.

## The change

Three lines, the same shape as #3026 ("Respect `--dns-resolver` in `--self-check` and `--submit`", merged 2026-08-31): add the parameter to `self_check()`, forward it at the `site_self_check()` call, and pass `args.cookie_file` from `maigret.py`. Default `None`, so nothing changes for a run without the flag.

## Tests

`tests/test_checking.py`:

- `test_self_check_forwards_cookies_jar_file` — `self_check(..., cookies='my_cookies.txt')` reaches `site_self_check` with that value.
- `test_self_check_without_cookies_jar_file` — guard: without the flag the argument stays `None`.

Run with `python -m pytest tests/test_checking.py tests/test_cli.py tests/test_submit.py -q`: **120 passed** against a clean-tree baseline of **118 passed**, with the same pre-existing 6 failures and 6 errors both times (they need network access and `pytest-httpserver`). Reverting only the two source files makes the first test fail with `TypeError: self_check() got an unexpected keyword argument 'cookies'`, while the guard still passes.

`flake8 --select=E9,F63,F7,F82` clean. `black --skip-string-normalization --check` reports no new diff in my lines; all three files already fail that check on `main`.
